### PR TITLE
Sliding window handles expired value and duplicate value

### DIFF
--- a/java/feathub-udf/flink-udf/pom.xml
+++ b/java/feathub-udf/flink-udf/pom.xml
@@ -30,7 +30,31 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -44,25 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java-bridge</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-planner-loader</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-runtime</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowDefaultRowExpiredRowHandler.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowDefaultRowExpiredRowHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import java.time.Instant;
+
+/**
+ * PostSlidingWindowDefaultRowExpiredRowHandler output a row with the default values when a row is
+ * expired.
+ */
+public class PostSlidingWindowDefaultRowExpiredRowHandler
+        implements PostSlidingWindowExpiredRowHandler {
+
+    private final Row defaultRow;
+    private final String rowTimeFieldName;
+    private final String[] keyFieldNames;
+
+    public PostSlidingWindowDefaultRowExpiredRowHandler(
+            Row defaultRow, String rowTimeFieldName, String... keyFieldNames) {
+        this.defaultRow = defaultRow;
+        this.rowTimeFieldName = rowTimeFieldName;
+        this.keyFieldNames = keyFieldNames;
+    }
+
+    @Override
+    public void handleExpiredRow(Collector<Row> out, Row expiredRow, long currentTimestamp) {
+        Row row = Row.copy(defaultRow);
+        row.setField(rowTimeFieldName, Instant.ofEpochMilli(currentTimestamp));
+        for (String keyFieldName : keyFieldNames) {
+            row.setField(keyFieldName, expiredRow.getField(keyFieldName));
+        }
+        out.collect(row);
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowExpiredRowHandler.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowExpiredRowHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+/** Interface for handling post sliding window expired row. */
+// TODO: Implement a PostSlidingWindowExpiredRowHandler that retract the expired row.
+public interface PostSlidingWindowExpiredRowHandler extends Serializable {
+    void handleExpiredRow(Collector<Row> out, Row expiredRow, long currentTimestamp);
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowKeyedProcessFunction.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowKeyedProcessFunction.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import java.time.Instant;
+
+/**
+ * The KeyedProcessFunction that is used after the Flink SQL Sliding Window operation by Feathub.
+ *
+ * <p>The function output the rows only when the result of the sliding window changes if
+ * skipSameWindowOutput is true. And it handles the expired row with the given {@link
+ * PostSlidingWindowExpiredRowHandler}.
+ *
+ * <p>It assumes that the rows of each key are ordered by the row time, which should hold true after
+ * a sliding window.
+ */
+public class PostSlidingWindowKeyedProcessFunction extends KeyedProcessFunction<Row, Row, Row>
+        implements ResultTypeQueryable<Row> {
+
+    private final long windowStepSizeMs;
+    private final TypeSerializer<Row> keySerializer;
+    private final TypeSerializer<Row> rowTypeSerializer;
+    private final ExternalTypeInfo<Row> rowTypeInfo;
+
+    private final String rowTimeFieldName;
+    private final PostSlidingWindowExpiredRowHandler expiredRowHandler;
+    private final boolean skipSameWindowOutput;
+
+    private MapState<Row, Tuple2<Long, Row>> lastRowState;
+
+    public PostSlidingWindowKeyedProcessFunction(
+            ResolvedSchema schema,
+            long windowStepSizeMs,
+            String[] keyFieldNames,
+            String rowTimeFieldName,
+            PostSlidingWindowExpiredRowHandler expiredRowHandler,
+            boolean skipSameWindowOutput) {
+        this.windowStepSizeMs = windowStepSizeMs;
+        this.rowTimeFieldName = rowTimeFieldName;
+        this.expiredRowHandler = expiredRowHandler;
+        this.skipSameWindowOutput = skipSameWindowOutput;
+
+        DataTypes.Field[] keyFields = new DataTypes.Field[keyFieldNames.length];
+        for (int i = 0; i < keyFields.length; ++i) {
+            final String keyFieldName = keyFieldNames[i];
+            final Column keyCol =
+                    schema.getColumn(keyFieldName)
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    String.format(
+                                                            "The given key field %s doesn't exist.",
+                                                            keyFieldName)));
+            keyFields[i] = DataTypes.FIELD(keyCol.getName(), keyCol.getDataType());
+        }
+
+        this.keySerializer =
+                ExternalTypeInfo.<Row>of(DataTypes.ROW(keyFields)).createSerializer(null);
+        rowTypeInfo = ExternalTypeInfo.of(schema.toPhysicalRowDataType());
+        this.rowTypeSerializer = rowTypeInfo.createSerializer(null);
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        final TupleSerializer<Tuple2<Long, Row>> tupleSerializer =
+                new TupleSerializer(
+                        Tuple2.class,
+                        new TypeSerializer[] {LongSerializer.INSTANCE, rowTypeSerializer});
+        lastRowState =
+                getRuntimeContext()
+                        .getMapState(
+                                new MapStateDescriptor<>(
+                                        "lastRowState", keySerializer, tupleSerializer));
+    }
+
+    @Override
+    public void processElement(
+            Row row, KeyedProcessFunction<Row, Row, Row>.Context ctx, Collector<Row> out)
+            throws Exception {
+        final Row currentKey = ctx.getCurrentKey();
+        final Tuple2<Long, Row> lastRowTuple = lastRowState.get(currentKey);
+        final Instant rowInstant = row.getFieldAs(rowTimeFieldName);
+
+        long currentRowTs = rowInstant.toEpochMilli();
+        long currentRowExpirationTs = currentRowTs + windowStepSizeMs;
+        ctx.timerService().registerEventTimeTimer(currentRowExpirationTs);
+
+        if (lastRowTuple == null) {
+            lastRowState.put(currentKey, new Tuple2<>(currentRowExpirationTs, row));
+            out.collect(row);
+            return;
+        }
+
+        final long lastRowExpirationTs = lastRowTuple.f0;
+        final Row lastRow = lastRowTuple.f1;
+        ctx.timerService().deleteEventTimeTimer(lastRowExpirationTs);
+
+        if (lastRowExpirationTs < currentRowTs) {
+            // The last row is expired.
+            expiredRowHandler.handleExpiredRow(out, lastRow, lastRowExpirationTs);
+        }
+
+        // Do not output the current row if skipSameWindowOutput is true, last row is not expire
+        // and the values do not change.
+        if (skipSameWindowOutput
+                && lastRowExpirationTs >= currentRowTs
+                && isRowValueEquals(lastRow, row)) {
+            // Only update the expiration timestamp
+            lastRowState.put(currentKey, new Tuple2<>(currentRowExpirationTs, lastRow));
+            return;
+        }
+
+        lastRowState.put(currentKey, new Tuple2<>(currentRowExpirationTs, row));
+        out.collect(row);
+    }
+
+    @Override
+    public void onTimer(
+            long timestamp,
+            KeyedProcessFunction<Row, Row, Row>.OnTimerContext ctx,
+            Collector<Row> out)
+            throws Exception {
+        final Row currentKey = ctx.getCurrentKey();
+        final Tuple2<Long, Row> lastRowTuple = lastRowState.get(currentKey);
+
+        expiredRowHandler.handleExpiredRow(out, lastRowTuple.f1, timestamp);
+        lastRowState.remove(currentKey);
+    }
+
+    @Override
+    public TypeInformation<Row> getProducedType() {
+        return rowTypeInfo;
+    }
+
+    private boolean isRowValueEquals(Row row1, Row row2) {
+        row1 = Row.copy(row1);
+        row2 = Row.copy(row2);
+        row1.setField(rowTimeFieldName, null);
+        row2.setField(rowTimeFieldName, null);
+
+        return row1.equals(row2);
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.Row;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+
+/** Utility method to be used by Feathub after sliding window. */
+public class PostSlidingWindowUtils {
+
+    /**
+     * Apply the {@link PostSlidingWindowKeyedProcessFunction} to the given table. A row with
+     * default value is sent when a result is expired. If skipSameWindowOutput is false, rows are
+     * only emitted when the values are changed.
+     *
+     * @param tEnv The StreamTableEnvironment of the table.
+     * @param table The input table.
+     * @param windowStepSizeMs The step size of the sliding window that the input table has been
+     *     applied.
+     * @param defaultRow The default row that contains default values of the all the fields, except
+     *     row time field and key fields.
+     * @param skipSameWindowOutput Whether to output if the sliding window output the same result.
+     * @param rowTimeFieldName The name of the row time field.
+     * @param keyFieldNames The names of the group by keys of the sliding window that the input
+     *     table has been applied.
+     * @return The result table.
+     */
+    public static Table postSlidingWindow(
+            StreamTableEnvironment tEnv,
+            Table table,
+            long windowStepSizeMs,
+            Row defaultRow,
+            boolean skipSameWindowOutput,
+            String rowTimeFieldName,
+            String... keyFieldNames) {
+        final ResolvedSchema resolvedSchema = table.getResolvedSchema();
+        DataStream<Row> rowDataStream =
+                tEnv.toChangelogStream(
+                        table,
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        ChangelogMode.all());
+
+        for (String fieldName : Objects.requireNonNull(defaultRow.getFieldNames(true))) {
+            final Object defaultValue = defaultRow.getFieldAs(fieldName);
+            if (defaultValue == null) {
+                continue;
+            }
+
+            final DataType dataType =
+                    resolvedSchema
+                            .getColumn(fieldName)
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    String.format(
+                                                            "The given default value of field %s doesn't exist.",
+                                                            fieldName)))
+                            .getDataType();
+            final LogicalTypeRoot defaultValueType = dataType.getLogicalType().getTypeRoot();
+
+            // Integer value pass as Integer type with PY4J from python to Java if the value is less
+            // than Integer.MAX_VALUE. Floating point value pass as Double from python to Java.
+            // Therefore, we need to cast to the corresponding data type of the column.
+            switch (defaultValueType) {
+                case INTEGER:
+                case DOUBLE:
+                    break;
+                case BIGINT:
+                    if (defaultValue instanceof Integer) {
+                        final Integer intValue = (Integer) defaultValue;
+                        defaultRow.setField(fieldName, intValue.longValue());
+                        break;
+                    } else if (defaultValue instanceof Long) {
+                        break;
+                    } else {
+                        throw new RuntimeException(
+                                String.format(
+                                        "Unknown default value type %s for BIGINT column.",
+                                        defaultValue.getClass().getName()));
+                    }
+                case FLOAT:
+                    if (defaultValue instanceof Double) {
+                        final Double doubleValue = (Double) defaultValue;
+                        defaultRow.setField(fieldName, doubleValue.floatValue());
+                    } else if (defaultValue instanceof Float) {
+                        break;
+                    } else {
+                        throw new RuntimeException(
+                                String.format(
+                                        "Unknown default value type %s for FLOAT column.",
+                                        defaultValue.getClass().getName()));
+                    }
+                    break;
+                default:
+                    throw new RuntimeException(
+                            String.format("Unknown default value type %s", defaultValueType));
+            }
+        }
+
+        rowDataStream =
+                rowDataStream
+                        .keyBy(new PostWindowKeySelector(keyFieldNames))
+                        .process(
+                                new PostSlidingWindowKeyedProcessFunction(
+                                        resolvedSchema,
+                                        windowStepSizeMs,
+                                        keyFieldNames,
+                                        rowTimeFieldName,
+                                        new PostSlidingWindowDefaultRowExpiredRowHandler(
+                                                defaultRow, rowTimeFieldName, keyFieldNames),
+                                        skipSameWindowOutput))
+                        .name(
+                                String.format(
+                                        "PostSlidingWindow[keys=%s, stepSizeMs=%s, emptyWindowOutput=default_value, skipSameWindowOutput=%s]",
+                                        Arrays.toString(keyFieldNames),
+                                        windowStepSizeMs,
+                                        skipSameWindowOutput));
+        return tEnv.fromDataStream(
+                rowDataStream,
+                getResultTableSchema(resolvedSchema, rowTimeFieldName, keyFieldNames));
+    }
+
+    private static Schema getResultTableSchema(
+            ResolvedSchema resolvedSchema, String rowTimeFieldName, String[] keyFieldNames) {
+        final HashSet<String> keyNames = new HashSet<>(Arrays.asList(keyFieldNames));
+        final Schema.Builder builder = Schema.newBuilder();
+        for (Column column : resolvedSchema.getColumns()) {
+            String colName = column.getName();
+            DataType dataType = column.getDataType();
+            if (keyNames.contains(colName)) {
+                // key fields cannot not be null.
+                dataType = dataType.notNull();
+            }
+            builder.column(colName, dataType);
+        }
+
+        if (keyFieldNames.length > 0) {
+            builder.primaryKey(keyFieldNames);
+        }
+
+        // Records are ordered by row time after sliding window.
+        builder.watermark(
+                rowTimeFieldName, String.format("`%s` - INTERVAL '0' SECONDS", rowTimeFieldName));
+        return builder.build();
+    }
+
+    private static Row getKeyRow(Row row, String[] keyFieldNames) {
+        Object[] keyValues = new Object[keyFieldNames.length];
+        for (int i = 0; i < keyFieldNames.length; ++i) {
+            keyValues[i] = row.getFieldAs(keyFieldNames[i]);
+        }
+        return Row.of(keyValues);
+    }
+
+    /** KeySelector for post sliding window function. */
+    public static class PostWindowKeySelector implements KeySelector<Row, Row> {
+        private final String[] keyFieldNames;
+
+        public PostWindowKeySelector(String... keyFieldNames) {
+            this.keyFieldNames = keyFieldNames;
+        }
+
+        @Override
+        public Row getKey(Row row) {
+            return getKeyRow(row, keyFieldNames);
+        }
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/PostSlidingWindowKeyedProcessFunctionTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/PostSlidingWindowKeyedProcessFunctionTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.alibaba.feathub.flink.udf.PostSlidingWindowUtils.postSlidingWindow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link PostSlidingWindowKeyedProcessFunction}. */
+public class PostSlidingWindowKeyedProcessFunctionTest {
+    private StreamTableEnvironment tEnv;
+    private StreamExecutionEnvironment env;
+
+    @BeforeEach
+    public void setUp() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+    }
+
+    @Test
+    void testPostSlidingDefaultValueExpiredRow() {
+        final DataStream<Row> data =
+                env.fromElements(
+                        Row.of(0, 1, Instant.ofEpochMilli(0)),
+                        Row.of(1, 1, Instant.ofEpochMilli(100)),
+                        Row.of(0, 2, Instant.ofEpochMilli(500)),
+                        Row.of(1, 2, Instant.ofEpochMilli(600)),
+                        Row.of(0, 3, Instant.ofEpochMilli(4000)),
+                        Row.of(0, 4, Instant.ofEpochMilli(5000)));
+        Table inputTable =
+                tEnv.fromDataStream(
+                                data,
+                                Schema.newBuilder()
+                                        .column("f0", DataTypes.INT())
+                                        .column("f1", DataTypes.INT())
+                                        .column("f2", DataTypes.TIMESTAMP_LTZ(3))
+                                        .watermark("f2", "f2 - INTERVAL '2' SECOND")
+                                        .build())
+                        .as("id", "val", "ts");
+        tEnv.createTemporaryView("input_table", inputTable);
+        Table table =
+                tEnv.sqlQuery(
+                        "SELECT id, SUM(val) AS val_sum, window_time AS ts FROM TABLE("
+                                + "   HOP("
+                                + "       DATA => TABLE input_table,"
+                                + "       TIMECOL => DESCRIPTOR(ts),"
+                                + "       SLIDE => INTERVAL '1' SECOND,"
+                                + "       SIZE => INTERVAL '2' SECOND))"
+                                + "GROUP BY id, window_start, window_end, window_time");
+        final Row defaultRow = Row.withNames();
+        defaultRow.setField("val_sum", 0);
+        table = postSlidingWindow(tEnv, table, 1000, defaultRow, false, "ts", "id");
+
+        List<Row> expected =
+                Arrays.asList(
+                        Row.ofKind(RowKind.INSERT, 0, 3, Instant.ofEpochMilli(999)),
+                        Row.ofKind(RowKind.INSERT, 0, 3, Instant.ofEpochMilli(1999)),
+                        Row.ofKind(RowKind.INSERT, 0, 0, Instant.ofEpochMilli(2999)),
+                        Row.ofKind(RowKind.INSERT, 0, 3, Instant.ofEpochMilli(4999)),
+                        Row.ofKind(RowKind.INSERT, 0, 7, Instant.ofEpochMilli(5999)),
+                        Row.ofKind(RowKind.INSERT, 0, 4, Instant.ofEpochMilli(6999)),
+                        Row.ofKind(RowKind.INSERT, 0, 0, Instant.ofEpochMilli(7999)),
+                        Row.ofKind(RowKind.INSERT, 1, 3, Instant.ofEpochMilli(999)),
+                        Row.ofKind(RowKind.INSERT, 1, 3, Instant.ofEpochMilli(1999)),
+                        Row.ofKind(RowKind.INSERT, 1, 0, Instant.ofEpochMilli(2999)));
+
+        List<Row> actual = CollectionUtil.iteratorToList(table.execute().collect());
+        sortResult(actual);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testPostSlidingWindowDefaultValueExpireRowAndSkipSameWindowOutput() {
+        final DataStream<Row> data =
+                env.fromElements(
+                        Row.of(0, 1, Instant.ofEpochMilli(0)),
+                        Row.of(1, 1, Instant.ofEpochMilli(100)),
+                        Row.of(0, 2, Instant.ofEpochMilli(500)),
+                        Row.of(1, 2, Instant.ofEpochMilli(600)),
+                        Row.of(0, 3, Instant.ofEpochMilli(4000)),
+                        Row.of(0, 4, Instant.ofEpochMilli(5000)));
+        Table inputTable =
+                tEnv.fromDataStream(
+                                data,
+                                Schema.newBuilder()
+                                        .column("f0", DataTypes.INT())
+                                        .column("f1", DataTypes.INT())
+                                        .column("f2", DataTypes.TIMESTAMP_LTZ(3))
+                                        .watermark("f2", "f2 - INTERVAL '2' SECOND")
+                                        .build())
+                        .as("id", "val", "ts");
+        tEnv.createTemporaryView("input_table", inputTable);
+        Table table =
+                tEnv.sqlQuery(
+                        "SELECT id, SUM(val) AS val_sum, window_time AS ts FROM TABLE("
+                                + "   HOP("
+                                + "       DATA => TABLE input_table,"
+                                + "       TIMECOL => DESCRIPTOR(ts),"
+                                + "       SLIDE => INTERVAL '1' SECOND,"
+                                + "       SIZE => INTERVAL '2' SECOND))"
+                                + "GROUP BY id, window_start, window_end, window_time");
+        final Row defaultRow = Row.withNames();
+        defaultRow.setField("val_sum", 0);
+        table = postSlidingWindow(tEnv, table, 1000, defaultRow, true, "ts", "id");
+
+        List<Row> expected =
+                Arrays.asList(
+                        Row.ofKind(RowKind.INSERT, 0, 3, Instant.ofEpochMilli(999)),
+                        Row.ofKind(RowKind.INSERT, 0, 0, Instant.ofEpochMilli(2999)),
+                        Row.ofKind(RowKind.INSERT, 0, 3, Instant.ofEpochMilli(4999)),
+                        Row.ofKind(RowKind.INSERT, 0, 7, Instant.ofEpochMilli(5999)),
+                        Row.ofKind(RowKind.INSERT, 0, 4, Instant.ofEpochMilli(6999)),
+                        Row.ofKind(RowKind.INSERT, 0, 0, Instant.ofEpochMilli(7999)),
+                        Row.ofKind(RowKind.INSERT, 1, 3, Instant.ofEpochMilli(999)),
+                        Row.ofKind(RowKind.INSERT, 1, 0, Instant.ofEpochMilli(2999)));
+
+        List<Row> actual = CollectionUtil.iteratorToList(table.execute().collect());
+        sortResult(actual);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private void sortResult(List<Row> result) {
+        result.sort(
+                (o1, o2) -> {
+                    int i = (Integer) o1.getFieldAs("id") - (Integer) o2.getFieldAs("id");
+                    if (i == 0) {
+                        i =
+                                (int)
+                                        (((Instant) o1.getFieldAs("ts")).toEpochMilli()
+                                                - ((Instant) o2.getFieldAs("ts")).toEpochMilli());
+                    }
+                    return i;
+                });
+    }
+}

--- a/python/feathub/common/test_utils.py
+++ b/python/feathub/common/test_utils.py
@@ -15,6 +15,8 @@
 import unittest
 import tempfile
 import shutil
+from datetime import datetime
+
 import pandas as pd
 from typing import Optional, List
 
@@ -94,3 +96,19 @@ class LocalProcessorTestCase(unittest.TestCase):
             include_timestamp_field=include_timestamp_field,
             store_type=MemoryOnlineStore.STORE_TYPE,
         )
+
+
+def to_epoch_millis(
+    timestamp_str: str, timestamp_format: str = "%Y-%m-%d %H:%M:%S.%f"
+) -> int:
+    """
+    Returns the number of milliseconds since epoch for the given timestamp string.
+    """
+    return int(datetime.strptime(timestamp_str, timestamp_format).timestamp() * 1000)
+
+
+def to_epoch(timestamp_str: str, timestamp_format: str = "%Y-%m-%d %H:%M:%S.%f") -> int:
+    """
+    Returns the number of seconds since epoch for the given timestamp string.
+    """
+    return int(datetime.strptime(timestamp_str, timestamp_format).timestamp())

--- a/python/feathub/feathub_client.py
+++ b/python/feathub/feathub_client.py
@@ -148,17 +148,22 @@ class FeathubClient:
         )
 
     def build_features(
-        self, features_list: List[TableDescriptor]
+        self, features_list: List[TableDescriptor], props: Optional[Dict] = None
     ) -> List[TableDescriptor]:
         """
         For each table descriptor in the given list, resolve this descriptor by
         recursively replacing its dependent table and feature names with the
         corresponding table descriptors and features from the cache or registry.
+        Then recursively configure the table descriptor and its dependent table that is
+        referred by a TableDescriptor with the given global properties if it is not
+        configured already.
 
         And caches the resolved table descriptors in memory so that they can be used
         when building other table descriptors.
 
         :param features_list: A list of table descriptors.
+        :param props: Optional. If it is not None, it is the global properties that are
+                      used to configure the given table descriptors.
         :return: A list of resolved descriptors corresponding to the input descriptors.
         """
-        return self.registry.build_features(features_list=features_list)
+        return self.registry.build_features(features_list=features_list, props=props)

--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Union, Dict, Sequence
+from typing import Union, Dict, Sequence, Optional
 
 from feathub.common.exceptions import FeathubException
 from feathub.feature_views.transforms.join_transform import JoinTransform
@@ -61,7 +61,9 @@ class DerivedFeatureView(FeatureView):
             keep_source_fields=keep_source_fields,
         )
 
-    def build(self, registry: Registry) -> TableDescriptor:
+    def build(
+        self, registry: Registry, props: Optional[Dict] = None
+    ) -> TableDescriptor:
         """
         Gets a copy of self as a resolved table descriptor.
 

--- a/python/feathub/feature_views/on_demand_feature_view.py
+++ b/python/feathub/feature_views/on_demand_feature_view.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Dict, Sequence
+from typing import Union, Dict, Sequence, Optional
 
 from feathub.common import types
 from feathub.feature_tables.feature_table import FeatureTable
@@ -92,7 +92,9 @@ class OnDemandFeatureView(FeatureView):
                 )
 
     # TODO: cache the feature view itself in the registry. Same for other views.
-    def build(self, registry: Registry) -> TableDescriptor:
+    def build(
+        self, registry: Registry, props: Optional[Dict] = None
+    ) -> TableDescriptor:
         """
         Gets a copy of self as a resolved table descriptor.
 

--- a/python/feathub/processors/flink/job_submitter/feathub_job_descriptor.py
+++ b/python/feathub/processors/flink/job_submitter/feathub_job_descriptor.py
@@ -32,7 +32,7 @@ class FeathubJobDescriptor:
         sink: FeatureTable,
         local_registry_tables: Dict[str, TableDescriptor],
         allow_overwrite: bool,
