### PR TITLE
Skip nightly build on fork unless manually triggered

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -12,16 +12,22 @@ on:
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yaml
+    # Don't do this in forks unless manually triggered
+    if: github.repository == 'alibaba/feathub' || github.event_name == 'workflow_dispatch'
     with:
       debug_enabled: ${{ inputs.debug_enabled || false }}
   build-and-upload-wheel:
     uses: ./.github/workflows/build-and-upload-wheel.yaml
+    # Don't do this in forks unless manually triggered
+    if: github.repository == 'alibaba/feathub' || github.event_name == 'workflow_dispatch'
     with:
       debug_enabled: ${{ inputs.debug_enabled || false }}
       is_nightly: true
     needs: build-and-test
   run-e2e-examples:
     uses: ./.github/workflows/run-e2e-examples.yaml
+    # Don't do this in forks unless manually triggered
+    if: github.repository == 'alibaba/feathub' || github.event_name == 'workflow_dispatch'
     with:
       debug_enabled: ${{ inputs.debug_enabled || false }}
     needs: build-and-upload-wheel


### PR DESCRIPTION
## What is the purpose of the change

Skip nightly build on fork unless manually triggered. This fixes #37.

## Brief change log

- Update nightly-build.yaml to skip nightly build on fork unless manually triggered

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable