### PR TITLE
KafkaSource supports bounded mode

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/pom.xml
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The Feathub Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--TODO: This module is a temporary solution to let Flink Kafka SQL connector
+     support bounded mode. We will use the native Flink Kafka SQL connector when
+     it support bounded mode. See https://issues.apache.org/jira/browse/FLINK-24456
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-connectors</artifactId>
+        <groupId>com.alibaba.feathub</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-kafka</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kafka</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-base</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.16.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.16.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-loader</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-csv</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.19.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaDynamicSource.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaDynamicSource.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.ProviderContext;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+// TODO: This class will be removed after FLINK-24456 resolved.
+/**
+ * {@link BoundedKafkaDynamicSource} extends {@link KafkaDynamicSource} to support bounded Kafka
+ * source. The bounded Kafka source stops at the latest offsets of the partitions when the
+ * KafkaSource starts to run.
+ */
+public class BoundedKafkaDynamicSource extends KafkaDynamicSource {
+    private static final String KAFKA_TRANSFORMATION = "bounded-kafka";
+
+    public BoundedKafkaDynamicSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<KafkaTopicPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis,
+            boolean upsertMode,
+            String tableIdentifier) {
+        super(
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                upsertMode,
+                tableIdentifier);
+    }
+
+    @Override
+    public ScanTableSource.ScanRuntimeProvider getScanRuntimeProvider(
+            ScanTableSource.ScanContext context) {
+        final DeserializationSchema<RowData> keyDeserialization =
+                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+
+        final DeserializationSchema<RowData> valueDeserialization =
+                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
+
+        final KafkaSource<RowData> kafkaSource =
+                createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
+
+        return new DataStreamScanProvider() {
+            @Override
+            public DataStream<RowData> produceDataStream(
+                    ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                if (watermarkStrategy == null) {
+                    watermarkStrategy = WatermarkStrategy.noWatermarks();
+                }
+                DataStreamSource<RowData> sourceStream =
+                        execEnv.fromSource(
+                                kafkaSource,
+                                watermarkStrategy,
+                                "BoundedKafkaSource-" + tableIdentifier);
+                providerContext.generateUid(KAFKA_TRANSFORMATION).ifPresent(sourceStream::uid);
+                return sourceStream;
+            }
+
+            @Override
+            public boolean isBounded() {
+                return kafkaSource.getBoundedness() == Boundedness.BOUNDED;
+            }
+        };
+    }
+
+    private @Nullable DeserializationSchema<RowData> createDeserialization(
+            DynamicTableSource.Context context,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+            int[] projection,
+            @Nullable String prefix) {
+        if (format == null) {
+            return null;
+        }
+        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
+        if (prefix != null) {
+            physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+        }
+        return format.createRuntimeDecoder(context, physicalFormatDataType);
+    }
+
+    @Override
+    protected KafkaSource<RowData> createKafkaSource(
+            DeserializationSchema<RowData> keyDeserialization,
+            DeserializationSchema<RowData> valueDeserialization,
+            TypeInformation<RowData> producedTypeInfo) {
+
+        final KafkaDeserializationSchema<RowData> kafkaDeserializer =
+                createKafkaDeserializationSchema(
+                        keyDeserialization, valueDeserialization, producedTypeInfo);
+
+        final KafkaSourceBuilder<RowData> kafkaSourceBuilder = KafkaSource.builder();
+
+        if (topics != null) {
+            kafkaSourceBuilder.setTopics(topics);
+        } else {
+            kafkaSourceBuilder.setTopicPattern(topicPattern);
+        }
+
+        switch (startupMode) {
+            case EARLIEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.earliest());
+                break;
+            case LATEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.latest());
+                break;
+            case GROUP_OFFSETS:
+                String offsetResetConfig =
+                        properties.getProperty(
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                OffsetResetStrategy.NONE.name());
+                OffsetResetStrategy offsetResetStrategy = getResetStrategy(offsetResetConfig);
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.committedOffsets(offsetResetStrategy));
+                break;
+            case SPECIFIC_OFFSETS:
+                Map<TopicPartition, Long> offsets = new HashMap<>();
+                specificStartupOffsets.forEach(
+                        (tp, offset) ->
+                                offsets.put(
+                                        new TopicPartition(tp.getTopic(), tp.getPartition()),
+                                        offset));
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.offsets(offsets));
+                break;
+            case TIMESTAMP:
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.timestamp(startupTimestampMillis));
+                break;
+        }
+
+        kafkaSourceBuilder.setBounded(OffsetsInitializer.latest());
+
+        kafkaSourceBuilder
+                .setProperties(properties)
+                .setDeserializer(KafkaRecordDeserializationSchema.of(kafkaDeserializer));
+
+        return kafkaSourceBuilder.build();
+    }
+
+    private OffsetResetStrategy getResetStrategy(String offsetResetConfig) {
+        return Arrays.stream(OffsetResetStrategy.values())
+                .filter(ors -> ors.name().equals(offsetResetConfig.toUpperCase(Locale.ROOT)))
+                .findAny()
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "%s can not be set to %s. Valid values: [%s]",
+                                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                                offsetResetConfig,
+                                                Arrays.stream(OffsetResetStrategy.values())
+                                                        .map(Enum::name)
+                                                        .map(String::toLowerCase)
+                                                        .collect(Collectors.joining(",")))));
+    }
+
+    private KafkaDeserializationSchema<RowData> createKafkaDeserializationSchema(
+            DeserializationSchema<RowData> keyDeserialization,
+            DeserializationSchema<RowData> valueDeserialization,
+            TypeInformation<RowData> producedTypeInfo) {
+        final DynamicKafkaDeserializationSchema.MetadataConverter[] metadataConverters =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .map(m -> m.converter)
+                        .toArray(DynamicKafkaDeserializationSchema.MetadataConverter[]::new);
+
+        // check if connector metadata is used at all
+        final boolean hasMetadata = metadataKeys.size() > 0;
+
+        // adjust physical arity with value format's metadata
+        final int adjustedPhysicalArity =
+                DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
+
+        // adjust value format projection to include value format's metadata columns at the end
+        final int[] adjustedValueProjection =
+                IntStream.concat(
+                                IntStream.of(valueProjection),
+                                IntStream.range(
+                                        keyProjection.length + valueProjection.length,
+                                        adjustedPhysicalArity))
+                        .toArray();
+
+        return new DynamicKafkaDeserializationSchema(
+                adjustedPhysicalArity,
+                keyDeserialization,
+                keyProjection,
+                valueDeserialization,
+                adjustedValueProjection,
+                hasMetadata,
+                metadataConverters,
+                producedTypeInfo,
+                upsertMode);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        final BoundedKafkaDynamicSource copy =
+                new BoundedKafkaDynamicSource(
+                        physicalDataType,
+                        keyDecodingFormat,
+                        valueDecodingFormat,
+                        keyProjection,
+                        valueProjection,
+                        keyPrefix,
+                        topics,
+                        topicPattern,
+                        properties,
+                        startupMode,
+                        specificStartupOffsets,
+                        startupTimestampMillis,
+                        upsertMode,
+                        tableIdentifier);
+        copy.producedDataType = producedDataType;
+        copy.metadataKeys = metadataKeys;
+        copy.watermarkStrategy = watermarkStrategy;
+        return copy;
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaDynamicTableFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaDynamicTableFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+// TODO: This class will be removed after FLINK-24456 resolved.
+/**
+ * Factory for creating configured instances of {@link BoundedKafkaDynamicSource} and {@link
+ * KafkaDynamicSink}.
+ */
+public class BoundedKafkaDynamicTableFactory extends KafkaDynamicTableFactory {
+
+    public static final String IDENTIFIER = "bounded-kafka";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    protected BoundedKafkaDynamicSource createKafkaTableSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<KafkaTopicPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis,
+            String tableIdentifier) {
+        return new BoundedKafkaDynamicSource(
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                false,
+                tableIdentifier);
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.flink.streaming.connectors.kafka.table.BoundedKafkaDynamicTableFactory

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaTableITCase.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/BoundedKafkaTableITCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link BoundedKafkaDynamicSource}. */
+public class BoundedKafkaTableITCase extends KafkaTableTestBase {
+
+    @Test
+    public void testBoundedKafkaSource() throws Exception {
+        final String topic = "test-topic";
+        createTestTopic(topic, 1, 1);
+
+        // ---------- Produce an event time stream into Kafka -------------------
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "create table kafka (\n"
+                                + "  id INTEGER,\n"
+                                + "  val DOUBLE\n"
+                                + ") with (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  'format' = 'csv'\n"
+                                + ")",
+                        BoundedKafkaDynamicTableFactory.IDENTIFIER, topic, bootstraps, groupId);
+
+        tEnv.executeSql(createTable);
+
+        String initialValues =
+                "INSERT INTO kafka\n"
+                        + "SELECT id, val \n"
+                        + "FROM (VALUES (1, 2.02), (1, 1.11), (1, 50), (1, 3.1), (2, 5.33), (2, 0.0))\n"
+                        + "  AS orders (id, val)";
+        tEnv.executeSql(initialValues).await();
+
+        // ---------- Consume stream from Kafka -------------------
+
+        String query = "SELECT * FROM kafka\n";
+
+        DataStream<Row> result = tEnv.toDataStream(tEnv.sqlQuery(query));
+        final List<Row> rows = CollectionUtil.iteratorToList(result.executeAndCollect());
+        assertThat(rows).hasSize(6);
+
+        // ------------- cleanup -------------------
+
+        deleteTestTopic(topic);
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.DockerImageVersions;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+// TODO: This class will be removed after FLINK-24456 resolved.
+/**
+ * Base class for Kafka Table IT Cases.
+ *
+ * <p>This class is copied from Apache Flink project. We cannot re-use the class as it is not
+ * packaged in the test jar.
+ */
+public abstract class KafkaTableTestBase extends AbstractTestBase {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTableTestBase.class);
+
+    private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
+    private static final int zkTimeoutMills = 30000;
+
+    @ClassRule
+    public static final KafkaContainer KAFKA_CONTAINER =
+            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
+                @Override
+                protected void doStart() {
+                    super.doStart();
+                    if (LOG.isInfoEnabled()) {
+                        this.followOutput(new Slf4jLogConsumer(LOG));
+                    }
+                }
+            }.withEmbeddedZookeeper()
+                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
+                    .withEnv(
+                            "KAFKA_TRANSACTION_MAX_TIMEOUT_MS",
+                            String.valueOf(Duration.ofHours(2).toMillis()))
+                    // Disable log deletion to prevent records from being deleted during test run
+                    .withEnv("KAFKA_LOG_RETENTION_MS", "-1");
+
+    protected StreamExecutionEnvironment env;
+    protected StreamTableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    public Properties getStandardProps() {
+        Properties standardProps = new Properties();
+        standardProps.put("bootstrap.servers", KAFKA_CONTAINER.getBootstrapServers());
+        standardProps.put("group.id", "flink-tests");
+        standardProps.put("enable.auto.commit", false);
+        standardProps.put("auto.offset.reset", "earliest");
+        standardProps.put("max.partition.fetch.bytes", 256);
+        standardProps.put("zookeeper.session.timeout.ms", zkTimeoutMills);
+        standardProps.put("zookeeper.connection.timeout.ms", zkTimeoutMills);
+        return standardProps;
+    }
+
+    public String getBootstrapServers() {
+        return KAFKA_CONTAINER.getBootstrapServers();
+    }
+
+    public void createTestTopic(String topic, int numPartitions, int replicationFactor) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
+        try (AdminClient admin = AdminClient.create(properties)) {
+            admin.createTopics(
+                    Collections.singletonList(
+                            new NewTopic(topic, numPartitions, (short) replicationFactor)));
+        }
+    }
+
+    public void deleteTestTopic(String topic) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
+        try (AdminClient admin = AdminClient.create(properties)) {
+            admin.deleteTopics(Collections.singletonList(topic));
+        }
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/java/feathub-connectors/flink-connectors/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/java/feathub-connectors/flink-connectors/pom.xml
+++ b/java/feathub-connectors/flink-connectors/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The Feathub Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>feathub-connectors</artifactId>
+        <groupId>com.alibaba.feathub</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>flink-connectors</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>flink-connector-kafka</module>
+    </modules>
+
+</project>

--- a/java/feathub-connectors/pom.xml
+++ b/java/feathub-connectors/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The Feathub Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>feathub-parent</artifactId>
+        <groupId>com.alibaba.feathub</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>feathub-connectors</artifactId>
+    <modules>
+        <module>flink-connectors</module>
+    </modules>
+
+
+</project>

--- a/java/feathub-dist/pom.xml
+++ b/java/feathub-dist/pom.xml
@@ -36,6 +36,12 @@
 
         <dependency>
             <groupId>com.alibaba.feathub</groupId>
+            <artifactId>flink-connector-kafka</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.feathub</groupId>
             <artifactId>feathub-udf</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/java/feathub-dist/src/main/assemblies/bin.xml
+++ b/java/feathub-dist/src/main/assemblies/bin.xml
@@ -31,20 +31,6 @@
             <unpack>false</unpack>
             <useProjectArtifact>false</useProjectArtifact>
             <useProjectAttachments>false</useProjectAttachments>
-
-            <includes>
-                <include>org.apache.flink:flink-sql-connector-kafka</include>
-            </includes>
         </dependencySet>
     </dependencySets>
-
-    <files>
-        <!-- Feathub UDF -->
-        <file>
-            <source>../feathub-udf/target/feathub-udf-${project.version}.jar</source>
-            <outputDirectory>lib</outputDirectory>
-            <destName>feathub-udf-${project.version}.jar</destName>
-            <fileMode>0644</fileMode>
-        </file>
-    </files>
 </assembly>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>feathub-dist</module>
         <module>feathub-udf</module>
+        <module>feathub-connectors</module>
     </modules>
 
     <properties>

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -19,3 +19,4 @@ autopep8>=1.6.0
 pytest==4.4.1
 flake8==4.0.1
 mypy==0.971
+testcontainers[kafka]~=3.7.0

--- a/python/feathub/feature_tables/sources/kafka_source.py
+++ b/python/feathub/feature_tables/sources/kafka_source.py
@@ -39,6 +39,7 @@ class KafkaSource(FeatureTable):
         startup_mode: str = "group-offsets",
         startup_datetime: Optional[datetime] = None,
         partition_discovery_interval: timedelta = timedelta(minutes=5),
+        is_bounded: bool = False,
     ):
         """
         :param name: The name that uniquely identifies this source in a registry.
@@ -83,6 +84,9 @@ class KafkaSource(FeatureTable):
                                              Default to 5 minutes so that it is
                                              consistent with the 'metadata.max.age.ms'
                                              for Kafka Consumer config.
+        :param is_bounded: Whether the KafkaSource should be bounded. If the KafkaSource
+                           is bounded, it stops at the latest offsets of the partitions
+                           when the KafkaSource starts to run.
         """
         super().__init__(
             name=name,
@@ -111,6 +115,7 @@ class KafkaSource(FeatureTable):
             raise FeathubException(
                 "startup_datetime is required when startup_mode is timestamp."
             )
+        self.is_bounded = is_bounded
 
     def to_json(self) -> Dict:
         return {
@@ -134,4 +139,5 @@ class KafkaSource(FeatureTable):
             else int(self.startup_datetime.timestamp() * 1000),
             "partition_discovery_interval_ms": self.partition_discovery_interval
             / timedelta(milliseconds=1),
+            "is_bounded": self.is_bounded,
         }

--- a/python/feathub/processors/flink/flink_jar_utils.py
+++ b/python/feathub/processors/flink/flink_jar_utils.py
@@ -48,14 +48,14 @@ def find_jar_lib() -> str:
     )
 
 
-def add_jar_to_t_env(t_env: StreamTableEnvironment, jar_path: str) -> None:
+def add_jar_to_t_env(t_env: StreamTableEnvironment, *jar_paths: str) -> None:
     """
-    Add the jar path to the given StreamTableEnvironment if it is not already added.
+    Add each jar path to the given StreamTableEnvironment if it is not already added.
     """
     old_jars = t_env.get_config().get("pipeline.jars", "")
     old_jars = [] if old_jars == "" else old_jars.split(";")
-    jar_path = f"file://{jar_path}"
-    if jar_path in old_jars:
-        # already added
+    jars = [f"file://{jar_path}" for jar_path in jar_paths if jar_path not in old_jars]
+    if len(jars) == 0:
+        # all jars already added
         return
-    t_env.get_config().set("pipeline.jars", ";".join([*old_jars, jar_path]))
+    t_env.get_config().set("pipeline.jars", ";".join([*old_jars, *jars]))

--- a/python/feathub/processors/flink/table_builder/file_system_utils.py
+++ b/python/feathub/processors/flink/table_builder/file_system_utils.py
@@ -80,7 +80,7 @@ def insert_into_file_sink(
     # have a name in VVR-6.0.2, which should be fixed in next version VVR-6.0.3. As a
     # current workaround, we have to generate a random table name. We should update the
     # code to use anonymous table sink after VVR-6.0.3 is released.
-    random_sink_name = generate_random_table_name()
+    random_sink_name = generate_random_table_name("FileSink")
     t_env.create_temporary_table(
         random_sink_name,
         NativeFlinkTableDescriptor.for_connector("filesystem")

--- a/python/feathub/processors/flink/table_builder/print_utils.py
+++ b/python/feathub/processors/flink/table_builder/print_utils.py
@@ -32,7 +32,7 @@ def insert_into_print_sink(
     # have a name in VVR-6.0.2, which should be fixed in next version VVR-6.0.3. As a
     # current workaround, we have to generate a random table name. We should update the
     # code to use anonymous table sink after VVR-6.0.3 is released.
-    random_sink_name = generate_random_table_name()
+    random_sink_name = generate_random_table_name("PrintSink")
     t_env.create_temporary_table(
         random_sink_name,
         NativeFlinkTableDescriptor.for_connector("print")

--- a/python/feathub/processors/flink/table_builder/source_sink_utils_common.py
+++ b/python/feathub/processors/flink/table_builder/source_sink_utils_common.py
@@ -27,8 +27,8 @@ from feathub.processors.flink.table_builder.flink_table_builder_constants import
 )
 
 
-def generate_random_table_name() -> str:
-    random_sink_name = "anonymous" + str(uuid.uuid4()).replace("-", "") + "table"
+def generate_random_table_name(name_prefix: str) -> str:
+    random_sink_name = name_prefix + str(uuid.uuid4()).replace("-", "") + "table"
     return random_sink_name
 
 

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from feathub.registries.registry import Registry
 
 
+# TODO: Add API to support setting boundedness of the TableDescriptor.
 class TableDescriptor(Entity):
     """
     Provides metadata to access, derive and interpret a table of feature values. Each


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to solve the problem that the Table#to_pandas method never returns when using KafkaSource by supporting bounded mode for Flink Kafka. User can now use bounded KafkaSource so that Table#to_pandas method can return.

Currently, the native Flink Kafka SQL connector doesn't support bounded mode. There is a [ticket](https://issues.apache.org/jira/browse/FLINK-24456) tracking the issue. As a temporary solution, we introduce a `BoundedKafkaDynamicSource` that extends the native `KafkaDynamicSource` to support bounded mode.

## Brief change log

- Introduce `BoundedKafkaDynamicSource`
- Use testcontainers for Kafka test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable