### PR TITLE
Improve the readme doc to avoid unpredictable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Prerequisites for building python packages:
 - Unix-like operating system (e.g. Linux, Mac OS X)
 - x86_64 architecture
 - Python 3.7
+- Pip >= 21.3
 - Java 8
 - Maven >= 3.1.1
 
@@ -87,7 +88,7 @@ $ python python/feathub/examples/nyc_taxi.py
 #### Quickstart using Flink Processor
 
 If you are interested in computing the Feathub features with Flink processor in a local 
-Flink cluster. You can see the following quickstart with different deployment modes:
+Flink cluster, you can see the following quickstart with different deployment modes:
 
 - [Flink Processor Session Mode Quickstart](docs/quickstarts/flink_processor_session_quickstart.md)
 - [Flink Processor Cli Mode Quickstart](docs/quickstarts/flink_processor_cli_quickstart.md)

--- a/docs/quickstarts/flink_processor_cli_quickstart.md
+++ b/docs/quickstarts/flink_processor_cli_quickstart.md
@@ -15,7 +15,7 @@ The prerequisites to run the quickstart are listed below.
 
 ### Install Flink 
 
-Download a stable release of Flink 1.15, then extract the archive:
+Download a stable release of Flink 1.15.2, then extract the archive:
 
 ```bash
 $ curl -LO https://archive.apache.org/dist/flink/flink-1.15.2/flink-1.15.2-bin-scala_2.12.tgz

--- a/docs/quickstarts/flink_processor_session_quickstart.md
+++ b/docs/quickstarts/flink_processor_session_quickstart.md
@@ -5,7 +5,7 @@ the Feathub feature with a local standalone Flink cluster.
 
 ### Install Flink 
 
-Download a stable release of Flink 1.15, then extract the archive:
+Download a stable release of Flink 1.15.2, then extract the archive:
 
 ```bash
 $ curl -LO https://archive.apache.org/dist/flink/flink-1.15.2/flink-1.15.2-bin-scala_2.12.tgz


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Feathub - we are happy that you want to help us improve Feathub. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
## Contribution Checklist
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review. 
  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Improve the readme doc to avoid unpredictable error.

## Brief change log

  - Requires Pip version  >= 21.3. With a lower version, the following error would happen.
```
ERROR: Command errored out with exit status 1:
     command: /Users/alibaba/work/venv/venv-feathub/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-req-build-7xp8d0cb/setup.py'"'"'; __file__='"'"'/private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-req-build-7xp8d0cb/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d
         cwd: /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-req-build-7xp8d0cb/
    Complete output (8 lines):
    running egg_info
    creating /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info
    writing /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info/PKG-INFO
    writing dependency_links to /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info/dependency_links.txt
    writing requirements to /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info/requires.txt
    writing top-level names to /private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info/top_level.txt
    writing manifest file '/private/var/folders/b0/rv05qnd128vd9d4569g62md00000gp/T/pip-pip-egg-info-xk_s_o9d/feathub.egg-info/SOURCES.txt'
    error: package directory 'deps/processors/flink/lib' does not exist
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
  - Requires the Flink version to be 1.15.2, which is the same as the version of the flink library. Otherwise the job submission would fail in session mode with the following exception.
```
Caused by: java.io.InvalidClassException: org.apache.flink.streaming.api.operators.collect.CollectSinkOperator; local class incompatible: stream classdesc serialVersionUID = -2753539520389490329, local class serialVersionUID = -3967023039272272048
        at java.io.ObjectStreamClass.initNonProxy(ObjectStreamClass.java:699)
        at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2001)
        at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1848)
        at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2158)
        at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
        at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
        at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
        at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
        at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
        at java.io.ObjectInputStream.readObject(ObjectInputStream.java:501)
        at java.io.ObjectInputStream.readObject(ObjectInputStream.java:459)
        at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:617)
        at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:602)
        at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:589)
        at org.apache.flink.util.InstantiationUtil.readObjectFromConfig(InstantiationUtil.java:543)
        at org.apache.flink.streaming.api.graph.StreamConfig.getStreamOperatorFactory(StreamConfig.java:324)
        ... 14 more
```


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)