-        config: Dict,
+        props: Dict,
     ):
         """
         Instantiate a FeathubJobDescriptor.
@@ -59,7 +59,7 @@ class FeathubJobDescriptor:
                                       table.
         :param allow_overwrite: If it is true, throw error if the features collide with
                                 existing data in the given sink.
-        :param config: All configurations of Feathub.
+        :param props: All properties of Feathub.
         """
         self.features = features
         self.keys = keys
@@ -68,7 +68,7 @@ class FeathubJobDescriptor:
         self.sink = sink
         self.local_registry_tables = local_registry_tables
         self.allow_overwrite = allow_overwrite
-        self.config = config
+        self.props = props
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -80,5 +80,5 @@ class FeathubJobDescriptor:
             and self.sink == other.sink
             and self.local_registry_tables == other.local_registry_tables
             and self.allow_overwrite == other.allow_overwrite
-            and self.config == other.config
+            and self.props == other.props
         )

--- a/python/feathub/processors/flink/job_submitter/flink_application_cluster_job_entry.py
+++ b/python/feathub/processors/flink/job_submitter/flink_application_cluster_job_entry.py
@@ -50,8 +50,8 @@ def run_job(feathub_job_descriptor_path: str) -> None:
     env = StreamExecutionEnvironment.get_execution_environment()
     t_env = StreamTableEnvironment.create(env)
 
-    config = feathub_job_descriptor.config
-    registry = Registry.instantiate(props=config)
+    props = feathub_job_descriptor.props
+    registry = Registry.instantiate(props=props)
 
     for _, join_table in feathub_job_descriptor.local_registry_tables.items():
         registry.register_features(features=join_table, override=True)

--- a/python/feathub/processors/flink/job_submitter/flink_kubernetes_application_cluster_job_submitter.py
+++ b/python/feathub/processors/flink/job_submitter/flink_kubernetes_application_cluster_job_submitter.py
@@ -123,7 +123,7 @@ class FlinkKubernetesApplicationClusterJobSubmitter(FlinkJobSubmitter):
             sink=sink,
             local_registry_tables=local_registry_tables,
             allow_overwrite=allow_overwrite,
-            config=self.processor_config.original_props,
+            props=self.processor_config.original_props,
         )
 
         job_id = str(uuid.uuid4())

--- a/python/feathub/processors/flink/job_submitter/tests/test_flink_application_job_entry.py
+++ b/python/feathub/processors/flink/job_submitter/tests/test_flink_application_job_entry.py
@@ -160,7 +160,7 @@ class FlinkApplicationJobEntryTest(unittest.TestCase):
             sink=sink,
             local_registry_tables=join_table,
             allow_overwrite=True,
-            config={},
+            props={},
         )
 
         with open(path, "wb") as f:

--- a/python/feathub/processors/flink/table_builder/aggregation_utils.py
+++ b/python/feathub/processors/flink/table_builder/aggregation_utils.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Tuple
 
-from pyflink.table.types import DataType
+from pyflink.table.types import DataType, DataTypes
 
 from feathub.common.exceptions import FeathubException
 from feathub.feature_views.feature import Feature
@@ -64,6 +64,16 @@ class AggregationFieldDescriptor:
         )
 
 
+INTEGER_TYPES = {
+    type(DataTypes.TINYINT()),
+    type(DataTypes.SMALLINT()),
+    type(DataTypes.INT()),
+    type(DataTypes.BIGINT()),
+}
+
+FLOAT_TYPES = {type(DataTypes.FLOAT()), type(DataTypes.DOUBLE())}
+
+
 def get_default_value_and_type(
     agg_descriptor: AggregationFieldDescriptor,
 ) -> Tuple[Any, DataType]:
@@ -71,7 +81,15 @@ def get_default_value_and_type(
         agg_descriptor.agg_func == AggFunc.COUNT
         or agg_descriptor.agg_func == AggFunc.SUM
     ):
-        default_value = 0
+        if type(agg_descriptor.field_data_type) in INTEGER_TYPES:
+            default_value: Any = 0
+        elif type(agg_descriptor.field_data_type) in FLOAT_TYPES:
+            default_value = 0.0
+        else:
+            raise FeathubException(
+                f"Unsupported DataType of AggFunc COUNT or SUM: "
+                f"{type(agg_descriptor.field_data_type)}"
+            )
     else:
         default_value = None
     return (

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -458,6 +458,7 @@ class FlinkTableBuilder:
                 tmp_table,
                 window_descriptor,
                 agg_descriptors,
+                feature_view.config,
             )
             if agg_table is None:
                 agg_table = tmp_agg_table

--- a/python/feathub/processors/flink/table_builder/join_utils.py
+++ b/python/feathub/processors/flink/table_builder/join_utils.py
@@ -21,7 +21,10 @@ from pyflink.table import (
 )
 from pyflink.table.types import DataType
 
-from feathub.feature_views.sliding_feature_view import SlidingFeatureView
+from feathub.feature_views.sliding_feature_view import (
+    SlidingFeatureView,
+    ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
+)
 from feathub.feature_views.transforms.sliding_window_transform import (
     SlidingWindowTransform,
 )
@@ -76,8 +79,10 @@ class JoinFieldDescriptor:
         feature = table_descriptor.get_feature(field_name)
         transform = feature.transform
 
-        if not isinstance(table_descriptor, SlidingFeatureView) or not isinstance(
-            transform, SlidingWindowTransform
+        if (
+            not isinstance(table_descriptor, SlidingFeatureView)
+            or not isinstance(transform, SlidingWindowTransform)
+            or table_descriptor.config.get(ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG)
         ):
             return JoinFieldDescriptor(field_name, to_flink_type(feature.dtype))
 

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_sliding_window.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_sliding_window.py
@@ -11,16 +11,20 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import datetime
 from datetime import timedelta
 from math import sqrt
 
 import pandas as pd
 
-from feathub.common.types import Int64, String, Float64, MapType
+from feathub.common.types import Int64, String, Float64, MapType, Float32
+from feathub.common.test_utils import to_epoch_millis, to_epoch
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
-from feathub.feature_views.sliding_feature_view import SlidingFeatureView
+from feathub.feature_views.sliding_feature_view import (
+    SlidingFeatureView,
+    ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
+    SKIP_SAME_WINDOW_OUTPUT_CONFIG,
+)
 from feathub.feature_views.transforms.python_udf_transform import PythonUdfTransform
 from feathub.feature_views.transforms.sliding_window_transform import (
     SlidingWindowTransform,
@@ -30,6 +34,19 @@ from feathub.processors.flink.table_builder.tests.table_builder_test_base import
     FlinkTableBuilderTestBase,
 )
 from feathub.table.schema import Schema
+
+ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT = {
+    ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG: True,
+    SKIP_SAME_WINDOW_OUTPUT_CONFIG: True,
+}
+DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT = {
+    ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG: False,
+    SKIP_SAME_WINDOW_OUTPUT_CONFIG: False,
+}
+ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT = {
+    ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG: True,
+    SKIP_SAME_WINDOW_OUTPUT_CONFIG: False,
+}
 
 
 class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
@@ -48,30 +65,67 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             ),
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[f_total_cost],
-        )
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), 500],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), 1000],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), 1600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), 1100],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), 0],
+                    ],
+                    columns=["window_time", "total_cost"],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), 500],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), 1000],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), 1600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), 1100],
+                    ],
+                    columns=["window_time", "total_cost"],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), 500],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), 1000],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), 1600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), 1100],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), 0],
+                    ],
+                    columns=["window_time", "total_cost"],
+                ),
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                [self._to_epoch_millis("2022-01-01 23:59:59.999"), 500],
-                [self._to_epoch_millis("2022-01-02 23:59:59.999"), 1000],
-                [self._to_epoch_millis("2022-01-03 23:59:59.999"), 1600],
-                [self._to_epoch_millis("2022-01-04 23:59:59.999"), 1100],
-            ],
-            columns=["window_time", "total_cost"],
-        )
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[f_total_cost],
+                props=props,
+            )
 
-        result_df = (
-            self.flink_table_builder.build(features=features)
-            .to_pandas()
-            .sort_values(by=["window_time"])
-            .reset_index(drop=True)
-        )
+            result_df = (
+                self.flink_table_builder.build(features=features)
+                .to_pandas()
+                .sort_values(by=["window_time"])
+                .reset_index(drop=True)
+            )
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_transform_with_limit(self):
         df = self.input_data.copy()
@@ -90,41 +144,94 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             ),
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[f_total_cost],
-        )
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 400],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 900],
+                        ["Alex", to_epoch_millis("2022-01-05 23:59:59.999"), 600],
+                        ["Alex", to_epoch_millis("2022-01-06 23:59:59.999"), 0],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-04 23:59:59.999"), 200],
+                        ["Emma", to_epoch_millis("2022-01-05 23:59:59.999"), 0],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-06 23:59:59.999"), 0],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 400],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 900],
+                        ["Alex", to_epoch_millis("2022-01-04 23:59:59.999"), 900],
+                        ["Alex", to_epoch_millis("2022-01-05 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-03 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-04 23:59:59.999"), 200],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-04 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-05 23:59:59.999"), 500],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 400],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 900],
+                        ["Alex", to_epoch_millis("2022-01-04 23:59:59.999"), 900],
+                        ["Alex", to_epoch_millis("2022-01-05 23:59:59.999"), 600],
+                        ["Alex", to_epoch_millis("2022-01-06 23:59:59.999"), 0],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-03 23:59:59.999"), 600],
+                        ["Emma", to_epoch_millis("2022-01-04 23:59:59.999"), 200],
+                        ["Emma", to_epoch_millis("2022-01-05 23:59:59.999"), 0],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-04 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-05 23:59:59.999"), 500],
+                        ["Jack", to_epoch_millis("2022-01-06 23:59:59.999"), 0],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                ["Alex", self._to_epoch_millis("2022-01-01 23:59:59.999"), 100],
-                ["Alex", self._to_epoch_millis("2022-01-02 23:59:59.999"), 400],
-                ["Alex", self._to_epoch_millis("2022-01-03 23:59:59.999"), 900],
-                ["Alex", self._to_epoch_millis("2022-01-04 23:59:59.999"), 900],
-                ["Alex", self._to_epoch_millis("2022-01-05 23:59:59.999"), 600],
-                ["Emma", self._to_epoch_millis("2022-01-01 23:59:59.999"), 400],
-                ["Emma", self._to_epoch_millis("2022-01-02 23:59:59.999"), 600],
-                ["Emma", self._to_epoch_millis("2022-01-03 23:59:59.999"), 600],
-                ["Emma", self._to_epoch_millis("2022-01-04 23:59:59.999"), 200],
-                ["Jack", self._to_epoch_millis("2022-01-03 23:59:59.999"), 500],
-                ["Jack", self._to_epoch_millis("2022-01-04 23:59:59.999"), 500],
-                ["Jack", self._to_epoch_millis("2022-01-05 23:59:59.999"), 500],
-            ],
-            columns=["name", "window_time", "total_cost"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "window_time"]
-        ).reset_index(drop=True)
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[f_total_cost],
+                props=props,
+            )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "window_time"]
+            ).reset_index(drop=True)
 
-        result_df = (
-            self.flink_table_builder.build(features=features)
-            .to_pandas()
-            .sort_values(by=["name", "window_time"])
-            .reset_index(drop=True)
-        )
+            result_df = (
+                self.flink_table_builder.build(features=features)
+                .to_pandas()
+                .sort_values(by=["name", "window_time"])
+                .reset_index(drop=True)
+            )
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_transform_with_expression_as_group_by_key(self):
         df = self.input_data.copy()
@@ -147,41 +254,94 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             ),
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[f_name_name, f_total_cost],
-        )
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Alex_Alex", 100],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Alex_Alex", 400],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Alex_Alex", 900],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Alex_Alex", 600],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "Alex_Alex", 0],
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Emma_Emma", 400],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Emma_Emma", 600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Emma_Emma", 200],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Emma_Emma", 0],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "Jack_Jack", 0],
+                    ],
+                    columns=["window_time", "name_name", "total_cost"],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Alex_Alex", 100],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Alex_Alex", 400],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Alex_Alex", 900],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Alex_Alex", 900],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Alex_Alex", 600],
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Emma_Emma", 400],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Emma_Emma", 600],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Emma_Emma", 600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Emma_Emma", 200],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Jack_Jack", 500],
+                    ],
+                    columns=["window_time", "name_name", "total_cost"],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Alex_Alex", 100],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Alex_Alex", 400],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Alex_Alex", 900],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Alex_Alex", 900],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Alex_Alex", 600],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "Alex_Alex", 0],
+                        [to_epoch_millis("2022-01-01 23:59:59.999"), "Emma_Emma", 400],
+                        [to_epoch_millis("2022-01-02 23:59:59.999"), "Emma_Emma", 600],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Emma_Emma", 600],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Emma_Emma", 200],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Emma_Emma", 0],
+                        [to_epoch_millis("2022-01-03 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-04 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "Jack_Jack", 500],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "Jack_Jack", 0],
+                    ],
+                    columns=["window_time", "name_name", "total_cost"],
+                ),
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                [self._to_epoch_millis("2022-01-01 23:59:59.999"), "Alex_Alex", 100],
-                [self._to_epoch_millis("2022-01-02 23:59:59.999"), "Alex_Alex", 400],
-                [self._to_epoch_millis("2022-01-03 23:59:59.999"), "Alex_Alex", 900],
-                [self._to_epoch_millis("2022-01-04 23:59:59.999"), "Alex_Alex", 900],
-                [self._to_epoch_millis("2022-01-05 23:59:59.999"), "Alex_Alex", 600],
-                [self._to_epoch_millis("2022-01-01 23:59:59.999"), "Emma_Emma", 400],
-                [self._to_epoch_millis("2022-01-02 23:59:59.999"), "Emma_Emma", 600],
-                [self._to_epoch_millis("2022-01-03 23:59:59.999"), "Emma_Emma", 600],
-                [self._to_epoch_millis("2022-01-04 23:59:59.999"), "Emma_Emma", 200],
-                [self._to_epoch_millis("2022-01-03 23:59:59.999"), "Jack_Jack", 500],
-                [self._to_epoch_millis("2022-01-04 23:59:59.999"), "Jack_Jack", 500],
-                [self._to_epoch_millis("2022-01-05 23:59:59.999"), "Jack_Jack", 500],
-            ],
-            columns=["window_time", "name_name", "total_cost"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["name_name", "window_time"]
-        ).reset_index(drop=True)
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[f_name_name, f_total_cost],
+                props=props,
+            )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name_name", "window_time"]
+            ).reset_index(drop=True)
 
-        result_df = (
-            self.flink_table_builder.build(features=features)
-            .to_pandas()
-            .sort_values(by=["name_name", "window_time"])
-            .reset_index(drop=True)
-        )
+            result_df = (
+                self.flink_table_builder.build(features=features)
+                .to_pandas()
+                .sort_values(by=["name_name", "window_time"])
+                .reset_index(drop=True)
+            )
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_transform_with_filter_expr(self):
         df = pd.DataFrame(
@@ -204,323 +364,804 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
         )
         source = self._create_file_source(df, schema=schema, keys=["name"])
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[
-                Feature(
-                    name="last_2_minute_total_pay",
-                    dtype=Float64,
-                    transform=SlidingWindowTransform(
-                        expr="cost",
-                        agg_func="SUM",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        filter_expr="action='pay'",
-                        step_size=timedelta(minutes=1),
-                    ),
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            300.0,
+                            300.0,
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            0.0,
+                            200.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            450.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:08:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            400.0,
+                            500.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:04:59.999"),
+                            300.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            0.0,
+                            500.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:07:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_total_pay",
+                        "last_2_minute_total_receive",
+                        "pay_count",
+                    ],
                 ),
-                Feature(
-                    name="last_2_minute_total_receive",
-                    dtype=Float64,
-                    transform=SlidingWindowTransform(
-                        expr="cost",
-                        agg_func="SUM",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        filter_expr="action='receive'",
-                        step_size=timedelta(minutes=1),
-                    ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            300.0,
+                            300.0,
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            300.0,
+                            300.0,
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            0.0,
+                            200.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:04:59.999"),
+                            0.0,
+                            200.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            450.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:07:59.999"),
+                            450.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            400.0,
+                            500.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            400.0,
+                            500.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:04:59.999"),
+                            300.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            300.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            0.0,
+                            500.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            0.0,
+                            500.0,
+                            0,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_total_pay",
+                        "last_2_minute_total_receive",
+                        "pay_count",
+                    ],
                 ),
-                Feature(
-                    name="pay_count",
-                    dtype=Int64,
-                    transform=SlidingWindowTransform(
-                        expr="0",
-                        agg_func="COUNT",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        filter_expr="action='pay'",
-                        step_size=timedelta(minutes=1),
-                    ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            300.0,
+                            300.0,
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            300.0,
+                            300.0,
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            0.0,
+                            200.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:04:59.999"),
+                            0.0,
+                            200.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            450.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:07:59.999"),
+                            450.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:08:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            400.0,
+                            500.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            400.0,
+                            500.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:04:59.999"),
+                            300.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            300.0,
+                            0.0,
+                            1,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:05:59.999"),
+                            0.0,
+                            500.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:06:59.999"),
+                            0.0,
+                            500.0,
+                            0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-01 09:07:59.999"),
+                            0.0,
+                            0.0,
+                            0,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_total_pay",
+                        "last_2_minute_total_receive",
+                        "pay_count",
+                    ],
                 ),
-            ],
-        )
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:01:59.999"),
-                    300.0,
-                    300.0,
-                    2,
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[
+                    Feature(
+                        name="last_2_minute_total_pay",
+                        dtype=Float64,
+                        transform=SlidingWindowTransform(
+                            expr="cost",
+                            agg_func="SUM",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            filter_expr="action='pay'",
+                            step_size=timedelta(minutes=1),
+                        ),
+                    ),
+                    Feature(
+                        name="last_2_minute_total_receive",
+                        dtype=Float32,
+                        transform=SlidingWindowTransform(
+                            expr="cost",
+                            agg_func="SUM",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            filter_expr="action='receive'",
+                            step_size=timedelta(minutes=1),
+                        ),
+                    ),
+                    Feature(
+                        name="pay_count",
+                        dtype=Int64,
+                        transform=SlidingWindowTransform(
+                            expr="0",
+                            agg_func="COUNT",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            filter_expr="action='pay'",
+                            step_size=timedelta(minutes=1),
+                        ),
+                    ),
                 ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:02:59.999"),
-                    300.0,
-                    300.0,
-                    2,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:03:59.999"),
-                    0.0,
-                    200.0,
-                    0,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:04:59.999"),
-                    0.0,
-                    200.0,
-                    0,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:06:59.999"),
-                    450.0,
-                    0.0,
-                    1,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:07:59.999"),
-                    450.0,
-                    0.0,
-                    1,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-01 09:02:59.999"),
-                    400.0,
-                    500.0,
-                    1,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-01 09:03:59.999"),
-                    400.0,
-                    500.0,
-                    1,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-01 09:04:59.999"),
-                    300.0,
-                    0.0,
-                    1,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-01 09:05:59.999"),
-                    300.0,
-                    0.0,
-                    1,
-                ],
-                [
-                    "Jack",
-                    self._to_epoch_millis("2022-01-01 09:05:59.999"),
-                    0.0,
-                    500.0,
-                    0,
-                ],
-                [
-                    "Jack",
-                    self._to_epoch_millis("2022-01-01 09:06:59.999"),
-                    0.0,
-                    500.0,
-                    0,
-                ],
-            ],
-            columns=[
-                "name",
-                "window_time",
-                "last_2_minute_total_pay",
-                "last_2_minute_total_receive",
-                "pay_count",
-            ],
-        )
+                props=props,
+            )
 
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "window_time"]
-        ).reset_index(drop=True)
+            expected_result_df = expected_result_df.astype(
+                {
+                    "name": str,
+                    "window_time": "int64",
+                    "last_2_minute_total_pay": "float64",
+                    "last_2_minute_total_receive": "float32",
+                    "pay_count": "int64",
+                }
+            )
 
-        result_df = (
-            self.flink_table_builder.build(features=features)
-            .to_pandas()
-            .sort_values(by=["name", "window_time"])
-            .reset_index(drop=True)
-        )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "window_time"]
+            ).reset_index(drop=True)
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            result_df = (
+                self.flink_table_builder.build(features=features)
+                .to_pandas()
+                .sort_values(by=["name", "window_time"])
+                .reset_index(drop=True)
+            )
+
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_transform_with_expr_feature_after_sliding_feature(self):
         df = self.input_data.copy()
         source = self._create_file_source(df)
 
-        features = SlidingFeatureView(
-            name="feature_view",
-            source=source,
-            features=[
-                Feature(
-                    name="first_time",
-                    dtype=String,
-                    transform=SlidingWindowTransform(
-                        expr="`time`",
-                        agg_func="FIRST_VALUE",
-                        group_by_keys=["name"],
-                        window_size=timedelta(days=2),
-                        step_size=timedelta(days=1),
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-01 08:01:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-02 08:03:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:03:00",
+                            "2022-01-03 08:06:00",
+                            86580.0,
+                            2,
+                            43290.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "2022-01-03 08:06:00",
+                            "2022-01-03 08:06:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-01 08:02:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-02 08:04:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:04:00",
+                            "2022-01-02 08:04:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-03 08:05:00",
+                            "2022-01-03 08:05:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "first_time",
+                        "last_time",
+                        "total_time",
+                        "cnt",
+                        "avg_time_per_trip",
+                    ],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-01 08:01:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-02 08:03:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:03:00",
+                            "2022-01-03 08:06:00",
+                            86580.0,
+                            2,
+                            43290.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "2022-01-03 08:06:00",
+                            "2022-01-03 08:06:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-01 08:02:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-02 08:04:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:04:00",
+                            "2022-01-02 08:04:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-03 08:05:00",
+                            "2022-01-03 08:05:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "2022-01-03 08:05:00",
+                            "2022-01-03 08:05:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "first_time",
+                        "last_time",
+                        "total_time",
+                        "cnt",
+                        "avg_time_per_trip",
+                    ],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-01 08:01:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:01:00",
+                            "2022-01-02 08:03:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:03:00",
+                            "2022-01-03 08:06:00",
+                            86580.0,
+                            2,
+                            43290.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "2022-01-03 08:06:00",
+                            "2022-01-03 08:06:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-01 08:02:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "2022-01-01 08:02:00",
+                            "2022-01-02 08:04:00",
+                            86520.0,
+                            2,
+                            43260.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-02 08:04:00",
+                            "2022-01-02 08:04:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Emma",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "2022-01-03 08:05:00",
+                            "2022-01-03 08:05:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "2022-01-03 08:05:00",
+                            "2022-01-03 08:05:00",
+                            0.0,
+                            1,
+                            0.0,
+                        ],
+                        [
+                            "Jack",
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            None,
+                            None,
+                            None,
+                            0,
+                            None,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "first_time",
+                        "last_time",
+                        "total_time",
+                        "cnt",
+                        "avg_time_per_trip",
+                    ],
+                ),
+            ),
+        ]
+
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="feature_view",
+                source=source,
+                features=[
+                    Feature(
+                        name="first_time",
+                        dtype=String,
+                        transform=SlidingWindowTransform(
+                            expr="`time`",
+                            agg_func="FIRST_VALUE",
+                            group_by_keys=["name"],
+                            window_size=timedelta(days=2),
+                            step_size=timedelta(days=1),
+                        ),
                     ),
-                ),
-                Feature(
-                    name="last_time",
-                    dtype=String,
-                    transform=SlidingWindowTransform(
-                        expr="`time`",
-                        agg_func="LAST_VALUE",
-                        group_by_keys=["name"],
-                        window_size=timedelta(days=2),
-                        step_size=timedelta(days=1),
+                    Feature(
+                        name="last_time",
+                        dtype=String,
+                        transform=SlidingWindowTransform(
+                            expr="`time`",
+                            agg_func="LAST_VALUE",
+                            group_by_keys=["name"],
+                            window_size=timedelta(days=2),
+                            step_size=timedelta(days=1),
+                        ),
                     ),
-                ),
-                Feature(
-                    name="total_time",
-                    dtype=Float64,
-                    transform="(UNIX_TIMESTAMP(last_time) - "
-                    "UNIX_TIMESTAMP(first_time))",
-                    keys=["name"],
-                ),
-                Feature(
-                    name="cnt",
-                    dtype=Int64,
-                    transform=SlidingWindowTransform(
-                        expr="0",
-                        agg_func="COUNT",
-                        group_by_keys=["name"],
-                        window_size=timedelta(days=2),
-                        step_size=timedelta(days=1),
+                    Feature(
+                        name="total_time",
+                        dtype=Float64,
+                        transform="(UNIX_TIMESTAMP(last_time) - "
+                        "UNIX_TIMESTAMP(first_time))",
+                        keys=["name"],
                     ),
-                ),
-                Feature(
-                    name="avg_time_per_trip",
-                    dtype=Float64,
-                    transform="(UNIX_TIMESTAMP(last_time) - "
-                    "UNIX_TIMESTAMP(first_time)) / cnt",
-                    keys=["name"],
-                ),
-            ],
-        )
+                    Feature(
+                        name="cnt",
+                        dtype=Int64,
+                        transform=SlidingWindowTransform(
+                            expr="0",
+                            agg_func="COUNT",
+                            group_by_keys=["name"],
+                            window_size=timedelta(days=2),
+                            step_size=timedelta(days=1),
+                        ),
+                    ),
+                    Feature(
+                        name="avg_time_per_trip",
+                        dtype=Float64,
+                        transform="(UNIX_TIMESTAMP(last_time) - "
+                        "UNIX_TIMESTAMP(first_time)) / cnt",
+                        keys=["name"],
+                    ),
+                ],
+                props=props,
+            )
 
-        expected_result_df = pd.DataFrame(
-            [
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 23:59:59.999"),
-                    "2022-01-01 08:01:00",
-                    "2022-01-01 08:01:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-02 23:59:59.999"),
-                    "2022-01-01 08:01:00",
-                    "2022-01-02 08:03:00",
-                    86520.0,
-                    2,
-                    43260.0,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "2022-01-02 08:03:00",
-                    "2022-01-03 08:06:00",
-                    86580.0,
-                    2,
-                    43290.0,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-04 23:59:59.999"),
-                    "2022-01-03 08:06:00",
-                    "2022-01-03 08:06:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-01 23:59:59.999"),
-                    "2022-01-01 08:02:00",
-                    "2022-01-01 08:02:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-02 23:59:59.999"),
-                    "2022-01-01 08:02:00",
-                    "2022-01-02 08:04:00",
-                    86520.0,
-                    2,
-                    43260.0,
-                ],
-                [
-                    "Emma",
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "2022-01-02 08:04:00",
-                    "2022-01-02 08:04:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-                [
-                    "Jack",
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "2022-01-03 08:05:00",
-                    "2022-01-03 08:05:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-                [
-                    "Jack",
-                    self._to_epoch_millis("2022-01-04 23:59:59.999"),
-                    "2022-01-03 08:05:00",
-                    "2022-01-03 08:05:00",
-                    0.0,
-                    1,
-                    0.0,
-                ],
-            ],
-            columns=[
-                "name",
-                "window_time",
-                "first_time",
-                "last_time",
-                "total_time",
-                "cnt",
-                "avg_time_per_trip",
-            ],
-        )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "window_time"]
+            ).reset_index(drop=True)
 
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "window_time"]
-        ).reset_index(drop=True)
+            result_df = (
+                self.flink_table_builder.build(features=features)
+                .to_pandas()
+                .sort_values(by=["name", "window_time"])
+                .reset_index(drop=True)
+            )
 
-        result_df = (
-            self.flink_table_builder.build(features=features)
-            .to_pandas()
-            .sort_values(by=["name", "window_time"])
-            .reset_index(drop=True)
-        )
-
-        self.assertTrue(expected_result_df.equals(result_df))
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_join_sliding_feature(self):
         df = pd.DataFrame(
@@ -548,66 +1189,104 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             df2, schema=Schema(["name", "time"], [String, String]), keys=["name"]
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[
-                Feature(
-                    name="last_2_minute_total_cost",
-                    dtype=Float64,
-                    transform=SlidingWindowTransform(
-                        expr="cost",
-                        agg_func="SUM",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        step_size=timedelta(minutes=1),
-                    ),
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", "2022-01-01 09:01:00", None, None],
+                        ["Alex", "2022-01-01 09:02:00", 300.0, 2],
+                        ["Alex", "2022-01-01 09:05:00", 0.0, 0],
+                        ["Alex", "2022-01-01 09:07:00", 450.0, 1],
+                        ["Alex", "2022-01-01 09:09:00", 0.0, 0],
+                    ],
+                    columns=["name", "time", "last_2_minute_total_cost", "cnt"],
                 ),
-                Feature(
-                    name="cnt",
-                    dtype=Int64,
-                    transform=SlidingWindowTransform(
-                        expr="1",
-                        agg_func="COUNT",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        step_size=timedelta(minutes=1),
-                    ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", "2022-01-01 09:01:00", 0.0, 0],
+                        ["Alex", "2022-01-01 09:02:00", 300.0, 2],
+                        ["Alex", "2022-01-01 09:05:00", 0.0, 0],
+                        ["Alex", "2022-01-01 09:07:00", 450.0, 1],
+                        ["Alex", "2022-01-01 09:09:00", 0.0, 0],
+                    ],
+                    columns=["name", "time", "last_2_minute_total_cost", "cnt"],
                 ),
-            ],
-        )
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", "2022-01-01 09:01:00", None, None],
+                        ["Alex", "2022-01-01 09:02:00", 300.0, 2],
+                        ["Alex", "2022-01-01 09:05:00", 0.0, 0],
+                        ["Alex", "2022-01-01 09:07:00", 450.0, 1],
+                        ["Alex", "2022-01-01 09:09:00", 0.0, 0],
+                    ],
+                    columns=["name", "time", "last_2_minute_total_cost", "cnt"],
+                ),
+            ),
+        ]
 
-        joined_feature = DerivedFeatureView(
-            name="joined_feature",
-            source=source2,
-            features=["features.last_2_minute_total_cost", "features.cnt"],
-        )
-        self.registry.build_features([features])
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[
+                    Feature(
+                        name="last_2_minute_total_cost",
+                        dtype=Float64,
+                        transform=SlidingWindowTransform(
+                            expr="cost",
+                            agg_func="SUM",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            step_size=timedelta(minutes=1),
+                        ),
+                    ),
+                    Feature(
+                        name="cnt",
+                        dtype=Int64,
+                        transform=SlidingWindowTransform(
+                            expr="1",
+                            agg_func="COUNT",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            step_size=timedelta(minutes=1),
+                        ),
+                    ),
+                ],
+                props=props,
+            )
 
-        built_joined_feature = self.registry.build_features([joined_feature])[0]
+            joined_feature = DerivedFeatureView(
+                name="joined_feature",
+                source=source2,
+                features=["features.last_2_minute_total_cost", "features.cnt"],
+            )
+            self.registry.build_features([features])
 
-        expected_result_df = pd.DataFrame(
-            [
-                ["Alex", "2022-01-01 09:01:00", 0.0, 0],
-                ["Alex", "2022-01-01 09:02:00", 300.0, 2],
-                ["Alex", "2022-01-01 09:05:00", 0.0, 0],
-                ["Alex", "2022-01-01 09:07:00", 450.0, 1],
-                ["Alex", "2022-01-01 09:09:00", 0.0, 0],
-            ],
-            columns=["name", "time", "last_2_minute_total_cost", "cnt"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "time"]
-        ).reset_index(drop=True)
+            built_joined_feature = self.registry.build_features([joined_feature])[0]
 
-        result_df = (
-            self.flink_table_builder.build(features=built_joined_feature)
-            .to_pandas()
-            .sort_values(by=["name", "time"])
-            .reset_index(drop=True)
-        )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "time"]
+            ).reset_index(drop=True)
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            result_df = (
+                self.flink_table_builder.build(features=built_joined_feature)
+                .to_pandas()
+                .sort_values(by=["name", "time"])
+                .reset_index(drop=True)
+            )
+
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_transform_with_value_counts(self):
         df = pd.DataFrame(
@@ -623,72 +1302,153 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
         schema = Schema(["name", "cost", "time"], [String, Float64, String])
         source = self._create_file_source(df, schema=schema, keys=["name"])
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[
-                Feature(
-                    name="last_2_minute_cost_value_counts",
-                    dtype=MapType(String, Int64),
-                    transform=SlidingWindowTransform(
-                        expr="cost",
-                        agg_func="VALUE_COUNTS",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        step_size=timedelta(minutes=1),
-                        limit=3,
-                    ),
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            {"100.0": 2},
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            {"200.0": 2, "100.0": 1},
+                            3,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            {"200.0": 2},
+                            2,
+                        ],
+                        ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_cost_value_counts",
+                        "cnt",
+                    ],
                 ),
-                Feature(
-                    name="cnt",
-                    dtype=Int64,
-                    transform=SlidingWindowTransform(
-                        expr="1",
-                        agg_func="COUNT",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        step_size=timedelta(minutes=1),
-                        limit=3,
-                    ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            {"100.0": 2},
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            {"200.0": 2, "100.0": 1},
+                            3,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            {"200.0": 2},
+                            2,
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_cost_value_counts",
+                        "cnt",
+                    ],
                 ),
-            ],
-        )
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:01:59.999"),
+                            {"100.0": 2},
+                            2,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:02:59.999"),
+                            {"200.0": 2, "100.0": 1},
+                            3,
+                        ],
+                        [
+                            "Alex",
+                            to_epoch_millis("2022-01-01 09:03:59.999"),
+                            {"200.0": 2},
+                            2,
+                        ],
+                        ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
+                    ],
+                    columns=[
+                        "name",
+                        "window_time",
+                        "last_2_minute_cost_value_counts",
+                        "cnt",
+                    ],
+                ),
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:01:59.999"),
-                    {"100.0": 2},
-                    2,
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[
+                    Feature(
+                        name="last_2_minute_cost_value_counts",
+                        dtype=MapType(String, Int64),
+                        transform=SlidingWindowTransform(
+                            expr="cost",
+                            agg_func="VALUE_COUNTS",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            step_size=timedelta(minutes=1),
+                            limit=3,
+                        ),
+                    ),
+                    Feature(
+                        name="cnt",
+                        dtype=Int64,
+                        transform=SlidingWindowTransform(
+                            expr="1",
+                            agg_func="COUNT",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            step_size=timedelta(minutes=1),
+                            limit=3,
+                        ),
+                    ),
                 ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:02:59.999"),
-                    {"200.0": 2, "100.0": 1},
-                    3,
-                ],
-                [
-                    "Alex",
-                    self._to_epoch_millis("2022-01-01 09:03:59.999"),
-                    {"200.0": 2},
-                    2,
-                ],
-            ],
-            columns=["name", "window_time", "last_2_minute_cost_value_counts", "cnt"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "window_time"]
-        ).reset_index(drop=True)
+                props=props,
+            )
 
-        table = self.flink_table_builder.build(features)
-        result_df = (
-            flink_table_to_pandas(table)
-            .sort_values(by=["name", "window_time"])
-            .reset_index(drop=True)
-        )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "window_time"]
+            ).reset_index(drop=True)
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            table = self.flink_table_builder.build(features)
+            result_df = (
+                flink_table_to_pandas(table)
+                .sort_values(by=["name", "window_time"])
+                .reset_index(drop=True)
+            )
+
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_sliding_window_with_millisecond_sliding_window_timestamp(self):
         df = pd.DataFrame(
@@ -706,67 +1466,158 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             df, schema=schema, keys=["name"], timestamp_format="%Y-%m-%d %H:%M:%S"
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[
-                Feature(
-                    name="cnt",
-                    dtype=Int64,
-                    transform=SlidingWindowTransform(
-                        expr="1",
-                        agg_func="COUNT",
-                        group_by_keys=["name"],
-                        window_size=timedelta(minutes=2),
-                        step_size=timedelta(minutes=1),
-                        limit=3,
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            "2022-01-01 09:01:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:01:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:02:59.999",
+                            3,
+                            to_epoch("2022-01-01 09:02:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:03:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:03:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:04:59.999",
+                            0,
+                            to_epoch("2022-01-01 09:04:59.999"),
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "sliding_window_timestamp",
+                        "cnt",
+                        "epoch_window_time",
+                    ],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            "2022-01-01 09:01:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:01:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:02:59.999",
+                            3,
+                            to_epoch("2022-01-01 09:02:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:03:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:03:59.999"),
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "sliding_window_timestamp",
+                        "cnt",
+                        "epoch_window_time",
+                    ],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            "Alex",
+                            "2022-01-01 09:01:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:01:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:02:59.999",
+                            3,
+                            to_epoch("2022-01-01 09:02:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:03:59.999",
+                            2,
+                            to_epoch("2022-01-01 09:03:59.999"),
+                        ],
+                        [
+                            "Alex",
+                            "2022-01-01 09:04:59.999",
+                            0,
+                            to_epoch("2022-01-01 09:04:59.999"),
+                        ],
+                    ],
+                    columns=[
+                        "name",
+                        "sliding_window_timestamp",
+                        "cnt",
+                        "epoch_window_time",
+                    ],
+                ),
+            ),
+        ]
+
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[
+                    Feature(
+                        name="cnt",
+                        dtype=Int64,
+                        transform=SlidingWindowTransform(
+                            expr="1",
+                            agg_func="COUNT",
+                            group_by_keys=["name"],
+                            window_size=timedelta(minutes=2),
+                            step_size=timedelta(minutes=1),
+                            limit=3,
+                        ),
                     ),
-                ),
-                Feature(
-                    name="epoch_window_time",
-                    dtype=Int64,
-                    transform="UNIX_TIMESTAMP(sliding_window_timestamp)",
-                ),
-            ],
-            timestamp_field="sliding_window_timestamp",
-            timestamp_format="%Y-%m-%d %H:%M:%S.%f",
-        )
-
-        expected_result_df = pd.DataFrame(
-            [
-                [
-                    "Alex",
-                    "2022-01-01 09:01:59.999",
-                    2,
-                    self._to_epoch("2022-01-01 09:01:59.999"),
+                    Feature(
+                        name="epoch_window_time",
+                        dtype=Int64,
+                        transform="UNIX_TIMESTAMP(sliding_window_timestamp)",
+                    ),
                 ],
-                [
-                    "Alex",
-                    "2022-01-01 09:02:59.999",
-                    3,
-                    self._to_epoch("2022-01-01 09:02:59.999"),
-                ],
-                [
-                    "Alex",
-                    "2022-01-01 09:03:59.999",
-                    2,
-                    self._to_epoch("2022-01-01 09:03:59.999"),
-                ],
-            ],
-            columns=["name", "sliding_window_timestamp", "cnt", "epoch_window_time"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["name", "sliding_window_timestamp"]
-        ).reset_index(drop=True)
+                timestamp_field="sliding_window_timestamp",
+                timestamp_format="%Y-%m-%d %H:%M:%S.%f",
+                props=props,
+            )
 
-        table = self.flink_table_builder.build(features)
-        result_df = (
-            flink_table_to_pandas(table)
-            .sort_values(by=["name", "sliding_window_timestamp"])
-            .reset_index(drop=True)
-        )
+            expected_result_df = expected_result_df.sort_values(
+                by=["name", "sliding_window_timestamp"]
+            ).reset_index(drop=True)
 
-        self.assertTrue(expected_result_df.equals(result_df))
+            table = self.flink_table_builder.build(features)
+            result_df = (
+                flink_table_to_pandas(table)
+                .sort_values(by=["name", "sliding_window_timestamp"])
+                .reset_index(drop=True)
+            )
+
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )
 
     def test_with_python_udf(self):
         df = self.input_data.copy()
@@ -797,114 +1648,272 @@ class FlinkTableBuilderSlidingWindowTransformTest(FlinkTableBuilderTestBase):
             transform=PythonUdfTransform(lambda row: sqrt(row["total_cost"])),
         )
 
-        features = SlidingFeatureView(
-            name="features",
-            source=source,
-            features=[f_lower_name, f_total_cost, f_total_cost_sqrt],
-        )
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "alex",
+                            100,
+                            sqrt(100),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "alex",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "alex",
+                            1000,
+                            sqrt(1000),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "alex",
+                            900,
+                            sqrt(900),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            "alex",
+                            600,
+                            sqrt(600),
+                        ],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "alex", 0, 0],
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "emma",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "emma",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "emma",
+                            200,
+                            sqrt(200),
+                        ],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "emma", 0, 0],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "jack", 0, 0],
+                    ],
+                    columns=[
+                        "window_time",
+                        "lower_name",
+                        "total_cost",
+                        "total_cost_sqrt",
+                    ],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "alex",
+                            100,
+                            sqrt(100),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "alex",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "alex",
+                            1000,
+                            sqrt(1000),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "alex",
+                            900,
+                            sqrt(900),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            "alex",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "emma",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "emma",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "emma",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "emma",
+                            200,
+                            sqrt(200),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                    ],
+                    columns=[
+                        "window_time",
+                        "lower_name",
+                        "total_cost",
+                        "total_cost_sqrt",
+                    ],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "alex",
+                            100,
+                            sqrt(100),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "alex",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "alex",
+                            1000,
+                            sqrt(1000),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "alex",
+                            900,
+                            sqrt(900),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            "alex",
+                            600,
+                            sqrt(600),
+                        ],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "alex", 0, 0],
+                        [
+                            to_epoch_millis("2022-01-01 23:59:59.999"),
+                            "emma",
+                            400,
+                            sqrt(400),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-02 23:59:59.999"),
+                            "emma",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "emma",
+                            600,
+                            sqrt(600),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "emma",
+                            200,
+                            sqrt(200),
+                        ],
+                        [to_epoch_millis("2022-01-05 23:59:59.999"), "emma", 0, 0],
+                        [
+                            to_epoch_millis("2022-01-03 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-04 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [
+                            to_epoch_millis("2022-01-05 23:59:59.999"),
+                            "jack",
+                            500,
+                            sqrt(500),
+                        ],
+                        [to_epoch_millis("2022-01-06 23:59:59.999"), "jack", 0, 0],
+                    ],
+                    columns=[
+                        "window_time",
+                        "lower_name",
+                        "total_cost",
+                        "total_cost_sqrt",
+                    ],
+                ),
+            ),
+        ]
 
-        expected_result_df = pd.DataFrame(
-            [
-                [
-                    self._to_epoch_millis("2022-01-01 23:59:59.999"),
-                    "alex",
-                    100,
-                    sqrt(100),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-02 23:59:59.999"),
-                    "alex",
-                    400,
-                    sqrt(400),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "alex",
-                    1000,
-                    sqrt(1000),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-04 23:59:59.999"),
-                    "alex",
-                    900,
-                    sqrt(900),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-05 23:59:59.999"),
-                    "alex",
-                    600,
-                    sqrt(600),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-01 23:59:59.999"),
-                    "emma",
-                    400,
-                    sqrt(400),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-02 23:59:59.999"),
-                    "emma",
-                    600,
-                    sqrt(600),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "emma",
-                    600,
-                    sqrt(600),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-04 23:59:59.999"),
-                    "emma",
-                    200,
-                    sqrt(200),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-03 23:59:59.999"),
-                    "jack",
-                    500,
-                    sqrt(500),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-04 23:59:59.999"),
-                    "jack",
-                    500,
-                    sqrt(500),
-                ],
-                [
-                    self._to_epoch_millis("2022-01-05 23:59:59.999"),
-                    "jack",
-                    500,
-                    sqrt(500),
-                ],
-            ],
-            columns=["window_time", "lower_name", "total_cost", "total_cost_sqrt"],
-        )
-        expected_result_df = expected_result_df.sort_values(
-            by=["lower_name", "window_time"]
-        ).reset_index(drop=True)
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[f_lower_name, f_total_cost, f_total_cost_sqrt],
+                props=props,
+            )
 
-        table = self.flink_table_builder.build(features)
-        result_df = (
-            flink_table_to_pandas(table)
-            .sort_values(by=["lower_name", "window_time"])
-            .reset_index(drop=True)
-        )
-        self.assertTrue(expected_result_df.equals(result_df))
+            expected_result_df = expected_result_df.sort_values(
+                by=["lower_name", "window_time"]
+            ).reset_index(drop=True)
 
-    @staticmethod
-    def _to_epoch_millis(
-        timestamp_str: str, timestamp_format: str = "%Y-%m-%d %H:%M:%S.%f"
-    ) -> int:
-        return int(
-            datetime.datetime.strptime(timestamp_str, timestamp_format).timestamp()
-            * 1000
-        )
-
-    @staticmethod
-    def _to_epoch(
-        timestamp_str: str, timestamp_format: str = "%Y-%m-%d %H:%M:%S.%f"
-    ) -> int:
-        return int(
-            datetime.datetime.strptime(timestamp_str, timestamp_format).timestamp()
-        )
+            table = self.flink_table_builder.build(features)
+            result_df = (
+                flink_table_to_pandas(table)
+                .sort_values(by=["lower_name", "window_time"])
+                .reset_index(drop=True)
+            )
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )

--- a/python/feathub/registries/local_registry.py
+++ b/python/feathub/registries/local_registry.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from feathub.common.config import BaseConfig, ConfigDef
 from feathub.common.exceptions import FeathubException
@@ -58,7 +58,7 @@ class LocalRegistry(Registry):
     # TODO: maintain the version and version_timestamp so that we can recover the
     # lineage information of a table as upstream table evolves.
     def build_features(
-        self, features_list: List[TableDescriptor]
+        self, features_list: List[TableDescriptor], props: Optional[Dict] = None
     ) -> List[TableDescriptor]:
         result = []
         for table in features_list:
@@ -66,7 +66,7 @@ class LocalRegistry(Registry):
                 raise FeathubException(
                     "Cannot build a TableDescriptor with empty name."
                 )
-            self.tables[table.name] = table.build(self)
+            self.tables[table.name] = table.build(self, props)
             result.append(self.tables[table.name])
 
         return result

--- a/python/feathub/registries/registry.py
+++ b/python/feathub/registries/registry.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import List, Dict
+from typing import List, Dict, Optional
 from abc import ABC, abstractmethod
 
 from feathub.registries.registry_config import (
@@ -40,18 +40,23 @@ class Registry(ABC):
 
     @abstractmethod
     def build_features(
-        self, features_list: List[TableDescriptor]
+        self, features_list: List[TableDescriptor], props: Optional[Dict] = None
     ) -> List[TableDescriptor]:
         """
         For each table descriptor in the given list, resolve this descriptor by
         recursively replacing its dependent table and feature names with the
         corresponding table descriptors and features from the cache or registry.
+        Then recursively configure the table descriptor and its dependent table that is
+        referred by a TableDescriptor with the given global properties if it is not
+        configured already.
 
         And caches the resolved descriptors and well as their dependent table
         descriptors in memory so that they can be used when building other table
         descriptors.
 
         :param features_list: A list of table descriptors.
+        :param props: Optional. If it is not None, it is the global properties that are
+                      used to configure the given table descriptors.
         :return: A list of resolved descriptors corresponding to the input descriptors.
         """
         pass

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Optional, List, TYPE_CHECKING
+from typing import Optional, List, TYPE_CHECKING, Dict
 from abc import abstractmethod
 
 from feathub.registries.entity import Entity
@@ -56,15 +56,21 @@ class TableDescriptor(Entity):
         self.timestamp_field = timestamp_field
         self.timestamp_format = timestamp_format
 
-    def build(self, registry: "Registry") -> TableDescriptor:
+    def build(
+        self, registry: "Registry", props: Optional[Dict] = None
+    ) -> TableDescriptor:
         """
         Gets a copy of self after recursively replacing the dependent table and feature
-        names with the corresponding table descriptors and features.
+        names with the corresponding table descriptors and features, then
+        recursively configuring the table descriptor and its dependent table with the
+        given global properties if it is not configured already.
 
         And caches this descriptor as well as its dependent table descriptors in memory
         so that they can be used when building other table descriptors.
 
         :param registry: The entity registry to retrieve table description by name.
+        :param props: Optional. If it is not None, it is the global properties that are
+                      used to configure the given table descriptors.
         :return: A resolved table descriptor.
         """
 


### PR DESCRIPTION
## What is the purpose of the change

**Motivation**

Currently, Flink sliding window only output result when a sliding window has at least one data point in the sliding window. When the sliding window becomes empty, the sliding window will not output anything to let the downstream know that the current sliding window becomes empty. Usually, it requires the external system to clean up the expired result periodically or to check the timestamp of the result to determine if it is still valid when using the result.
And the Flink sliding window outputs results at every step, even when the result doesn't change, which causes unnecessary usage of network IO.
In this PR, we want to improve the Feathub sliding window so that it can output a message when a sliding window becomes empty and skip the same sliding window output.


**Public API**

We introduce two global configurations to config the behavior of the sliding window.
- `sdk.sliding_feature_view.enable_empty_window_output`: Default to True. If it is True, when the sliding window becomes emtpy, it outputs zero value for aggregation function SUM and COUNT, and output None for other aggregation function. If it is False, the sliding window doesn't output anything when the sliding window becomes empty.
- `sdk.sliding_feature_view.skip_same_window_output`: Default to True. If it is True, the sliding feature view only outputs when the result of the sliding window changes. If it is False, the sliding feature view outputs at every step size even if the result of the sliding window doesn't change. 

By default, `enable_empty_window_output` is `True` and `skip_same_window_output` is `True` so that we get the best performance of the sliding window.
For users who prefer the Flink native sliding window behavior, where there is no output on an empty window and without skipping the same window output, they can set `enable_empty_window_output` to `False` and `skip_same_window_output` to `False`.
For users who want to get the sliding window result's last updated timestamp and the message when the result is expired, they can set `enable_empty_window_output` to `True` and `skip_same_window_output` to `False`.
Note that we prevent setting `skip_same_window_output` to `True` when `enable_empty_window_output` is `False` because, with this configuration, there is not enough information to determine if a result is expired or not. 


**Implementation**

In this PR, we introduce the `PostSlidingWindowKeyedProcessFunction` that Feathub will apply after the native Flink sliding window so that it can handle the expired row and skip the same sliding window result. If the sliding window has group-by-keys, the `PostSlidingWindowKeyedProcessFunction` requires storing one row for each key to the Flink state. If the sliding window doesn't have a group-by-key, the `PostSlidingWindowKeyedProcessFunction` only requires storing one row in the Flink state.

## Brief change log

- Introduce PostSlidingWindowKeyedProcessFunction that can handle expired values and skip the same window results
- Introduce SlidingWindowConfig with global config `sdk.sliding_feature_view.enable_empty_window_output` and `sdk.sliding_feature_view.skip_same_window_output`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Python docstring