### PR TITLE
Add docs for installing Feathub nightly build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Prerequisites for building python packages:
 
 ### Install Feathub
 
+#### Install Nightly Build
+Run the following command to install preview(nightly) version of Feathub.
+```bash
+$ python -m pip install feathub-nightly
+```
+
+#### Install From Source
 Run the following command to install Feathub from source.
 ```bash
 # Build Java dependencies for Feathub 

--- a/python/feathub/examples/nyc_taxi_flink_session.py
+++ b/python/feathub/examples/nyc_taxi_flink_session.py
@@ -15,10 +15,9 @@
 import sys
 from pathlib import Path
 
-from feathub.examples.nyc_taxi import run_nyc_taxi_example
-
 sys.path.append(str(Path(__file__).parent.parent.parent.resolve()))
 
+from feathub.examples.nyc_taxi import run_nyc_taxi_example
 from feathub.feathub_client import FeathubClient
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -98,6 +98,7 @@ try:
 
     PACKAGE_DATA = {
         "feathub.processors.flink.lib": ["*.jar"],
+        "feathub.examples": ["*.csv"],
     }
 
     install_requires = [


### PR DESCRIPTION
## What is the purpose of the change

Add docs for installing Feathub nightly build.

## Brief change log

- Add docs for installing Feathub nightly build.
- Fix nightly build by including the example data into the wheel.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable