### PR TITLE
Share t_env and env across tests

### DIFF
--- a/python/feathub/processors/flink/table_builder/tests/test_datagen_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_datagen_utils.py
@@ -11,10 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import unittest
-
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment
 
 from feathub.common.types import Int32, Timestamp
 from feathub.feature_tables.sources.datagen_source import (
@@ -25,15 +21,15 @@ from feathub.feature_tables.sources.datagen_source import (
 from feathub.processors.flink.table_builder.datagen_utils import (
     get_table_from_data_gen_source,
 )
+from feathub.processors.flink.table_builder.tests.table_builder_test_base import (
+    FlinkTableBuilderTestBase,
+)
 
 from feathub.table.schema import Schema
 
 
-class DataGenUtilsTest(unittest.TestCase):
+class DataGenUtilsTest(FlinkTableBuilderTestBase):
     def test_data_gen_source(self):
-        env = StreamExecutionEnvironment.get_execution_environment()
-        t_env = StreamTableEnvironment.create(env)
-
         source = DataGenSource(
             name="datagen_src",
             rows_per_second=10,
@@ -46,7 +42,7 @@ class DataGenUtilsTest(unittest.TestCase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        table = get_table_from_data_gen_source(t_env, source)
+        table = get_table_from_data_gen_source(self.t_env, source)
         df = table.to_pandas()
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_derived_feature.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_table_builder_derived_feature.py
@@ -395,7 +395,6 @@ class FlinkTableBuilderDerivedFeatureViewTest(FlinkTableBuilderTestBase):
         ).reset_index(drop=True)
 
         table = self.flink_table_builder.build(features=feature_view)
-        table.execute().print()
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )

--- a/python/feathub/processors/flink/table_builder/tests/test_print_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_print_utils.py
@@ -11,20 +11,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import unittest
-
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment
 
 from feathub.processors.flink.table_builder.print_utils import insert_into_print_sink
+from feathub.processors.flink.table_builder.tests.table_builder_test_base import (
+    FlinkTableBuilderTestBase,
+)
 
 
-class PrintSinkTest(unittest.TestCase):
+class PrintSinkTest(FlinkTableBuilderTestBase):
     def test_print_sink(self):
-        env = StreamExecutionEnvironment.get_execution_environment()
-        t_env = StreamTableEnvironment.create(env)
+        table = self.t_env.from_elements([(1,), (2,)], ["val"])
 
-        table = t_env.from_elements([(1,), (2,)], ["val"])
-
-        table_result = insert_into_print_sink(t_env, table)
+        table_result = insert_into_print_sink(self.t_env, table)
         table_result.wait()

--- a/python/feathub/processors/flink/tests/test_flink_type_utils.py
+++ b/python/feathub/processors/flink/tests/test_flink_type_utils.py
@@ -16,9 +16,9 @@ from typing import Dict
 
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import (
-    StreamTableEnvironment,
     TableDescriptor,
     DataTypes,
+    StreamTableEnvironment,
 )
 
 from feathub.common.exceptions import FeathubTypeException


### PR DESCRIPTION
## What is the purpose of the change

This PR mitigate the file descriptor leak when running unit test. This PR fix #24.

## Brief change log

- Share t_env and env across tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable