### PR TITLE
Raises exception when sinking csv files to s3 using Flink processor

### DIFF
--- a/python/feathub/processors/flink/table_builder/file_system_utils.py
+++ b/python/feathub/processors/flink/table_builder/file_system_utils.py
@@ -78,6 +78,13 @@ def insert_into_file_sink(
 ) -> TableResult:
     path = sink.path
 
+    # TODO: Remove this check after FLINK-28513 is resolved.
+    if sink.data_format == "csv" and path.startswith("s3://"):
+        raise FeathubException(
+            "Cannot sink files in CSV format to s3 because of Flink issue. "
+            "See FLINK-28513."
+        )
+
     # TODO: Alibaba Cloud Realtime Compute has bug that assumes all the tables should
     # have a name in VVR-6.0.2, which should be fixed in next version VVR-6.0.3. As a
     # current workaround, we have to generate a random table name. We should update the

--- a/python/feathub/processors/flink/table_builder/file_system_utils.py
+++ b/python/feathub/processors/flink/table_builder/file_system_utils.py
@@ -81,8 +81,7 @@ def insert_into_file_sink(
     # TODO: Remove this check after FLINK-28513 is resolved.
     if sink.data_format == "csv" and path.startswith("s3://"):
         raise FeathubException(
-            "Cannot sink files in CSV format to s3 because of Flink issue. "
-            "See FLINK-28513."
+            "Cannot sink files in CSV format to s3 due to FLINK-28513."
         )
 
     # TODO: Alibaba Cloud Realtime Compute has bug that assumes all the tables should

--- a/python/feathub/processors/flink/table_builder/tests/test_filesystem_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_filesystem_utils.py
@@ -1,0 +1,29 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
+from feathub.processors.flink.table_builder.source_sink_utils import insert_into_sink
+from feathub.processors.flink.table_builder.tests.table_builder_test_base import (
+    FlinkTableBuilderTestBase,
+)
+
+
+class SinkUtilTest(FlinkTableBuilderTestBase):
+    def test_nsupported_file_format(self):
+        sink = FileSystemSink("s3://dummy-bucket/path", "csv")
+        table = self.t_env.from_elements([(1,)])
+        with self.assertRaisesRegex(
+            FeathubException, "Cannot sink files in CSV format to s3"
+        ):
+            insert_into_sink(self.t_env, table, sink, ("id",))


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Feathub - we are happy that you want to help us improve Feathub. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
## Contribution Checklist
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review. 
  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since Flink has a bug when sinking CSV files to s3, see [FLINK-28513](https://issues.apache.org/jira/browse/FLINK-28513). Feathub should check for this during compile time to avoid unclear exceptions.

## Brief change log

  - Raises exception when sinking csv files to s3 using Flink processor

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)