### PR TITLE
Fix unstable test and nightly build

### DIFF
--- a/.github/workflows/publish-wheel.yaml
+++ b/.github/workflows/publish-wheel.yaml
@@ -19,4 +19,4 @@ jobs:
           path: ./wheels
       - name: Upload Feathub package
         run: |
-          twine upload --username=${{ secrets.PYPI_REPOSITORY_USERNAME }} --password=${{ secrets.PYPI_REPOSITORY_PASSWORD }} wheels/*
+          twine upload --skip-existing --username=${{ secrets.PYPI_REPOSITORY_USERNAME }} --password=${{ secrets.PYPI_REPOSITORY_PASSWORD }} wheels/*

--- a/python/feathub/processors/flink/table_builder/tests/table_builder_test_base.py
+++ b/python/feathub/processors/flink/table_builder/tests/table_builder_test_base.py
@@ -70,7 +70,8 @@ class FlinkTableBuilderTestBase(unittest.TestCase):
         timestamp_format: str = "%Y-%m-%d %H:%M:%S",
         schema: Optional[Schema] = None,
     ) -> FileSystemSource:
-        path = tempfile.NamedTemporaryFile(dir=self.temp_dir).name
+        # Add suffix so that it is not inferred with compression, e.g. xz, zip, etc.
+        path = tempfile.NamedTemporaryFile(dir=self.temp_dir).name + ".csv"
         df.to_csv(path, index=False, header=False)
         return FileSystemSource(
             f"source_{str(uuid.uuid4()).replace('-', '')}_table",


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes #12 and #10.

## Brief change log

- Add option to nightly build twine command to skip uploading wheel if the wheel already exists
- Add the ".csv" suffix to the randomly generated filename to fix unstable test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable