### PR TITLE
SlidingFeatureView supports sliding window with different sizes

### DIFF
--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/AggregationFieldsDescriptor.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/AggregationFieldsDescriptor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.table.types.DataType;
+
+import com.alibaba.feathub.flink.udf.aggregation.AggFunc;
+import com.alibaba.feathub.flink.udf.aggregation.AggFuncUtils;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+/** The descriptor of aggregation fields in the window operator. */
+public class AggregationFieldsDescriptor implements Serializable {
+    private final List<AggregationFieldDescriptor> aggregationFieldDescriptors;
+
+    private AggregationFieldsDescriptor(
+            List<AggregationFieldDescriptor> aggregationFieldDescriptors) {
+        this.aggregationFieldDescriptors = aggregationFieldDescriptors;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public List<AggregationFieldDescriptor> getAggFieldDescriptors() {
+        return aggregationFieldDescriptors;
+    }
+
+    public long getMaxWindowSizeMs() {
+        return aggregationFieldDescriptors.stream()
+                .mapToLong(descriptor -> descriptor.windowSizeMs)
+                .max()
+                .orElseThrow(() -> new RuntimeException("Fail to get max window size."));
+    }
+
+    /** Builder for {@link AggregationFieldsDescriptor}. */
+    public static class Builder {
+        private final List<AggregationFieldDescriptor> aggregationFieldDescriptors;
+
+        private Builder() {
+            aggregationFieldDescriptors = new LinkedList<>();
+        }
+
+        public Builder addField(
+                String inFieldName,
+                DataType inDataType,
+                String outFieldNames,
+                DataType outDataType,
+                Long windowSizeMs,
+                String aggFunc) {
+            aggregationFieldDescriptors.add(
+                    new AggregationFieldDescriptor(
+                            inFieldName,
+                            inDataType,
+                            outFieldNames,
+                            outDataType,
+                            windowSizeMs,
+                            aggFunc));
+            return this;
+        }
+
+        public AggregationFieldsDescriptor build() {
+            return new AggregationFieldsDescriptor(aggregationFieldDescriptors);
+        }
+    }
+
+    /** The descriptor of an aggregation field. */
+    public static class AggregationFieldDescriptor implements Serializable {
+        public String inFieldName;
+        public String outFieldName;
+        public DataType outDataType;
+        public Long windowSizeMs;
+        public AggFunc<Object, ?> aggFunc;
+
+        @SuppressWarnings({"unchecked"})
+        public AggregationFieldDescriptor(
+                String inFieldName,
+                DataType inDataType,
+                String outFieldNames,
+                DataType outDataType,
+                Long windowSizeMs,
+                String aggFunc) {
+            this.inFieldName = inFieldName;
+            this.outFieldName = outFieldNames;
+            this.outDataType = outDataType;
+            this.windowSizeMs = windowSizeMs;
+            this.aggFunc = (AggFunc<Object, ?>) AggFuncUtils.getAggFunc(aggFunc, inDataType);
+        }
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
@@ -28,6 +28,9 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.types.Row;
 
+import com.alibaba.feathub.flink.udf.processfunction.PostSlidingWindowDefaultRowExpiredRowHandler;
+import com.alibaba.feathub.flink.udf.processfunction.PostSlidingWindowKeyedProcessFunction;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/PostSlidingWindowUtils.java
@@ -165,9 +165,11 @@ public class PostSlidingWindowUtils {
             builder.primaryKey(keyFieldNames);
         }
 
-        // Records are ordered by row time after sliding window.
+        // Records are ordered by row time after sliding window. We need to generate watermark as
+        // row timestamp - 1 ms to account for row with the same timestamp.
         builder.watermark(
-                rowTimeFieldName, String.format("`%s` - INTERVAL '0' SECONDS", rowTimeFieldName));
+                rowTimeFieldName,
+                String.format("`%s` - INTERVAL '0.001' SECONDS", rowTimeFieldName));
         return builder.build();
     }
 

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/SlidingWindowUtils.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/SlidingWindowUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import com.alibaba.feathub.flink.udf.processfunction.SlidingWindowKeyedProcessFunction;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Utility methods to apply sliding windows. */
+public class SlidingWindowUtils {
+
+    /**
+     * Apply sliding window with the given step size to the given {@link Table} and {@link
+     * AggregationFieldsDescriptor}. The {@link AggregationFieldsDescriptor} describes how to
+     * compute each field. It includes the field name and data type of the input and output, the
+     * size of the sliding window under which the aggregation performs, and the aggregation
+     * function, e.g. SUM, AVG, etc.
+     *
+     * <p>The {@link SlidingWindowKeyedProcessFunction} is optimized to reduce the state usage when
+     * computing aggregations under different sliding window sizes.
+     *
+     * @param tEnv The StreamTableEnvironment of the table.
+     * @param table The input table.
+     * @param keyFieldNames The names of the group by keys for the sliding window.
+     * @param rowTimeFieldName The name of the row time field.
+     * @param stepSizeMs The step size of the sliding window in milliseconds.
+     * @param aggregationFieldsDescriptor The descriptor of the aggregation field in the sliding
+     *     window.
+     */
+    public static Table applySlidingWindowKeyedProcessFunction(
+            StreamTableEnvironment tEnv,
+            Table table,
+            String[] keyFieldNames,
+            String rowTimeFieldName,
+            long stepSizeMs,
+            AggregationFieldsDescriptor aggregationFieldsDescriptor) {
+        final ResolvedSchema resolvedSchema = table.getResolvedSchema();
+        DataStream<Row> rowDataStream =
+                tEnv.toChangelogStream(
+                        table,
+                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
+                        ChangelogMode.all());
+
+        final TypeSerializer<Row> rowTypeSerializer =
+                ExternalTypeInfo.<Row>of(resolvedSchema.toPhysicalRowDataType())
+                        .createSerializer(null);
+        rowDataStream =
+                rowDataStream
+                        .keyBy(
+                                (KeySelector<Row, Row>)
+                                        value ->
+                                                Row.of(
+                                                        Arrays.stream(keyFieldNames)
+                                                                .map(value::getField)
+                                                                .toArray()))
+                        .process(
+                                new SlidingWindowKeyedProcessFunction(
+                                        aggregationFieldsDescriptor,
+                                        rowTypeSerializer,
+                                        rowTimeFieldName,
+                                        stepSizeMs))
+                        .returns(
+                                ExternalTypeInfo.of(
+                                        DataTypes.ROW(
+                                                getTableFields(
+                                                        keyFieldNames,
+                                                        rowTimeFieldName,
+                                                        aggregationFieldsDescriptor,
+                                                        resolvedSchema))));
+
+        table =
+                tEnv.fromDataStream(
+                        rowDataStream,
+                        getResultTableSchema(
+                                resolvedSchema,
+                                aggregationFieldsDescriptor,
+                                rowTimeFieldName,
+                                keyFieldNames));
+        for (AggregationFieldsDescriptor.AggregationFieldDescriptor aggregationFieldDescriptor :
+                aggregationFieldsDescriptor.getAggFieldDescriptors()) {
+            table =
+                    table.addOrReplaceColumns(
+                            $(aggregationFieldDescriptor.outFieldName)
+                                    .cast(aggregationFieldDescriptor.outDataType)
+                                    .as(aggregationFieldDescriptor.outFieldName));
+        }
+        return table;
+    }
+
+    private static List<DataTypes.Field> getTableFields(
+            String[] keyFieldNames,
+            String rowTimeFieldName,
+            AggregationFieldsDescriptor aggregationFieldsDescriptor,
+            ResolvedSchema resolvedSchema) {
+        List<DataTypes.Field> keyFields =
+                Arrays.stream(keyFieldNames)
+                        .map(
+                                fieldName ->
+                                        DataTypes.FIELD(
+                                                fieldName, getDataType(resolvedSchema, fieldName)))
+                        .collect(Collectors.toList());
+        List<DataTypes.Field> aggFieldDataTypes =
+                aggregationFieldsDescriptor.getAggFieldDescriptors().stream()
+                        .map(d -> DataTypes.FIELD(d.outFieldName, d.aggFunc.getResultDatatype()))
+                        .collect(Collectors.toList());
+        final List<DataTypes.Field> fields = new LinkedList<>();
+        fields.addAll(keyFields);
+        fields.addAll(aggFieldDataTypes);
+        fields.add(
+                DataTypes.FIELD(rowTimeFieldName, getDataType(resolvedSchema, rowTimeFieldName)));
+        return fields;
+    }
+
+    private static DataType getDataType(ResolvedSchema resolvedSchema, String fieldName) {
+        return resolvedSchema
+                .getColumn(fieldName)
+                .orElseThrow(
+                        () ->
+                                new RuntimeException(
+                                        String.format("Cannot find column %s.", fieldName)))
+                .getDataType();
+    }
+
+    private static Schema getResultTableSchema(
+            ResolvedSchema resolvedSchema,
+            AggregationFieldsDescriptor descriptor,
+            String rowTimeFieldName,
+            String[] keyFieldNames) {
+        final Schema.Builder builder = Schema.newBuilder();
+
+        for (String keyFieldName : keyFieldNames) {
+            builder.column(keyFieldName, getDataType(resolvedSchema, keyFieldName).notNull());
+        }
+
+        if (keyFieldNames.length > 0) {
+            builder.primaryKey(keyFieldNames);
+        }
+
+        for (AggregationFieldsDescriptor.AggregationFieldDescriptor aggregationFieldDescriptor :
+                descriptor.getAggFieldDescriptors()) {
+            builder.column(
+                    aggregationFieldDescriptor.outFieldName,
+                    aggregationFieldDescriptor.aggFunc.getResultDatatype());
+        }
+
+        builder.column(rowTimeFieldName, getDataType(resolvedSchema, rowTimeFieldName));
+
+        // Records are ordered by row time after sliding window.
+        builder.watermark(
+                rowTimeFieldName,
+                String.format("`%s` - INTERVAL '0.001' SECONDS", rowTimeFieldName));
+        return builder.build();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFunc.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+import java.io.Serializable;
+
+// TODO: Update AbstractTimeWindowedAggFunc to reuse the implementations of AggFunc.
+/**
+ * Interface of aggregation function. The aggregation function can aggregate any number of records
+ * with its timestamp and get the aggregation result. It also has a reset method to reset the
+ * aggregation function to its initial state.
+ */
+public interface AggFunc<IN_T, OUT_T> extends Serializable {
+
+    /** Reset the aggregation function. */
+    void reset();
+
+    /**
+     * Aggregate the value with the timestamp.
+     *
+     * @param value The value.
+     * @param timestamp The timestamp of the value.
+     */
+    void aggregate(IN_T value, long timestamp);
+
+    /** @return The aggregation result. */
+    OUT_T getResult();
+
+    /** @return The DataType of the aggregation result. */
+    DataType getResultDatatype();
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFuncUtils.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFuncUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+/** Utility of aggregation functions. */
+public class AggFuncUtils {
+    public static AggFunc<?, ?> getAggFunc(String aggFunc, DataType inDataType) {
+        if ("SUM".equals(aggFunc)) {
+            return getSumAggFunc(inDataType);
+        } else if ("AVG".equals(aggFunc)) {
+            return new RowAvgAggFunc(inDataType);
+        } else if ("FIRST_VALUE".equals(aggFunc)) {
+            return new FirstValueAggFunc<>(inDataType);
+        } else if ("LAST_VALUE".equals(aggFunc)) {
+            return new LastValueAggFunc<>(inDataType);
+        } else if ("MAX".equals(aggFunc)) {
+            return new MaxAggFunc<>(inDataType);
+        } else if ("MIN".equals(aggFunc)) {
+            return new MinAggFunc<>(inDataType);
+        } else if ("COUNT".equals(aggFunc) || "ROW_NUMBER".equals(aggFunc)) {
+            return new CountAggFunc();
+        } else if ("VALUE_COUNTS".equals(aggFunc)) {
+            return new MergeValueCountsAggFunc(inDataType);
+        }
+
+        throw new RuntimeException(String.format("Unsupported aggregation function %s", aggFunc));
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private static <IN_T> SumAggFunc<IN_T> getSumAggFunc(DataType inDataType) {
+        final Class<?> inClass = inDataType.getConversionClass();
+        if (inClass.equals(Integer.class)) {
+            return (SumAggFunc<IN_T>) new SumAggFunc.IntSumAggFunc();
+        } else if (inClass.equals(Long.class)) {
+            return (SumAggFunc<IN_T>) new SumAggFunc.LongSumAggFunc();
+        } else if (inClass.equals(Float.class)) {
+            return (SumAggFunc<IN_T>) new SumAggFunc.FloatSumAggFunc();
+        } else if (inClass.equals(Double.class)) {
+            return (SumAggFunc<IN_T>) new SumAggFunc.DoubleSumAggFunc();
+        }
+        throw new RuntimeException(
+                String.format("Unsupported type for AvgAggregationFunction %s.", inDataType));
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/CountAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/CountAggFunc.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation function that counts the number of values. */
+public class CountAggFunc implements AggFunc<Object, Long> {
+    private long cnt = 0;
+
+    @Override
+    public void reset() {
+        cnt = 0;
+    }
+
+    @Override
+    public void aggregate(Object value, long timestamp) {
+        cnt += 1;
+    }
+
+    @Override
+    public Long getResult() {
+        return cnt;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return DataTypes.BIGINT();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/FirstValueAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/FirstValueAggFunc.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation function that gets the first value. */
+public class FirstValueAggFunc<T> implements AggFunc<T, T> {
+
+    private final DataType inDataType;
+    private T firstValue = null;
+    private long minTimestamp = Long.MAX_VALUE;
+
+    public FirstValueAggFunc(DataType inDataType) {
+        this.inDataType = inDataType;
+    }
+
+    @Override
+    public void reset() {
+        firstValue = null;
+        minTimestamp = Long.MAX_VALUE;
+    }
+
+    @Override
+    public void aggregate(T value, long timestamp) {
+        if (timestamp >= minTimestamp) {
+            return;
+        }
+        firstValue = value;
+        minTimestamp = timestamp;
+    }
+
+    @Override
+    public T getResult() {
+        return firstValue;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return inDataType;
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/LastValueAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/LastValueAggFunc.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation function that gets the last value. */
+public class LastValueAggFunc<T> implements AggFunc<T, T> {
+    private final DataType inDataType;
+    private T lastValue = null;
+    private long maxTimestamp = Long.MIN_VALUE;
+
+    public LastValueAggFunc(DataType inDataType) {
+        this.inDataType = inDataType;
+    }
+
+    @Override
+    public void reset() {
+        lastValue = null;
+        maxTimestamp = Long.MIN_VALUE;
+    }
+
+    @Override
+    public void aggregate(T value, long timestamp) {
+        if (timestamp < maxTimestamp) {
+            return;
+        }
+        lastValue = value;
+        maxTimestamp = timestamp;
+    }
+
+    @Override
+    public T getResult() {
+        return lastValue;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return inDataType;
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MaxAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MaxAggFunc.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation function that gets the maximum value. */
+public class MaxAggFunc<T extends Comparable<T>> implements AggFunc<T, T> {
+    private final DataType inDataType;
+    private T maxValue = null;
+
+    public MaxAggFunc(DataType inDataType) {
+        this.inDataType = inDataType;
+    }
+
+    @Override
+    public void reset() {
+        maxValue = null;
+    }
+
+    @Override
+    public void aggregate(T value, long timestamp) {
+        if (maxValue == null) {
+            maxValue = value;
+            return;
+        }
+        maxValue = maxValue.compareTo(value) < 0 ? value : maxValue;
+    }
+
+    @Override
+    public T getResult() {
+        return maxValue;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return inDataType;
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MergeValueCountsAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MergeValueCountsAggFunc.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Aggregate function that merge value counts. */
+public class MergeValueCountsAggFunc implements AggFunc<Map<Object, Long>, Map<Object, Long>> {
+    private final Map<Object, Long> valueCounts = new HashMap<>();
+    private final DataType inDataType;
+
+    public MergeValueCountsAggFunc(DataType inDataType) {
+        this.inDataType = inDataType;
+    }
+
+    @Override
+    public void reset() {
+        valueCounts.clear();
+    }
+
+    @Override
+    public void aggregate(Map<Object, Long> value, long timestamp) {
+        for (Map.Entry<Object, Long> entry : value.entrySet()) {
+            final Object key = entry.getKey();
+            valueCounts.put(key, valueCounts.getOrDefault(key, 0L) + entry.getValue());
+        }
+    }
+
+    @Override
+    public Map<Object, Long> getResult() {
+        if (valueCounts.isEmpty()) {
+            return null;
+        }
+        return valueCounts;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return inDataType;
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MinAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/MinAggFunc.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation function that gets the minimum value. */
+public class MinAggFunc<T extends Comparable<T>> implements AggFunc<T, T> {
+    private final DataType inDataType;
+    private T minValue = null;
+
+    public MinAggFunc(DataType inDataType) {
+        this.inDataType = inDataType;
+    }
+
+    @Override
+    public void reset() {
+        minValue = null;
+    }
+
+    @Override
+    public void aggregate(T value, long timestamp) {
+        if (minValue == null) {
+            minValue = value;
+            return;
+        }
+        minValue = minValue.compareTo(value) >= 0 ? value : minValue;
+    }
+
+    @Override
+    public T getResult() {
+        return minValue;
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return inDataType;
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/RowAvgAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/RowAvgAggFunc.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.Row;
+
+import java.util.List;
+
+/** Aggregation function that calculates the average of rows with sum and count. */
+public class RowAvgAggFunc implements AggFunc<Row, Double> {
+
+    private final DataType valueType;
+    Row avgRow = null;
+
+    public RowAvgAggFunc(DataType valueType) {
+        final List<DataType> childrenType = valueType.getChildren();
+        if (childrenType.size() != 2
+                || (!childrenType
+                        .get(1)
+                        .getLogicalType()
+                        .getTypeRoot()
+                        .equals(LogicalTypeRoot.BIGINT))) {
+            throw new RuntimeException(
+                    "RowAvgAggregationFunction expect Row with two fields and the second fields has to be BIGINT.");
+        }
+        this.valueType = childrenType.get(0);
+    }
+
+    @Override
+    public void reset() {
+        avgRow = null;
+    }
+
+    @Override
+    public void aggregate(Row value, long timestamp) {
+        if (avgRow == null) {
+            avgRow = value;
+            return;
+        }
+
+        mergeRow(value);
+    }
+
+    private void mergeRow(Row value) {
+        Object sum1 = avgRow.getField(0);
+        Object sum2 = value.getField(0);
+        Long cnt1 = avgRow.getFieldAs(1);
+        Long cnt2 = value.getFieldAs(1);
+
+        if (sum1 == null || sum2 == null || cnt1 == null || cnt2 == null) {
+            throw new RuntimeException("sum and count cannot be null.");
+        }
+
+        if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.INTEGER)) {
+            avgRow = Row.of((Integer) sum1 + (Integer) sum2, cnt1 + cnt2);
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.BIGINT)) {
+            avgRow = Row.of((Long) sum1 + (Long) sum2, cnt1 + cnt2);
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.FLOAT)) {
+            avgRow = Row.of((Float) sum1 + (Float) sum2, cnt1 + cnt2);
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.DOUBLE)) {
+            avgRow = Row.of((Double) sum1 + (Double) sum2, cnt1 + cnt2);
+        } else {
+            throw new RuntimeException(
+                    String.format("Unsupported type for AvgAggregationFunction %s.", valueType));
+        }
+    }
+
+    @Override
+    public Double getResult() {
+        if (avgRow == null) {
+            return null;
+        }
+        Object sum = avgRow.getField(0);
+        Long cnt = avgRow.getFieldAs(1);
+
+        if (sum == null || cnt == null) {
+            throw new RuntimeException("sum and count cannot be null.");
+        }
+
+        if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.INTEGER)) {
+            return ((Integer) sum) * 1.0 / cnt;
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.BIGINT)) {
+            return ((Long) sum) * 1.0 / cnt;
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.FLOAT)) {
+            return (double) (((Float) sum) / cnt);
+        } else if (valueType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.DOUBLE)) {
+            return ((Double) sum) / cnt;
+        } else {
+            throw new RuntimeException(
+                    String.format("Unsupported type for AvgAggregationFunction %s.", valueType));
+        }
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return DataTypes.DOUBLE();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/SumAggFunc.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/SumAggFunc.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+
+/** Aggregation functions that calculates the sum of values. */
+public abstract class SumAggFunc<IN_T> implements AggFunc<IN_T, IN_T> {
+
+    /** Aggregation functions that calculates the sum of Integer values. */
+    public static class IntSumAggFunc extends SumAggFunc<Integer> {
+        private int agg = 0;
+
+        @Override
+        public void reset() {
+            agg = 0;
+        }
+
+        @Override
+        public void aggregate(Integer value, long timestamp) {
+            agg += value;
+        }
+
+        @Override
+        public Integer getResult() {
+            return agg;
+        }
+
+        @Override
+        public DataType getResultDatatype() {
+            return DataTypes.INT();
+        }
+    }
+
+    /** Aggregation functions that calculates the sum of Long values. */
+    public static class LongSumAggFunc extends SumAggFunc<Long> {
+        private long agg = 0;
+
+        @Override
+        public void reset() {
+            agg = 0;
+        }
+
+        @Override
+        public void aggregate(Long value, long timestamp) {
+            agg += value;
+        }
+
+        @Override
+        public Long getResult() {
+            return agg;
+        }
+
+        @Override
+        public DataType getResultDatatype() {
+            return DataTypes.BIGINT();
+        }
+    }
+
+    /** Aggregation functions that calculates the sum of Float values. */
+    public static class FloatSumAggFunc extends SumAggFunc<Float> {
+        private float agg = 0.0f;
+
+        @Override
+        public void reset() {
+            agg = 0;
+        }
+
+        @Override
+        public void aggregate(Float value, long timestamp) {
+            agg += value;
+        }
+
+        @Override
+        public Float getResult() {
+            return agg;
+        }
+
+        @Override
+        public DataType getResultDatatype() {
+            return DataTypes.FLOAT();
+        }
+    }
+
+    /** Aggregation functions that calculates the sum of Double values. */
+    public static class DoubleSumAggFunc extends SumAggFunc<Double> {
+        private double agg = 0.0;
+
+        @Override
+        public void reset() {
+            agg = 0;
+        }
+
+        @Override
+        public void aggregate(Double value, long timestamp) {
+            agg += value;
+        }
+
+        @Override
+        public Double getResult() {
+            return agg;
+        }
+
+        @Override
+        public DataType getResultDatatype() {
+            return DataTypes.DOUBLE();
+        }
+    }
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowDefaultRowExpiredRowHandler.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowDefaultRowExpiredRowHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.feathub.flink.udf;
+package com.alibaba.feathub.flink.udf.processfunction;
 
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Collector;

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowExpiredRowHandler.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowExpiredRowHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.processfunction;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+/** Interface for handling post sliding window expired row. */
+// TODO: Implement a PostSlidingWindowExpiredRowHandler that retract the expired row.
+public interface PostSlidingWindowExpiredRowHandler extends Serializable {
+    void handleExpiredRow(Collector<Row> out, Row expiredRow, long currentTimestamp);
+}

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowKeyedProcessFunction.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowKeyedProcessFunction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.feathub.flink.udf;
+package com.alibaba.feathub.flink.udf.processfunction;
 
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunction.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunction.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.processfunction;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Collector;
+
+import com.alibaba.feathub.flink.udf.AggregationFieldsDescriptor;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * A KeyedProcessFunction that aggregate sliding windows with different sizes. The ProcessFunction
+ * should be applied after the input has been aggregated with a tumble window with size equals to
+ * the step size of sliding window.
+ *
+ * <p>One native Flink sliding window operator can only aggregate under one sliding window size. If
+ * we need aggregation under different window sizes, we need to apply multiple native Flink window
+ * operators with different sizes and join the results together. Each window operator keeps the rows
+ * for its window size. This will result in a lots of duplicates row in the state backend. For
+ * example, if we want to do aggregation under 1 hour and 2 hours, both sliding window will keep the
+ * rows in the last one hour, which are duplicated. With this process function, we only keep the
+ * rows for the maximum window size so that we can avoid duplicated rows in state backend.
+ *
+ * <p>The ProcessFunction assumes that: 1. rows of each key are ordered by the row time 2. row time
+ * attribute of rows with the same key are all distinct. The assumptions hold true after applying
+ * the tumbling window aggregation to the input with window size that is same as the step size of
+ * the {@link SlidingWindowKeyedProcessFunction} to be applied.
+ */
+public class SlidingWindowKeyedProcessFunction extends KeyedProcessFunction<Row, Row, Row> {
+
+    private final AggregationFieldsDescriptor aggregationFieldsDescriptor;
+    private final TypeSerializer<Row> rowTypeSerializer;
+    private final String rowTimeFieldName;
+    private final long stepSizeMs;
+    private MultiWindowSizeState state;
+
+    public SlidingWindowKeyedProcessFunction(
+            AggregationFieldsDescriptor aggregationFieldsDescriptor,
+            TypeSerializer<Row> rowTypeSerializer,
+            String rowTimeFieldName,
+            long stepSizeMs) {
+        this.aggregationFieldsDescriptor = aggregationFieldsDescriptor;
+        this.rowTypeSerializer = rowTypeSerializer;
+        this.rowTimeFieldName = rowTimeFieldName;
+        this.stepSizeMs = stepSizeMs;
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        state = MultiWindowSizeState.create(getRuntimeContext(), rowTypeSerializer);
+    }
+
+    @Override
+    public void processElement(
+            Row row, KeyedProcessFunction<Row, Row, Row>.Context ctx, Collector<Row> out)
+            throws Exception {
+        final long rowTime = ((Instant) row.getFieldAs(rowTimeFieldName)).toEpochMilli();
+        long triggerTime = rowTime;
+        while (triggerTime <= rowTime + aggregationFieldsDescriptor.getMaxWindowSizeMs()) {
+            ctx.timerService().registerEventTimeTimer(triggerTime);
+            triggerTime += stepSizeMs;
+        }
+        state.addRow(ctx.getCurrentKey(), rowTime, row);
+    }
+
+    @Override
+    public void onTimer(
+            long timestamp,
+            KeyedProcessFunction<Row, Row, Row>.OnTimerContext ctx,
+            Collector<Row> out)
+            throws Exception {
+        aggregationFieldsDescriptor.getAggFieldDescriptors().forEach(d -> d.aggFunc.reset());
+
+        boolean hasRow = false;
+
+        for (long rowTime : state.keyToTimestamps.get(ctx.getCurrentKey())) {
+            if (rowTime > timestamp) {
+                break;
+            }
+            Row curRow = state.timestampToRow.get(rowTime);
+
+            // TODO: Optimize by supporting retract value from aggregation function.
+            for (AggregationFieldsDescriptor.AggregationFieldDescriptor descriptor :
+                    aggregationFieldsDescriptor.getAggFieldDescriptors()) {
+                if (timestamp - descriptor.windowSizeMs >= rowTime) {
+                    continue;
+                }
+                descriptor.aggFunc.aggregate(curRow.getField(descriptor.inFieldName), rowTime);
+                hasRow = true;
+            }
+        }
+
+        state.pruneRow(
+                ctx.getCurrentKey(), timestamp - aggregationFieldsDescriptor.getMaxWindowSizeMs());
+
+        if (!hasRow) {
+            // output nothing if no row is aggregated.
+            return;
+        }
+
+        final Row aggResultRow =
+                Row.of(
+                        aggregationFieldsDescriptor.getAggFieldDescriptors().stream()
+                                .map(d -> d.aggFunc.getResult())
+                                .toArray());
+
+        out.collect(
+                Row.join(
+                        ctx.getCurrentKey(),
+                        aggResultRow,
+                        Row.of(Instant.ofEpochMilli(timestamp))));
+    }
+
+    /** The state of {@link SlidingWindowKeyedProcessFunction}. */
+    private static class MultiWindowSizeState {
+        private final MapState<Long, Row> timestampToRow;
+
+        // One KeyedProcessFunction can process rows from different keys. Unlike KeyedState, which
+        // is already scoped by key by Flink, we need to have a map that store the timestamp list
+        // for each key.
+        private final Map<Row, LinkedList<Long>> keyToTimestamps;
+
+        private MultiWindowSizeState(MapState<Long, Row> mapState) {
+            this.timestampToRow = mapState;
+            this.keyToTimestamps = new HashMap<>();
+        }
+
+        public static MultiWindowSizeState create(
+                RuntimeContext context, TypeSerializer<Row> rowTypeSerializer) {
+            final MapState<Long, Row> mapState =
+                    context.getMapState(
+                            new MapStateDescriptor<>(
+                                    "RowState", LongSerializer.INSTANCE, rowTypeSerializer));
+
+            return new MultiWindowSizeState(mapState);
+        }
+
+        public void addRow(Row key, long timestamp, Row row) throws Exception {
+            LinkedList<Long> orderedTimestamp = keyToTimestamps.get(key);
+            if (orderedTimestamp == null) {
+                // Construct the timestamp list from the key of timestampToRow map state in case of
+                // failure recovery.
+                orderedTimestamp = new LinkedList<>();
+                CollectionUtil.iterableToList(timestampToRow.keys()).stream()
+                        .sorted()
+                        .forEach(orderedTimestamp::add);
+            }
+            timestampToRow.put(timestamp, row);
+            orderedTimestamp.addLast(timestamp);
+            keyToTimestamps.put(key, orderedTimestamp);
+        }
+
+        public void pruneRow(Row key, long lowerBound) throws Exception {
+            LinkedList<Long> orderedTimestamp = keyToTimestamps.get(key);
+            if (orderedTimestamp == null) {
+                return;
+            }
+            final Iterator<Long> iterator = orderedTimestamp.iterator();
+            while (iterator.hasNext()) {
+                final long cur = iterator.next();
+                if (cur > lowerBound) {
+                    break;
+                }
+                timestampToRow.remove(cur);
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/CountAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/CountAggFuncTest.java
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 
-package com.alibaba.feathub.flink.udf;
+package com.alibaba.feathub.flink.udf.aggregation;
 
-import org.apache.flink.types.Row;
-import org.apache.flink.util.Collector;
+import org.junit.jupiter.api.Test;
 
-import java.io.Serializable;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/** Interface for handling post sliding window expired row. */
-// TODO: Implement a PostSlidingWindowExpiredRowHandler that retract the expired row.
-public interface PostSlidingWindowExpiredRowHandler extends Serializable {
-    void handleExpiredRow(Collector<Row> out, Row expiredRow, long currentTimestamp);
+/** Test for {@link CountAggFunc}. */
+class CountAggFuncTest {
+    @Test
+    void testCountAggregationFunction() {
+        final CountAggFunc aggFunc = new CountAggFunc();
+        assertThat(aggFunc.getResult()).isEqualTo(0);
+        aggFunc.aggregate(0, 0);
+        aggFunc.aggregate(0, 0);
+        assertThat(aggFunc.getResult()).isEqualTo(2);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isEqualTo(0);
+    }
 }

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/FirstValueAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/FirstValueAggFuncTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link FirstValueAggFunc}. */
+class FirstValueAggFuncTest {
+    @Test
+    void tesFirstValueAggregationFunction() {
+        final FirstValueAggFunc<Integer> aggFunc = new FirstValueAggFunc<>(DataTypes.INT());
+        assertThat(aggFunc.getResult()).isNull();
+        aggFunc.aggregate(1, 1);
+        aggFunc.aggregate(2, 2);
+        aggFunc.aggregate(0, 0);
+        aggFunc.aggregate(3, 3);
+        assertThat(aggFunc.getResult()).isEqualTo(0);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isNull();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/LastValueAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/LastValueAggFuncTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link LastValueAggFunc}. */
+class LastValueAggFuncTest {
+    @Test
+    void testLastValueAggregationFunction() {
+        final LastValueAggFunc<Integer> aggFunc = new LastValueAggFunc<>(DataTypes.INT());
+        assertThat(aggFunc.getResult()).isNull();
+        aggFunc.aggregate(1, 1);
+        aggFunc.aggregate(2, 2);
+        aggFunc.aggregate(0, 0);
+        aggFunc.aggregate(3, 3);
+        assertThat(aggFunc.getResult()).isEqualTo(3);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isNull();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MaxAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MaxAggFuncTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MaxAggFunc}. */
+class MaxAggFuncTest {
+    @Test
+    void testMaxAggregationFunction() {
+        final MaxAggFunc<Integer> aggFunc = new MaxAggFunc<>(DataTypes.INT());
+        assertThat(aggFunc.getResult()).isNull();
+        aggFunc.aggregate(1, 0);
+        aggFunc.aggregate(3, 0);
+        aggFunc.aggregate(0, 0);
+        aggFunc.aggregate(4, 0);
+        assertThat(aggFunc.getResult()).isEqualTo(4);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isNull();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MergeValueCountsAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MergeValueCountsAggFuncTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MergeValueCountsAggFunc}. */
+class MergeValueCountsAggFuncTest {
+    @Test
+    void testMergeValueCountsAggregationFunction() {
+        final MergeValueCountsAggFunc aggFunc =
+                new MergeValueCountsAggFunc(DataTypes.MAP(DataTypes.STRING(), DataTypes.BIGINT()));
+        assertThat(aggFunc.getResult()).isNull();
+        aggFunc.aggregate(Collections.singletonMap("a", 1L), 0);
+        aggFunc.aggregate(Collections.singletonMap("a", 1L), 0);
+        aggFunc.aggregate(Collections.singletonMap("b", 1L), 0);
+        Map<Object, Long> expectedResult = new HashMap<>();
+        expectedResult.put("a", 2L);
+        expectedResult.put("b", 1L);
+        assertThat(aggFunc.getResult()).isEqualTo(expectedResult);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isNull();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MinAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/MinAggFuncTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MinAggFunc}. */
+class MinAggFuncTest {
+    @Test
+    void testMinAggregationFunction() {
+        final MinAggFunc<Integer> aggFunc = new MinAggFunc<>(DataTypes.INT());
+        assertThat(aggFunc.getResult()).isNull();
+        aggFunc.aggregate(1, 0);
+        aggFunc.aggregate(3, 0);
+        aggFunc.aggregate(0, 0);
+        aggFunc.aggregate(4, 0);
+        assertThat(aggFunc.getResult()).isEqualTo(0);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isNull();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/RowAvgAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/RowAvgAggFuncTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.types.Row;
+
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RowAvgAggFunc}. */
+class RowAvgAggFuncTest {
+
+    @Test
+    void testAvgAggregationFunctions() {
+        innerTest(
+                Arrays.array(1, 2, 3, 4),
+                2.5,
+                new RowAvgAggFunc(DataTypes.ROW(DataTypes.INT(), DataTypes.BIGINT())));
+        innerTest(
+                Arrays.array(1L, 2L, 3L),
+                2.0,
+                new RowAvgAggFunc(DataTypes.ROW(DataTypes.BIGINT(), DataTypes.BIGINT())));
+        innerTest(
+                Arrays.array(1.0f, 2.0f, 3.0f),
+                2.0,
+                new RowAvgAggFunc(DataTypes.ROW(DataTypes.FLOAT(), DataTypes.BIGINT())));
+        innerTest(
+                Arrays.array(1.0, 2.0, 3.0),
+                2.0,
+                new RowAvgAggFunc(DataTypes.ROW(DataTypes.DOUBLE(), DataTypes.BIGINT())));
+    }
+
+    private void innerTest(Object[] inputs, Double expectedResult, RowAvgAggFunc aggFunc) {
+        assertThat(aggFunc.getResult()).isEqualTo(null);
+        for (Object input : inputs) {
+            aggFunc.aggregate(Row.of(input, 1L), 0);
+        }
+        assertThat(aggFunc.getResult()).isEqualTo(expectedResult);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isEqualTo(null);
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/SumAggFuncTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/aggregation/SumAggFuncTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SumAggFunc}. */
+class SumAggFuncTest {
+
+    @Test
+    void testSumAggregationFunctions() {
+        innerTest(Arrays.array(1, 2, 3), 6, 0, new SumAggFunc.IntSumAggFunc());
+        innerTest(Arrays.array(1L, 2L, 3L), 6L, 0L, new SumAggFunc.LongSumAggFunc());
+        innerTest(Arrays.array(1.0f, 2.0f, 3.0f), 6.0f, 0.0f, new SumAggFunc.FloatSumAggFunc());
+        innerTest(Arrays.array(1.0, 2.0, 3.0), 6.0, 0.0, new SumAggFunc.DoubleSumAggFunc());
+    }
+
+    private <T> void innerTest(
+            T[] inputs, T expectedResult, T expectedInitRes, SumAggFunc<T> aggFunc) {
+        assertThat(aggFunc.getResult()).isEqualTo(expectedInitRes);
+        for (T input : inputs) {
+            aggFunc.aggregate(input, 0);
+        }
+        assertThat(aggFunc.getResult()).isEqualTo(expectedResult);
+        aggFunc.reset();
+        assertThat(aggFunc.getResult()).isEqualTo(expectedInitRes);
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowKeyedProcessFunctionTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/PostSlidingWindowKeyedProcessFunctionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.feathub.flink.udf;
+package com.alibaba.feathub.flink.udf.processfunction;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunctionTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunctionTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 The Feathub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.processfunction;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Expressions;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import com.alibaba.feathub.flink.udf.AggregationFieldsDescriptor;
+import com.alibaba.feathub.flink.udf.SlidingWindowUtils;
+import com.alibaba.feathub.flink.udf.ValueCountsAggFunc;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SlidingWindowKeyedProcessFunction}. */
+public class SlidingWindowKeyedProcessFunctionTest {
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+
+    @BeforeEach
+    void setUp() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+        final DataStream<Row> data =
+                env.fromElements(
+                        Row.of(0, 1L, Instant.ofEpochMilli(0)),
+                        Row.of(1, 2L, Instant.ofEpochMilli(600)),
+                        Row.of(1, 3L, Instant.ofEpochMilli(1100)),
+                        Row.of(0, 4L, Instant.ofEpochMilli(5000)),
+                        Row.of(0, 3L, Instant.ofEpochMilli(4000)),
+                        Row.of(0, 5L, Instant.ofEpochMilli(6000)));
+        inputTable =
+                tEnv.fromDataStream(
+                                data,
+                                Schema.newBuilder()
+                                        .column("f0", DataTypes.INT())
+                                        .column("f1", DataTypes.BIGINT())
+                                        .column("f2", DataTypes.TIMESTAMP_LTZ(3))
+                                        .watermark("f2", "f2 - INTERVAL '2' SECOND")
+                                        .build())
+                        .as("id", "val", "ts");
+    }
+
+    @Test
+    void testMultiSlidingWindowSizeProcessFunction() {
+        tEnv.createTemporaryView("input_table", inputTable);
+
+        Table table =
+                tEnv.sqlQuery(
+                        "SELECT * FROM TABLE("
+                                + "   HOP("
+                                + "       DATA => TABLE input_table,"
+                                + "       TIMECOL => DESCRIPTOR(ts),"
+                                + "       SLIDE => INTERVAL '1' SECOND,"
+                                + "       SIZE => INTERVAL '1' SECOND))");
+
+        table =
+                table.groupBy($("id"), $("window_start"), $("window_end"), $("window_time"))
+                        .select(
+                                $("id"),
+                                $("val").sum().as("val_sum"),
+                                Expressions.row($("val").sum(), $("val").count()).as("val_avg"),
+                                Expressions.call(ValueCountsAggFunc.class, $("val"))
+                                        .as("val_value_counts"),
+                                $("window_time"));
+
+        table =
+                SlidingWindowUtils.applySlidingWindowKeyedProcessFunction(
+                        tEnv,
+                        table,
+                        Arrays.array("id"),
+                        "window_time",
+                        1000L,
+                        AggregationFieldsDescriptor.builder()
+                                .addField(
+                                        "val_sum",
+                                        DataTypes.BIGINT(),
+                                        "val_sum_1",
+                                        DataTypes.BIGINT(),
+                                        1000L,
+                                        "SUM")
+                                .addField(
+                                        "val_sum",
+                                        DataTypes.BIGINT(),
+                                        "val_sum_2",
+                                        DataTypes.BIGINT(),
+                                        2000L,
+                                        "SUM")
+                                .addField(
+                                        "val_avg",
+                                        table.getResolvedSchema()
+                                                .getColumn("val_avg")
+                                                .orElseThrow(RuntimeException::new)
+                                                .getDataType(),
+                                        "val_avg_1",
+                                        DataTypes.FLOAT(),
+                                        1000L,
+                                        "AVG")
+                                .addField(
+                                        "val_avg",
+                                        table.getResolvedSchema()
+                                                .getColumn("val_avg")
+                                                .orElseThrow(RuntimeException::new)
+                                                .getDataType(),
+                                        "val_avg_2",
+                                        DataTypes.DOUBLE(),
+                                        2000L,
+                                        "AVG")
+                                .addField(
+                                        "val_value_counts",
+                                        DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
+                                        "val_value_counts_2",
+                                        DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
+                                        2000L,
+                                        "VALUE_COUNTS")
+                                .build());
+
+        List<Row> expected =
+                java.util.Arrays.asList(
+                        Row.of(
+                                1,
+                                2L,
+                                2L,
+                                2.0f,
+                                2.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(2L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(999)),
+                        Row.of(
+                                1,
+                                3L,
+                                5L,
+                                3.0f,
+                                2.5,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(2L, 1L);
+                                        put(3L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(1999)),
+                        Row.of(
+                                1,
+                                0L,
+                                3L,
+                                null,
+                                3.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(3L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(2999)),
+                        Row.of(
+                                0,
+                                1L,
+                                1L,
+                                1.0f,
+                                1.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(1L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(999)),
+                        Row.of(
+                                0,
+                                0L,
+                                1L,
+                                null,
+                                1.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(1L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(1999)),
+                        Row.of(
+                                0,
+                                3L,
+                                3L,
+                                3.0f,
+                                3.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(3L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(4999)),
+                        Row.of(
+                                0,
+                                4L,
+                                7L,
+                                4.0f,
+                                3.5,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(3L, 1L);
+                                        put(4L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(5999)),
+                        Row.of(
+                                0,
+                                5L,
+                                9L,
+                                5.0f,
+                                4.5,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(4L, 1L);
+                                        put(5L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(6999)),
+                        Row.of(
+                                0,
+                                0L,
+                                5L,
+                                null,
+                                5.0,
+                                new HashMap<Long, Long>() {
+                                    {
+                                        put(5L, 1L);
+                                    }
+                                },
+                                Instant.ofEpochMilli(7999)));
+
+        List<Row> actual = CollectionUtil.iteratorToList(table.execute().collect());
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+}

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -300,12 +300,3 @@ class SlidingFeatureView(FeatureView):
             raise FeathubException(
                 f"SlidingWindowTransforms have different step size " f"{steps}."
             )
-
-        window_sizes = set(
-            [transform.window_size for transform in sliding_window_transforms]
-        )
-        if len(window_sizes) > 1:
-            raise FeathubException(
-                f"SlidingWindowTransforms have different window size "
-                f"{window_sizes}."
-            )

--- a/python/feathub/feature_views/tests/test_sliding_feature_view.py
+++ b/python/feathub/feature_views/tests/test_sliding_feature_view.py
@@ -221,42 +221,6 @@ class SlidingFeatureViewTest(unittest.TestCase):
             )
         self.assertIn("different step size", cm.exception.args[0])
 
-    def test_different_window_size(self):
-        feature_1 = Feature(
-            name="feature_1",
-            dtype=types.Float32,
-            transform=SlidingWindowTransform(
-                expr="CAST(fare_amount AS FLOAT)",
-                agg_func="SUM",
-                window_size=timedelta(seconds=30),
-                group_by_keys=["id"],
-                step_size=timedelta(seconds=10),
-            ),
-        )
-
-        feature_2 = Feature(
-            name="feature_2",
-            dtype=types.Float32,
-            transform=SlidingWindowTransform(
-                expr="CAST(fare_amount AS FLOAT) + 1",
-                agg_func="SUM",
-                window_size=timedelta(seconds=31),
-                group_by_keys=["id"],
-                step_size=timedelta(seconds=10),
-            ),
-        )
-
-        with self.assertRaises(FeathubException) as cm:
-            SlidingFeatureView(
-                name="feature_view_1",
-                source=self.source,
-                features=[
-                    feature_1,
-                    feature_2,
-                ],
-            )
-        self.assertIn("different window size", cm.exception.args[0])
-
     def test_without_sliding_window_transform(self):
         feature_1 = "feature_1"
 

--- a/python/feathub/processors/flink/flink_table.py
+++ b/python/feathub/processors/flink/flink_table.py
@@ -56,7 +56,9 @@ def flink_table_to_pandas(table: NativeFlinkTable) -> pd.DataFrame:
     schema = table.get_schema()
     field_names = schema.get_field_names()
     field_types = {
-        name: FLINK_DATA_TYPE_TO_NUMPY_TYPE.get(schema.get_field_data_type(name), None)
+        name: FLINK_DATA_TYPE_TO_NUMPY_TYPE.get(
+            type(schema.get_field_data_type(name)), None
+        )
         for name in field_names
     }
     with table.execute().collect() as results:

--- a/python/feathub/processors/flink/table_builder/aggregation_utils.py
+++ b/python/feathub/processors/flink/table_builder/aggregation_utils.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from datetime import timedelta
 from typing import Any, Tuple
 
 from pyflink.table.types import DataType, DataTypes
@@ -40,11 +40,13 @@ class AggregationFieldDescriptor:
         field_data_type: DataType,
         expr: str,
         agg_func: AggFunc,
+        window_size: timedelta,
     ) -> None:
         self.field_name = field_name
         self.field_data_type = field_data_type
         self.expr = expr
         self.agg_func = agg_func
+        self.window_size = window_size
 
     @staticmethod
     def from_feature(feature: Feature) -> "AggregationFieldDescriptor":
@@ -61,6 +63,7 @@ class AggregationFieldDescriptor:
             to_flink_type(feature.dtype),
             to_flink_sql_expr(transform.expr),
             transform.agg_func,
+            transform.window_size,
         )
 
 

--- a/python/feathub/processors/flink/table_builder/datagen_utils.py
+++ b/python/feathub/processors/flink/table_builder/datagen_utils.py
@@ -31,9 +31,6 @@ from feathub.processors.flink.table_builder.source_sink_utils_common import (
     define_watermark,
     generate_random_table_name,
 )
-from feathub.processors.flink.table_builder.time_utils import (
-    timedelta_to_flink_sql_interval,
-)
 
 
 def get_table_from_data_gen_source(
@@ -46,9 +43,7 @@ def get_table_from_data_gen_source(
         flink_schema = define_watermark(
             t_env,
             flink_schema,
-            timedelta_to_flink_sql_interval(
-                data_gen_source.max_out_of_orderness, day_precision=3
-            ),
+            data_gen_source.max_out_of_orderness,
             data_gen_source.timestamp_field,
             data_gen_source.timestamp_format,
             data_gen_source.schema.get_field_type(data_gen_source.timestamp_field),

--- a/python/feathub/processors/flink/table_builder/file_system_utils.py
+++ b/python/feathub/processors/flink/table_builder/file_system_utils.py
@@ -28,9 +28,6 @@ from feathub.processors.flink.table_builder.source_sink_utils_common import (
     get_schema_from_table,
     define_watermark,
 )
-from feathub.processors.flink.table_builder.time_utils import (
-    timedelta_to_flink_sql_interval,
-)
 
 
 def get_table_from_file_source(
@@ -49,9 +46,7 @@ def get_table_from_file_source(
         flink_schema = define_watermark(
             t_env,
             flink_schema,
-            timedelta_to_flink_sql_interval(
-                file_source.max_out_of_orderness, day_precision=3
-            ),
+            file_source.max_out_of_orderness,
             file_source.timestamp_field,
             file_source.timestamp_format,
             schema.get_field_type(file_source.timestamp_field),

--- a/python/feathub/processors/flink/table_builder/kafka_utils.py
+++ b/python/feathub/processors/flink/table_builder/kafka_utils.py
@@ -68,9 +68,7 @@ def get_table_from_kafka_source(
             flink_schema = define_watermark(
                 t_env,
                 flink_schema,
-                timedelta_to_flink_sql_interval(
-                    kafka_source.max_out_of_orderness, day_precision=3
-                ),
+                kafka_source.max_out_of_orderness,
                 kafka_source.timestamp_field,
                 kafka_source.timestamp_format,
                 schema.get_field_type(kafka_source.timestamp_field),

--- a/python/feathub/processors/flink/table_builder/kafka_utils.py
+++ b/python/feathub/processors/flink/table_builder/kafka_utils.py
@@ -154,7 +154,8 @@ def get_table_from_kafka_source(
         #  https://issues.apache.org/jira/browse/FLINK-19200
         schema = to_flink_schema(schema)
         max_out_of_orderness_interval = timedelta_to_flink_sql_interval(
-            kafka_source.max_out_of_orderness, day_precision=3
+            kafka_source.max_out_of_orderness + timedelta(milliseconds=1),
+            day_precision=3,
         )
         schema = (
             Schema.new_builder()

--- a/python/feathub/processors/flink/table_builder/source_sink_utils_common.py
+++ b/python/feathub/processors/flink/table_builder/source_sink_utils_common.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import uuid
+from datetime import timedelta
 
 from pyflink.table import (
     Table as NativeFlinkTable,
@@ -25,6 +26,9 @@ from feathub.common.types import DType
 from feathub.common.utils import to_java_date_format
 from feathub.processors.flink.table_builder.flink_table_builder_constants import (
     EVENT_TIME_ATTRIBUTE_NAME,
+)
+from feathub.processors.flink.table_builder.time_utils import (
+    timedelta_to_flink_sql_interval,
 )
 
 
@@ -46,7 +50,7 @@ def get_schema_from_table(table: NativeFlinkTable) -> NativeFlinkSchema:
 def define_watermark(
     t_env: StreamTableEnvironment,
     flink_schema: NativeFlinkSchema,
-    max_out_of_orderness_interval: str,
+    max_out_of_orderness: timedelta,
     timestamp_field: str,
     timestamp_format: str,
     timestamp_field_dtype: DType,
@@ -99,6 +103,9 @@ def define_watermark(
             f"3)",
         )
 
+    max_out_of_orderness_interval = timedelta_to_flink_sql_interval(
+        max_out_of_orderness + timedelta(milliseconds=1), day_precision=3
+    )
     builder.watermark(
         EVENT_TIME_ATTRIBUTE_NAME,
         watermark_expr=f"`{EVENT_TIME_ATTRIBUTE_NAME}` "


### PR DESCRIPTION
## What is the purpose of the change

This PR update the SlidingFeatureView and FlinkTableBuilder to support applying sliding window with different sizes in one SlidingFeatureView. 

The implementation applies a pre-aggregation with a tumbling window whose window size is the same as the step size of the sliding window to be applied. Then sliding window only stores the rows for the maximum window size, instead of rows for each sliding window, which uses less space in the Flink state backend than the approach that applies multiple sliding windows and then joins them together.

## Brief change log

- Introduce Java implementation of MultiSizeSlidingWindowKeyedProcessFunction.
- SlidingFeatureView supports sliding window with different sizes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable