### PR TITLE
Allow passing flink table and execution configuration in cli mode and session mode

### DIFF
--- a/docs/flink_processor.md
+++ b/docs/flink_processor.md
@@ -81,13 +81,20 @@ These are the configurations for the FlinkProcessor regardless of the deployment
 |-----------------|----------|---------|--------|------------------------------------------------------------------------------------------|
 | deployment_mode | optional | session | String | The flink job deployment mode, it could be "cli", "session" or "kubernetes-application". |
 
+### Cli Mode Configuration
+
+| key     | Required | default | type   | Description                                                                                                                                |
+|---------|----------|---------|--------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| flink.* | optional | (none)  | String | This can set and pass arbitrary Flink execution config and table config. The "flink" prefix in the key is removed before passing to Flink. |
+
 ### Session Mode Configuration
 These are the configurations for FlinkProcessor running in session mode.
 
-| key          | Required | default | type    | Description                                   |
-|--------------|----------|---------|---------|-----------------------------------------------|
-| rest.address | required | (none)  | String  | The ip or hostname where the JobManager runs. |
-| rest.port    | required | (none)  | Integer | The port where the JobManager runs.           |
+| key          | Required | default | type    | Description                                                                                                                                |
+|--------------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| rest.address | required | (none)  | String  | The ip or hostname where the JobManager runs.                                                                                              |
+| rest.port    | required | (none)  | Integer | The port where the JobManager runs.                                                                                                        |
+| flink.*      | optional | (none)  | String  | This can set and pass arbitrary Flink execution config and table config. The "flink" prefix in the key is removed before passing to Flink. |
 
 ### Kubernetes Application Mode Configuration
 These are the configurations for FlinkProcessor running in Kubernetes Application mode.

--- a/python/feathub/processors/flink/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/tests/test_flink_processor.py
@@ -323,3 +323,14 @@ class FlinkProcessorTest(unittest.TestCase):
                     )["val"]
                 )
             )
+
+    def test_flink_config(self):
+        processor = FlinkProcessor(
+            config={"deployment_mode": "cli", "flink.key": "value"},
+            stores=self.stores,
+            registry=self.registry,
+        )
+
+        self.assertEqual(
+            processor.flink_table_builder.t_env.get_config().get("key", None), "value"
+        )


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Feathub - we are happy that you want to help us improve Feathub. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
## Contribution Checklist
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review. 
  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Allow passing flink table and execution configuration in cli mode and session mode.

## Brief change log

- Allow passing flink table and execution configuration in cli mode and session mode.
- Add doc in FlinkProcessor docs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs