### PR TITLE
Update DerivedFeatureView to support inter-features reference

### DIFF
--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -46,7 +46,10 @@ class DerivedFeatureView(FeatureView):
                          feature is a string, it should be either in the format
                          {table_name}.{feature_name}, which refers to a feature in the
                          table with the given name, or in the format {feature_name},
-                         which refers to a feature in the source table.
+                         which refers to a feature in the source table. For any feature
+                         computed by ExpressionTransform or OverWindowTransform, its
+                         expression can only depend on the features specified earlier in
+                         this list and the features in the source table.
         :param keep_source_fields: True iff all fields in the source table should be
                                    included in this table.
         """
@@ -100,6 +103,10 @@ class DerivedFeatureView(FeatureView):
                         f"'{join_table_name}' does not have keys specified."
                     )
             features.append(feature)
+
+        # TODO: Validate ExpressionTransform features that depends on
+        #  OverWindowTransform or JoinTransform features are listed after the first
+        #  OverWindowTransform or JoinTransform feature.
 
         return DerivedFeatureView(
             name=self.name,

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -234,16 +234,26 @@ class FlinkTableBuilder:
             Tuple[str, Sequence[str]], Dict[str, JoinFieldDescriptor]
         ] = {}
 
+        # This list contains all ExpressionTransform features listed after the first
+        # JoinTransform or OverWindowTransform feature in the dependent_features.
+        # These features are evaluated after all over windows and table join.
+        expression_features_following_first_over_window_or_join = []
+
         for feature in dependent_features:
             if feature.name in tmp_table.get_schema().get_field_names():
                 continue
             if isinstance(feature.transform, ExpressionTransform):
-                tmp_table = self._evaluate_expression_transform(
-                    tmp_table,
-                    feature.transform,
-                    feature.name,
-                    feature.dtype,
-                )
+                if len(right_tables) > 0 or len(window_agg_map) > 0:
+                    expression_features_following_first_over_window_or_join.append(
+                        feature
+                    )
+                else:
+                    tmp_table = self._evaluate_expression_transform(
+                        tmp_table,
+                        feature.transform,
+                        feature.name,
+                        feature.dtype,
+                    )
             elif isinstance(feature.transform, OverWindowTransform):
                 if feature_view.timestamp_field is None:
                     raise FeathubException(
@@ -329,6 +339,16 @@ class FlinkTableBuilder:
                 right_table,
                 keys,
                 right_table_join_field_descriptors,
+            )
+
+        for feature in expression_features_following_first_over_window_or_join:
+            if not isinstance(feature.transform, ExpressionTransform):
+                raise FeathubTransformationException("Unsupported transformation type")
+            tmp_table = self._evaluate_expression_transform(
+                tmp_table,
+                feature.transform,
+                feature.name,
+                feature.dtype,
             )
 
         output_fields = self._get_output_fields(feature_view, source_fields)

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -315,14 +315,6 @@ class FlinkTableBuilder:
                     f"{type(feature.transform).__name__} for feature {feature.name}."
                 )
 
-        for over_window_descriptor, agg_descriptor in window_agg_map.items():
-            tmp_table = evaluate_over_window_transform(
-                self.t_env,
-                tmp_table,
-                over_window_descriptor,
-                agg_descriptor,
-            )
-
         for (
             right_table_name,
             keys,
@@ -339,6 +331,14 @@ class FlinkTableBuilder:
                 right_table,
                 keys,
                 right_table_join_field_descriptors,
+            )
+
+        for over_window_descriptor, agg_descriptor in window_agg_map.items():
+            tmp_table = evaluate_over_window_transform(
+                self.t_env,
+                tmp_table,
+                over_window_descriptor,
+                agg_descriptor,
             )
 
         for feature in expression_features_following_first_over_window_or_join:

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_derived_feature.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_derived_feature.py
@@ -209,3 +209,69 @@ class FlinkTableBuilderDerivedFeatureViewTest(FlinkTableBuilderTestBase):
         self.assertListEqual(["name"], built_feature_view_2.keys)
         self.assertListEqual(["name"], built_feature_view_3.keys)
         self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_expression_transform_on_joined_field(self):
+        df_1 = self.input_data.copy()
+        source = self._create_file_source(df_1)
+
+        df_2 = pd.DataFrame(
+            [
+                ["Alex", 100.0, "2022-01-01,09:01:00"],
+                ["Emma", 400.0, "2022-01-01,09:02:00"],
+                ["Alex", 200.0, "2022-01-02,09:03:00"],
+                ["Emma", 300.0, "2022-01-02,09:04:00"],
+                ["Jack", 500.0, "2022-01-03,09:05:00"],
+                ["Alex", 450.0, "2022-01-03,09:06:00"],
+            ],
+            columns=["name", "avg_cost", "time"],
+        )
+        source_2 = self._create_file_source(
+            df_2,
+            schema=Schema(["name", "avg_cost", "time"], [String, Float64, String]),
+            timestamp_format="%Y-%m-%d,%H:%M:%S",
+            keys=["name"],
+        )
+        feature_view_2 = DerivedFeatureView(
+            name="feature_view_2",
+            source=source,
+            features=[
+                Feature(
+                    name="cost",
+                    dtype=Int64,
+                    transform="cost",
+                ),
+                "distance",
+                f"{source_2.name}.avg_cost",
+                Feature(
+                    name="derived_cost",
+                    dtype=Float64,
+                    transform="avg_cost * distance",
+                ),
+            ],
+            keep_source_fields=False,
+        )
+
+        [_, built_feature_view_2] = self.registry.build_features(
+            [source_2, feature_view_2]
+        )
+
+        expected_result_df = df_1
+        expected_result_df["avg_cost"] = pd.Series(
+            [None, None, 100.0, 400.0, None, 200.0]
+        )
+        expected_result_df["derived_cost"] = pd.Series(
+            [None, None, 20000.0, 100000.0, None, 160000.0]
+        )
+        expected_result_df = expected_result_df.sort_values(
+            by=["name", "time"]
+        ).reset_index(drop=True)
+
+        result_df = (
+            self.flink_table_builder.build(features=built_feature_view_2)
+            .to_pandas()
+            .sort_values(by=["name", "time"])
+            .reset_index(drop=True)
+        )
+
+        self.assertListEqual(["name"], built_feature_view_2.keys)
+        self.assertTrue(expected_result_df.equals(result_df))


### PR DESCRIPTION
## What is the purpose of the change

Update DerivedFeatureView to support ExpressionTransform on OverWindowTransform and JoinTransform features, as well as OverWindowTransform on JoinTransform features.

After this PR, users can define the following DerivedFeatureView
```python
        feature_view_2 = DerivedFeatureView(
            name="feature_view_2",
            source=source,
            features=[
                f"feature_view_1.avg_cost",
                Feature(
                    name="derived_cost",
                    dtype=Float64,
                    transform="avg_cost * distance",
                ),
                Feature(
                    name="last_avg_cost",
                    dtype=Int64,
                    transform=OverWindowTransform(
                        expr="avg_cost",
                        agg_func="LAST_VALUE",
                        window_size=timedelta(days=2),
                        group_by_keys=["name"],
                        limit=2,
                    ),
                ),
                Feature(
                    name="double_last_avg_cost",
                    dtype=Float64,
                    transform="last_avg_cost * 2",
                ),
            ],
        )
```

## Brief change log

- Update DerivedFeatureView to support ExpressionTransform on OverWindowTransform or JoinTransform features
- Evaluate OverWindowTransform after JoinTransform to allow OverWindowTransform referring joined field

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable