### PR TITLE
Update install requirement from sklearn to scikit-learn

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -102,7 +102,7 @@ try:
     }
 
     install_requires = [
-        "sklearn",
+        "scikit-learn",
         "ply>=3.11",
         "pandas>=1.1.5",
         "numpy>=1.14.3,<1.20",


### PR DESCRIPTION
## What is the purpose of the change

[Nightly build](https://github.com/alibaba/feathub/actions/runs/3421084013/jobs/5696903139) was failing in the last two days. It turns out that the package name `sklearn` is deprecated. According to [sklearn PYPI page](https://pypi.org/project/sklearn/#description), `sklearn` is deprecated and `scikit-learn` should be used. 

## Brief change log

- Update install requirement from sklearn to scikit-learn

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable