### PR TITLE
Remove ProcessorJob __enter__ and __exit__ methods

### DIFF
--- a/python/feathub/processors/processor_job.py
+++ b/python/feathub/processors/processor_job.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from typing import Optional, Any
+from typing import Optional
 
 
 class ProcessorJob(ABC):
@@ -47,9 +47,3 @@ class ProcessorJob(ABC):
         :param timeout_ms: If it is None, waits for the job termination indefinitely.
         """
         pass
-
-    def __enter__(self) -> "ProcessorJob":
-        return self
-
-    def __exit__(self, *args: Any) -> None:
-        self.cancel()


### PR DESCRIPTION
## What is the purpose of the change

Remove ProcessorJob __enter__ and __exit__ methods which should not be added.

## Brief change log

- Remove ProcessorJob __enter__ and __exit__ methods

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented