### PR TITLE
Move the join transform boundedness check to FlinkTableBuilder

### DIFF
--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 from typing import Union, Dict, Sequence, Optional
 
-from feathub.common.exceptions import FeathubException
 from feathub.feature_views.transforms.join_transform import JoinTransform
 from feathub.table.table_descriptor import TableDescriptor
 from feathub.feature_views.feature import Feature
@@ -90,17 +89,6 @@ class DerivedFeatureView(FeatureView):
                     join_feature_name = parts[0]
 
                 table_desc = registry.get_features(name=join_table_name)
-                if source.is_bounded() and not table_desc.is_bounded():
-                    # TODO: Remove this check after after Flink support terminate the
-                    #  job when the bounded left table finished.
-                    #  https://issues.apache.org/jira/projects/FLINK/issues/FLINK-30078
-                    # Raise exception if bounded left table join with an unbounded right
-                    # table.
-                    raise FeathubException(
-                        "Joining a bounded left table with an unbounded right table is "
-                        "currently not supported. You can make the right table bounded "
-                        "by setting its source to be bounded."
-                    )
                 join_feature = table_desc.get_feature(feature_name=join_feature_name)
                 if source.name == join_table_name:
                     feature = join_feature

--- a/python/feathub/feature_views/tests/test_feature_view.py
+++ b/python/feathub/feature_views/tests/test_feature_view.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-from feathub.common.exceptions import FeathubException
 from feathub.common.types import Int64
 from feathub.feature_tables.sources.datagen_source import DataGenSource
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
@@ -166,37 +165,3 @@ class FeatureViewTest(unittest.TestCase):
             [bounded_source_2, feature_view_2]
         )[1]
         self.assertTrue(built_feature_view_2.is_bounded())
-
-    def test_bounded_left_table_join_unbounded_right_table(self):
-        source = DataGenSource(
-            name="source_1",
-            schema=Schema(["id", "val1"], [Int64, Int64]),
-            timestamp_field="lpep_dropoff_datetime",
-            timestamp_format="%Y-%m-%d %H:%M:%S",
-            keys=["id"],
-            number_of_rows=1,
-        )
-
-        source_2 = DataGenSource(
-            name="source_2",
-            schema=Schema(["id", "val2"], [Int64, Int64]),
-            timestamp_field="lpep_dropoff_datetime",
-            timestamp_format="%Y-%m-%d %H:%M:%S",
-            keys=["id"],
-        )
-
-        feature_view_1 = DerivedFeatureView(
-            name="feature_view_1",
-            source=source,
-            features=["source_2.val2"],
-            keep_source_fields=True,
-        )
-
-        with self.assertRaises(FeathubException) as cm:
-            _ = self.registry.build_features([source_2, feature_view_1])[1]
-
-        self.assertIn(
-            "Joining a bounded left table with an unbounded right table is currently "
-            "not supported.",
-            cm.exception.args[0],
-        )

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -299,6 +299,20 @@ class FlinkTableBuilder:
 
                 join_transform = feature.transform
                 right_table_descriptor = descriptors_by_names[join_transform.table_name]
+                # TODO: Remove this check after after Flink support terminate the
+                #  job when the bounded left table finished.
+                #  https://issues.apache.org/jira/projects/FLINK/issues/FLINK-30078
+                # Raise exception if bounded left table join with an unbounded right
+                # table.
+                if (
+                    feature_view.is_bounded()
+                    and not right_table_descriptor.is_bounded()
+                ):
+                    raise FeathubException(
+                        "Joining a bounded left table with an unbounded right table is "
+                        "currently not supported. You can make the right table bounded "
+                        "by setting its source to be bounded."
+                    )
                 right_timestamp_field = right_table_descriptor.timestamp_field
                 if right_timestamp_field is None:
                     raise FeathubException(


### PR DESCRIPTION
## What is the purpose of the change

Currently, the boundedness of the left table and right table of JoinTransformation is checked when building the DerivedFeatureView.

The current implementation fails to raise an exception in the case of calling `to_pandas(force_bounded=True)` on a built unbounded left table that joins an unbounded right table. That's because, in the `to_pandas` method, we get a bounded feature view from the built unbounded table, and we don't check the bounded feature view and the unbounded right table to join.

More importantly, it exposes a processor-specific limitation to the DerivedFeatureView API.

Therefore, we move the boundedness check to FlinkTableBuilder in this PR.

## Brief change log

- Move the join transform boundedness check to FlinkTableBuilder

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable