### PR TITLE
Update SlidingFeatureView to support ExpressionTransform on SlidingTransform features

### DIFF
--- a/python/feathub/registries/local_registry.py
+++ b/python/feathub/registries/local_registry.py
@@ -63,7 +63,10 @@ class LocalRegistry(Registry):
 
     def get_features(self, name: str) -> TableDescriptor:
         if name not in self.tables:
-            raise RuntimeError(f"Table '{name}' is not found in the cache or registry.")
+            raise RuntimeError(
+                f"Table '{name}' is not found in the cache or registry. "
+                "Please invoke build_features(..) for this table."
+            )
         return self.tables[name]
 
     def delete_features(self, name: str) -> bool:

--- a/python/feathub/registries/tests/test_local_registry.py
+++ b/python/feathub/registries/tests/test_local_registry.py
@@ -71,8 +71,8 @@ class LocalRegistryTest(unittest.TestCase):
             self.registry.get_features(source.name)
             self.fail("RuntimeError should be raised.")
         except RuntimeError as err:
-            self.assertEqual(
-                str(err), "Table 'source' is not found in the cache or registry."
+            self.assertTrue(
+                "Table 'source' is not found in the cache or registry" in str(err)
             )
 
         self.registry.build_features([source])
@@ -102,8 +102,8 @@ class LocalRegistryTest(unittest.TestCase):
             self.processor.get_table(features=features).to_pandas()
             self.fail("RuntimeError should be raised.")
         except RuntimeError as err:
-            self.assertEqual(
-                str(err), "Table 'feature_view' is not found in the cache or registry."
+            self.assertTrue(
+                "Table 'feature_view' is not found in the cache or registry" in str(err)
             )
 
         # build_features() should fail because 'source' is not built or registered.
@@ -111,8 +111,8 @@ class LocalRegistryTest(unittest.TestCase):
             self.registry.build_features([features])
             self.fail("RuntimeError should be raised.")
         except RuntimeError as err:
-            self.assertEqual(
-                str(err), "Table 'source' is not found in the cache or registry."
+            self.assertTrue(
+                "Table 'source' is not found in the cache or registry" in str(err)
             )
 
         self.registry.build_features([source, features])


### PR DESCRIPTION
## What is the purpose of the change

Update SlidingFeatureView so that it can include features computed by ExpressionTransform on the SlidingWindowTransform features in this feature view.

The following requirements are enforced on the SlidingFeatureView:
- It only supports features computed by either ExpressionTransform or SlidingWindowTransform .
- ExpressionTransform features specified before the first SlidingWindowTransform feature must be included as the group-by keys in the SlidingWindowTransform features.
- ExpressionTransform features specified after the first SlidingWindowTransform features must depend only on the SlidingWindowTransform features.

For example, the following SlidingFeatureView can be defined after this PR:

```
features = SlidingFeatureView(
    name="feature_view",
    source=source,
    features=[
        Feature(
            name="first_time",
            dtype=String,
            transform=SlidingWindowTransform(
                expr="`time`",
                agg_func="FIRST_VALUE",
                group_by_keys=["name"],
                window_size=timedelta(days=2),
                step_size=timedelta(days=1),
            ),
        ),
        Feature(
            name="last_time",
            dtype=String,
            transform=SlidingWindowTransform(
                expr="`time`",
                agg_func="LAST_VALUE",
                group_by_keys=["name"],
                window_size=timedelta(days=2),
                step_size=timedelta(days=1),
            ),
        ),
        Feature(
            name="total_time",
            dtype=Float64,
            transform="(UNIX_TIMESTAMP(last_time) - UNIX_TIMESTAMP(first_time))",
            keys=["name"],
        ),
        Feature(
            name="cnt",
            dtype=Int64,
            transform=SlidingWindowTransform(
                expr="0",
                agg_func="COUNT",
                group_by_keys=["name"],
                window_size=timedelta(days=2),
                step_size=timedelta(days=1),
            ),
        ),
        Feature(
            name="avg_time_per_trip",
            dtype=Float64,
            transform="(UNIX_TIMESTAMP(last_time) - UNIX_TIMESTAMP(first_time)) / cnt",
            keys=["name"],
        ),
    ],
)
```


## Brief change log

Updated SlidingFeatureView so that it can include features computed by ExpressionTransform on the SlidingWindowTransform features in this feature view.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable