### PR TITLE
Table#to_pandas supports force bounded

### DIFF
--- a/python/feathub/examples/streaming_average_flink_cli.py
+++ b/python/feathub/examples/streaming_average_flink_cli.py
@@ -18,7 +18,6 @@ from feathub.feathub_client import FeathubClient
 from feathub.feature_tables.sinks.print_sink import PrintSink
 from feathub.feature_tables.sources.datagen_source import (
     DataGenSource,
-    DataGenConfig,
     RandomField,
 )
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
@@ -52,13 +51,11 @@ def main() -> None:
 
     source = DataGenSource(
         name="datagen_src",
-        data_gen_config=DataGenConfig(
-            rows_per_second=1,
-            field_configs={
-                "id": RandomField(minimum=0, maximum=9),
-                "val": RandomField(minimum=0, maximum=100),
-            },
-        ),
+        rows_per_second=1,
+        field_configs={
+            "id": RandomField(minimum=0, maximum=9),
+            "val": RandomField(minimum=0, maximum=100),
+        },
         schema=Schema.new_builder()
         .column("id", Int32)
         .column("val", Int32)

--- a/python/feathub/feature_tables/feature_table.py
+++ b/python/feathub/feature_tables/feature_table.py
@@ -16,8 +16,8 @@ from typing import List, Optional, Dict, Any
 
 from feathub.common.exceptions import FeathubException
 from feathub.feature_views.feature import Feature
-from feathub.table.table_descriptor import TableDescriptor
 from feathub.table.schema import Schema
+from feathub.table.table_descriptor import TableDescriptor
 
 
 # TODO: Update Sink implementation of FeatureTable to support rename timestamp field
@@ -92,4 +92,16 @@ class FeatureTable(TableDescriptor, ABC):
             dtype=self.schema.get_field_type(feature_name),
             transform=feature_name,
             keys=self.keys,
+        )
+
+    def is_bounded(self) -> bool:
+        # FeatureTable is bounded by default unless subclass overwrite the method.
+        return True
+
+    def get_bounded_view(self) -> TableDescriptor:
+        if self.is_bounded():
+            return self
+
+        raise FeathubException(
+            f"{type(self)} is unbounded and it doesn't support getting bounded view."
         )

--- a/python/feathub/feature_tables/sinks/file_system_sink.py
+++ b/python/feathub/feature_tables/sinks/file_system_sink.py
@@ -13,10 +13,10 @@
 #  limitations under the License.
 from typing import Dict
 
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 
 
-class FileSystemSink(FeatureTable):
+class FileSystemSink(Sink):
     """A Sink which writes data to files."""
 
     def __init__(self, path: str, data_format: str) -> None:
@@ -25,7 +25,10 @@ class FileSystemSink(FeatureTable):
         :param data_format: The format of the data that are written to the file.
         """
         super().__init__(
-            "", "filesystem", properties={"path": path}, data_format=data_format
+            name="",
+            system_name="filesystem",
+            properties={"path": path},
+            data_format=data_format,
         )
         self.path = path
 

--- a/python/feathub/feature_tables/sinks/kafka_sink.py
+++ b/python/feathub/feature_tables/sinks/kafka_sink.py
@@ -13,10 +13,10 @@
 #  limitations under the License.
 from typing import Dict, Optional
 
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 
 
-class KafkaSink(FeatureTable):
+class KafkaSink(Sink):
     def __init__(
         self,
         bootstrap_server: str,

--- a/python/feathub/feature_tables/sinks/online_store_sink.py
+++ b/python/feathub/feature_tables/sinks/online_store_sink.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 from typing import Dict
 
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 
 
-class OnlineStoreSink(FeatureTable):
+class OnlineStoreSink(Sink):
     """
     A sink corresponding to a table in an online feature store.
     """

--- a/python/feathub/feature_tables/sinks/sink.py
+++ b/python/feathub/feature_tables/sinks/sink.py
@@ -1,0 +1,59 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from abc import ABC
+from typing import Any, Dict, Optional
+
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.table.table_descriptor import TableDescriptor
+
+
+class Sink(FeatureTable, ABC):
+    """
+    Base class for all Sink Feature Table.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        system_name: str,
+        properties: Dict[str, Any],
+        data_format: Optional[str] = None,
+    ):
+        """
+        :param name: The name that uniquely identifies this feature table in a registry.
+        :param system_name: Uniquely identifies the underlying system, e.g. filesystem,
+                            kafka, etc.
+        :param properties: It contains the properties specific to the underlying system
+                           that are used to uniquely identify the physical table.
+        :param data_format: Optional. If it is not None, it specifies the format of the
+                            data, e.g. csv, json, parquet, etc. This is typically
+                            used by storage that does not require schema, e.g.
+                            filesystem, kafka, etc.
+        """
+        super().__init__(
+            name=name,
+            system_name=system_name,
+            properties=properties,
+            data_format=data_format,
+        )
+
+    def is_bounded(self) -> bool:
+        raise FeathubException(
+            "Sink feature table doesn't have boundedness. "
+            "This method should not be called."
+        )
+
+    def get_bounded_view(self) -> TableDescriptor:
+        raise FeathubException(f"Cannot get bounded feature table on {type(self)}.")

--- a/python/feathub/feature_tables/sources/tests/__init__.py
+++ b/python/feathub/feature_tables/sources/tests/__init__.py
@@ -11,18 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict
-
-from feathub.feature_tables.sinks.sink import Sink
-
-
-class PrintSink(Sink):
-    """
-    PrintSink prints the table row by row to stdout.
-    """
-
-    def __init__(self) -> None:
-        super().__init__(name="", system_name="print", properties={})
-
-    def to_json(self) -> Dict:
-        return {"type": "PrintSink"}

--- a/python/feathub/feature_tables/sources/tests/test_datagen_source.py
+++ b/python/feathub/feature_tables/sources/tests/test_datagen_source.py
@@ -1,0 +1,77 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from typing import cast
+
+from feathub.common.types import Int64
+from feathub.feature_tables.sources.datagen_source import (
+    DEFAULT_BOUNDED_NUMBER_OF_ROWS,
+    DataGenSource,
+    SequenceField,
+)
+from feathub.table.schema import Schema
+
+
+class DataGenSourceTest(unittest.TestCase):
+    def test_boundedness(self):
+        source = DataGenSource(
+            "source", Schema.new_builder().column("x", Int64).column("y", Int64).build()
+        )
+        self.assertFalse(source.is_bounded())
+
+        source = DataGenSource(
+            "source",
+            Schema.new_builder().column("x", Int64).column("y", Int64).build(),
+            number_of_rows=10,
+        )
+        self.assertTrue(source.is_bounded())
+
+        source = DataGenSource(
+            "source",
+            Schema.new_builder().column("x", Int64).column("y", Int64).build(),
+            field_configs={"x": SequenceField(start=1, end=10)},
+        )
+        self.assertTrue(source.is_bounded())
+
+    def test_get_bounded_feature_table(self):
+        source = DataGenSource(
+            "source", Schema.new_builder().column("x", Int64).column("y", Int64).build()
+        )
+        self.assertFalse(source.is_bounded())
+
+        bounded_source = source.get_bounded_view()
+        self.assertTrue(bounded_source.is_bounded())
+        self.assertEqual(
+            DEFAULT_BOUNDED_NUMBER_OF_ROWS,
+            cast(DataGenSource, bounded_source).number_of_rows,
+        )
+
+        source_json = source.to_json()
+        source_json.pop("number_of_rows")
+        bounded_source_json = bounded_source.to_json()
+        bounded_source_json.pop("number_of_rows")
+
+        self.assertEqual(source_json, bounded_source_json)

--- a/python/feathub/feature_tables/sources/tests/test_file_system_source.py
+++ b/python/feathub/feature_tables/sources/tests/test_file_system_source.py
@@ -11,18 +11,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict
+import unittest
 
-from feathub.feature_tables.sinks.sink import Sink
+from feathub.common.types import Int64
+from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.table.schema import Schema
 
 
-class PrintSink(Sink):
-    """
-    PrintSink prints the table row by row to stdout.
-    """
-
-    def __init__(self) -> None:
-        super().__init__(name="", system_name="print", properties={})
-
-    def to_json(self) -> Dict:
-        return {"type": "PrintSink"}
+class FileSystemSourceTest(unittest.TestCase):
+    def test_get_bounded_feature_table(self):
+        source = FileSystemSource(
+            "source",
+            "./path",
+            "csv",
+            Schema.new_builder().column("x", Int64).column("y", Int64).build(),
+        )
+        self.assertTrue(source.is_bounded())

--- a/python/feathub/feature_tables/sources/tests/test_kafka_source.py
+++ b/python/feathub/feature_tables/sources/tests/test_kafka_source.py
@@ -1,0 +1,42 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+from feathub.common.types import Int64
+from feathub.feature_tables.sources.kafka_source import KafkaSource
+from feathub.table.schema import Schema
+
+
+class TestKafkaSource(unittest.TestCase):
+    def test_get_bounded_feature_table(self):
+        source = KafkaSource(
+            "source",
+            "bootstrap_server",
+            "topic",
+            None,
+            "csv",
+            Schema.new_builder().column("x", Int64).column("y", Int64).build(),
+            "consumer_group",
+        )
+        self.assertFalse(source.is_bounded())
+
+        bounded_source = source.get_bounded_view()
+        self.assertTrue(bounded_source.is_bounded())
+
+        source_json = source.to_json()
+        source_json.pop("is_bounded")
+        bounded_source_json = bounded_source.to_json()
+        bounded_source_json.pop("is_bounded")
+
+        self.assertEqual(source_json, bounded_source_json)

--- a/python/feathub/feature_tables/sources/tests/test_online_store_source.py
+++ b/python/feathub/feature_tables/sources/tests/test_online_store_source.py
@@ -1,0 +1,31 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from typing import cast
+
+from feathub.feature_tables.sources.online_store_source import OnlineStoreSource
+
+
+class OnlineStoreSourceTest(unittest.TestCase):
+    def test_get_bounded_feature_table(self):
+        source = OnlineStoreSource("source", ["id"], "filesystem", "table")
+        self.assertTrue(source.is_bounded())
+
+        bounded_source = source.get_bounded_view()
+        self.assertTrue(cast(OnlineStoreSource, bounded_source).is_bounded())
+
+        source_json = source.to_json()
+        bounded_source_json = bounded_source.to_json()
+
+        self.assertEqual(source_json, bounded_source_json)

--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 from typing import Union, Dict, Sequence
 
+from feathub.common.exceptions import FeathubException
 from feathub.feature_views.transforms.join_transform import JoinTransform
 from feathub.table.table_descriptor import TableDescriptor
 from feathub.feature_views.feature import Feature
@@ -87,6 +88,17 @@ class DerivedFeatureView(FeatureView):
                     join_feature_name = parts[0]
 
                 table_desc = registry.get_features(name=join_table_name)
+                if source.is_bounded() and not table_desc.is_bounded():
+                    # TODO: Remove this check after after Flink support terminate the
+                    #  job when the bounded left table finished.
+                    #  https://issues.apache.org/jira/projects/FLINK/issues/FLINK-30078
+                    # Raise exception if bounded left table join with an unbounded right
+                    # table.
+                    raise FeathubException(
+                        "Joining a bounded left table with an unbounded right table is "
+                        "currently not supported. You can make the right table bounded "
+                        "by setting its source to be bounded."
+                    )
                 join_feature = table_desc.get_feature(feature_name=join_feature_name)
                 if source.name == join_table_name:
                     feature = join_feature

--- a/python/feathub/feature_views/feature_view.py
+++ b/python/feathub/feature_views/feature_view.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC
-from typing import Optional, List, Union, cast, Sequence
 from collections import OrderedDict
+from copy import deepcopy
+from typing import Optional, List, Union, cast, Sequence
 
 from feathub.common.exceptions import FeathubException
 from feathub.feature_views.feature import Feature
@@ -169,3 +170,14 @@ class FeatureView(TableDescriptor, ABC):
                 key_fields.extend(keys)
 
         return list(OrderedDict.fromkeys(key_fields))
+
+    def is_bounded(self) -> bool:
+        return self.get_resolved_source().is_bounded()
+
+    def get_bounded_view(self) -> TableDescriptor:
+        if self.is_bounded():
+            return self
+
+        feature_view = deepcopy(self)
+        feature_view.source = self.get_resolved_source().get_bounded_view()
+        return feature_view

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -48,7 +48,6 @@ class SlidingFeatureView(FeatureView):
     "epoch". Other fields in the source table will not be included.
     """
 
-    # TODO: support epoch format with millisecond precision.
     def __init__(
         self,
         name: str,

--- a/python/feathub/processors/flink/table_builder/datagen_utils.py
+++ b/python/feathub/processors/flink/table_builder/datagen_utils.py
@@ -57,17 +57,16 @@ def get_table_from_data_gen_source(
         "datagen"
     ).schema(flink_schema)
 
-    data_gen_config = data_gen_source.data_gen_config
     table_descriptor_builder.option(
-        "rows-per-second", str(data_gen_config.rows_per_second)
+        "rows-per-second", str(data_gen_source.rows_per_second)
     )
 
-    if data_gen_config.number_of_rows is not None:
+    if data_gen_source.number_of_rows is not None:
         table_descriptor_builder.option(
-            "number-of-rows", str(data_gen_source.data_gen_config.number_of_rows)
+            "number-of-rows", str(data_gen_source.number_of_rows)
         )
 
-    for field, field_config in data_gen_source.data_gen_config.field_configs.items():
+    for field, field_config in data_gen_source.field_configs.items():
         if isinstance(field_config, RandomField):
             table_descriptor_builder.option(f"fields.{field}.kind", "random")
             if field_config.minimum is not None:

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -150,6 +150,8 @@ class FlinkTableBuilder:
         if EVENT_TIME_ATTRIBUTE_NAME in table.get_schema().get_field_names():
             table = table.drop_columns(EVENT_TIME_ATTRIBUTE_NAME)
 
+        self._built_tables.clear()
+
         return table
 
     def _filter_table_by_keys(

--- a/python/feathub/processors/flink/table_builder/kafka_utils.py
+++ b/python/feathub/processors/flink/table_builder/kafka_utils.py
@@ -103,7 +103,7 @@ def get_table_from_kafka_source(
             )
             flink_schema = builder.build()
 
-    connector_type = "bounded-kafka" if kafka_source.is_bounded else "kafka"
+    connector_type = "bounded-kafka" if kafka_source.is_bounded() else "kafka"
     descriptor_builder = (
         NativeFlinkTableDescriptor.for_connector(connector_type)
         .option("value.format", kafka_source.value_format)

--- a/python/feathub/processors/flink/table_builder/tests/test_datagen_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_datagen_utils.py
@@ -19,7 +19,6 @@ from pyflink.table import StreamTableEnvironment
 from feathub.common.types import Int32, Timestamp
 from feathub.feature_tables.sources.datagen_source import (
     DataGenSource,
-    DataGenConfig,
     RandomField,
     SequenceField,
 )
@@ -37,13 +36,11 @@ class DataGenUtilsTest(unittest.TestCase):
 
         source = DataGenSource(
             name="datagen_src",
-            data_gen_config=DataGenConfig(
-                rows_per_second=10,
-                field_configs={
-                    "id": SequenceField(start=0, end=9),
-                    "val": RandomField(minimum=0, maximum=100),
-                },
-            ),
+            rows_per_second=10,
+            field_configs={
+                "id": SequenceField(start=0, end=9),
+                "val": RandomField(minimum=0, maximum=100),
+            },
             schema=Schema(["id", "val", "ts"], [Int32, Int32, Timestamp]),
             timestamp_field="ts",
             timestamp_format="%Y-%m-%d %H:%M:%S",

--- a/python/feathub/processors/flink/table_builder/tests/test_kafka_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_kafka_utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import unittest
 from datetime import datetime, timezone
+from typing import cast
 from unittest.mock import patch
 
 from pyflink.common import Row
@@ -25,6 +26,7 @@ from pyflink.table import (
 from testcontainers.kafka import KafkaContainer
 
 from feathub.common.types import Int64, String
+from feathub.feature_tables.feature_table import FeatureTable
 from feathub.feature_tables.sinks.kafka_sink import KafkaSink
 from feathub.feature_tables.sources.kafka_source import KafkaSource
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
@@ -101,8 +103,8 @@ class SourceUtilsTest(unittest.TestCase):
                 expected_options, dict(flink_table_descriptor.get_options())
             )
 
-            source.is_bounded = True
-            get_table_from_source(t_env, source)
+            bounded_source = source.get_bounded_view()
+            get_table_from_source(t_env, cast(FeatureTable, bounded_source))
             flink_table_descriptor = create_temporary_table.call_args[0][1]
 
             expected_col_strs = [

--- a/python/feathub/processors/flink/tests/test_flink_table.py
+++ b/python/feathub/processors/flink/tests/test_flink_table.py
@@ -1,0 +1,90 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from typing import Dict
+from unittest.mock import patch
+
+from feathub.common.exceptions import FeathubException
+from feathub.common.types import String
+from feathub.feature_tables.sources.datagen_source import DataGenSource
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.online_stores.memory_online_store import MemoryOnlineStore
+from feathub.online_stores.online_store import OnlineStore
+from feathub.processors.flink import flink_table
+from feathub.processors.flink.flink_processor import FlinkProcessor
+from feathub.processors.flink.flink_table import FlinkTable
+from feathub.registries.local_registry import LocalRegistry
+from feathub.table.schema import Schema
+from feathub.table.table_descriptor import TableDescriptor
+
+
+class FlinkTableTest(unittest.TestCase):
+    def setUp(self) -> None:
+        memory_online_store = OnlineStore.instantiate(
+            store_type=MemoryOnlineStore.STORE_TYPE, config={}
+        )
+        self.stores: Dict[str, OnlineStore] = {
+            MemoryOnlineStore.STORE_TYPE: memory_online_store
+        }
+        self.registry = LocalRegistry(config={})
+        self.processor = FlinkProcessor(
+            config={
+                "rest.address": "127.0.0.1",
+                "rest.port": "1234",
+            },
+            stores=self.stores,
+            registry=self.registry,
+        )
+
+    def test_to_pandas_force_bounded(self):
+
+        source = DataGenSource(
+            "source",
+            Schema.new_builder().column("x", String).build(),
+        )
+
+        source_2 = DataGenSource(
+            "source_2",
+            Schema.new_builder().column("x", String).column("y", String).build(),
+            keys=["x"],
+        )
+
+        features = DerivedFeatureView(
+            "sliding", source, ["source_2.y"], keep_source_fields=True
+        )
+        built_features = self.registry.build_features([source_2, features])[1]
+        table = FlinkTable(
+            flink_processor=self.processor,
+            feature=built_features,
+            keys=None,
+            start_datetime=None,
+            end_datetime=None,
+        )
+
+        with self.assertRaises(FeathubException) as cm:
+            table.to_pandas()
+
+        self.assertIn(
+            "Unbounded table cannot be converted to Pandas DataFrame.",
+            cm.exception.args[0],
+        )
+
+        with patch.object(
+            self.processor.flink_table_builder, "build"
+        ) as build_method, patch.object(flink_table, "flink_table_to_pandas") as _:
+            table.to_pandas(force_bounded=True)
+            self.assertIsInstance(
+                build_method.call_args[1]["features"], TableDescriptor
+            )
+            self.assertTrue(build_method.call_args[1]["features"].is_bounded())

--- a/python/feathub/processors/local/local_table.py
+++ b/python/feathub/processors/local/local_table.py
@@ -57,7 +57,7 @@ class LocalTable(Table):
             field_types.append(types.from_numpy_dtype(self.df.dtypes[i]))
         return Schema(field_names=field_names, field_types=field_types)
 
-    def to_pandas(self) -> pd.DataFrame:
+    def to_pandas(self, force_bounded: bool = False) -> pd.DataFrame:
         return self.df
 
     def execute_insert(

--- a/python/feathub/processors/processor_job.py
+++ b/python/feathub/processors/processor_job.py
@@ -38,6 +38,7 @@ class ProcessorJob(ABC):
         :return: The Future that is completed when the canceling command is
                  acknowledged.
         """
+        pass
 
     @abstractmethod
     def wait(self, timeout_ms: Optional[int] = None) -> None:

--- a/python/feathub/table/table.py
+++ b/python/feathub/table/table.py
@@ -49,9 +49,11 @@ class Table(ABC):
         pass
 
     @abstractmethod
-    def to_pandas(self) -> pd.DataFrame:
+    def to_pandas(self, force_bounded: bool = False) -> pd.DataFrame:
         """
         Returns a Pandas DataFrame containing values of this table.
+
+        :param force_bounded: Whether to force the table to be bounded.
         """
         pass
 

--- a/python/feathub/table/table.py
+++ b/python/feathub/table/table.py
@@ -53,7 +53,7 @@ class Table(ABC):
         """
         Returns a Pandas DataFrame containing values of this table.
         """
-        return pd.DataFrame()
+        pass
 
     @abstractmethod
     def execute_insert(

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -79,3 +79,20 @@ class TableDescriptor(Entity):
         :return: The feature with the given name.
         """
         pass
+
+    @abstractmethod
+    def get_bounded_view(self) -> TableDescriptor:
+        """
+        If the Table is bounded, returns self. Otherwise, return a copy of self that is
+        bounded.
+
+        :return: A bounded table descriptor.
+        """
+        pass
+
+    @abstractmethod
+    def is_bounded(self) -> bool:
+        """
+        Whether the Table is bounded.
+        """
+        pass


### PR DESCRIPTION
## What is the purpose of the change

Currently, Table#to_pandas never returns if the Table is unbounded. 

In this PR, we make the `to_pandas` method raise an exception when the Table is unbounded. And we add a `force_bounded` argument to the method to allow users to force the unbounded table to be bounded and convert to Pandas DataFrame. 

## Brief change log

- Add boundedness API to TableDescriptor
- Table#to_pandas supports force bounded

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Python docstring