### PR TITLE
Add OnlineStoreClient and RedisSource for online serving

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -21,3 +21,5 @@ flake8==4.0.1
 mypy==0.971
 testcontainers[kafka,redis]~=3.7.0
 protobuf~=3.17.3
+redis==4.3.0
+types-redis~=4.3.21

--- a/python/feathub/common/test_utils.py
+++ b/python/feathub/common/test_utils.py
@@ -74,7 +74,7 @@ class LocalProcessorTestCase(unittest.TestCase):
         table_name: str,
         input_data: pd.DataFrame,
         keys_to_get: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = True,
     ) -> pd.DataFrame:
         sink = OnlineStoreSink(
@@ -92,7 +92,7 @@ class LocalProcessorTestCase(unittest.TestCase):
         return self.processor.get_online_features(
             table_name=table_name,
             input_data=keys_to_get,
-            feature_fields=feature_fields,
+            feature_names=feature_names,
             include_timestamp_field=include_timestamp_field,
             store_type=MemoryOnlineStore.STORE_TYPE,
         )

--- a/python/feathub/feathub_client.py
+++ b/python/feathub/feathub_client.py
@@ -133,18 +133,18 @@ class FeathubClient:
         self,
         request_df: pd.DataFrame,
         feature_view: Union[str, OnDemandFeatureView],
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """
         Queries features for the given keys from the online store.
 
         :return: A DataFrame consisting of the input_data and the requested
-                 feature_fields.
+                 feature_names.
         """
         return self.feature_service.get_online_features(
             request_df=request_df,
             feature_view=feature_view,
-            feature_fields=feature_fields,
+            feature_names=feature_names,
         )
 
     def build_features(

--- a/python/feathub/feature_service/feature_service.py
+++ b/python/feathub/feature_service/feature_service.py
@@ -46,7 +46,7 @@ class FeatureService(ABC):
         self,
         request_df: pd.DataFrame,
         feature_view: Union[str, OnDemandFeatureView],
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """
         Returns a DataFrame obtained by applying the given OnDemandFeatureView on the
@@ -56,7 +56,7 @@ class FeatureService(ABC):
         :param feature_view: Describes the features to be included in the output. If it
                              is a string, it refers to the name of a OnDemandFeatureView
                              in the entity registry.
-        :param feature_fields: Optional. The names of fields of values that should be
+        :param feature_names: Optional. The names of fields of values that should be
                                included in the output DataFrame. If it is None, all
                                fields of the specified table should be outputted.
         :return: A DataFrame obtained according to the specified criteria.

--- a/python/feathub/feature_service/local_feature_service.py
+++ b/python/feathub/feature_service/local_feature_service.py
@@ -51,7 +51,7 @@ class LocalFeatureService(FeatureService):
         self,
         request_df: pd.DataFrame,
         feature_view: Union[str, OnDemandFeatureView],
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """
         Returns a DataFrame obtained by applying the given OnDemandFeatureView on the
@@ -61,7 +61,7 @@ class LocalFeatureService(FeatureService):
         :param feature_view: Describes the features to be included in the output. If it
                              is a string, it refers to the name of a OnDemandFeatureView
                              in the entity registry.
-        :param feature_fields: Optional. The names of fields of values that should be
+        :param feature_names: Optional. The names of fields of values that should be
                                included in the output DataFrame. If it is None, all
                                fields of the specified table should be outputted.
         :return: A DataFrame obtained according to the specified criteria.
@@ -84,8 +84,8 @@ class LocalFeatureService(FeatureService):
                     f"Unsupported transformation type for feature {feature.to_json()}."
                 )
 
-        if feature_fields is not None:
-            output_fields = feature_fields
+        if feature_names is not None:
+            output_fields = feature_names
         else:
             output_fields = feature_view.get_output_fields(input_fields)
 

--- a/python/feathub/feature_service/tests/test_feature_service.py
+++ b/python/feathub/feature_service/tests/test_feature_service.py
@@ -175,7 +175,7 @@ class FeatureServiceTest(LocalProcessorTestCase):
         online_features = self.feature_service.get_online_features(
             request_df=request_df,
             feature_view=on_demand_fv,
-            feature_fields=["distance", "avg_cost"],
+            feature_names=["distance", "avg_cost"],
         )
         expected_online_features = pd.DataFrame(
             [

--- a/python/feathub/feature_tables/sources/redis_source.py
+++ b/python/feathub/feature_tables/sources/redis_source.py
@@ -1,0 +1,92 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional, Dict
+
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.table.schema import Schema
+
+
+class RedisSource(FeatureTable):
+    """
+    A source which reads data from Redis. It can only read feature values written
+    to Redis with :class:`RedisSink`.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        schema: Schema,
+        keys: List[str],
+        host: str,
+        port: int = 6379,
+        username: str = None,
+        password: str = None,
+        db_num: int = 0,
+        namespace: str = "default",
+        timestamp_field: Optional[str] = None,
+    ):
+        """
+        :param name: The name that uniquely identifies this source in a registry.
+        :param schema: The schema of the data.
+        :param keys: The names of fields in this feature view that are necessary
+                     to locate a row of this table.
+        :param host: The host of the Redis instance to connect.
+        :param port: The port of the Redis instance to connect.
+        :param username: The username used by the Redis authorization process.
+        :param password: The password used by the Redis authorization process.
+        :param db_num: The No. of the Redis database to connect.
+        :param namespace: The namespace where the feature values reside in Redis. It
+                          must be equal to the namespace of the corresponding RedisSink
+                          when the features were written to Redis.
+        :param timestamp_field: Optional. If it is not None, it is the name of the field
+                                whose values show the time when the corresponding row
+                                is generated.
+        """
+        super().__init__(
+            name=name,
+            system_name="redis",
+            properties={
+                "host": host,
+                "port": port,
+                "username": username,
+                "password": password,
+                "db_num": db_num,
+                "namespace": namespace,
+            },
+            keys=keys,
+            schema=schema,
+            timestamp_field=timestamp_field,
+        )
+        self.host = host
+        self.schema = schema
+        self.port = port
+        self.username = username
+        self.password = password
+        self.db_num = db_num
+        self.namespace = namespace
+
+    def to_json(self) -> Dict:
+        return {
+            "type": "RedisSource",
+            "name": self.name,
+            "schema": None if self.schema is None else self.schema.to_json(),
+            "keys": self.keys,
+            "host": self.host,
+            "port": self.port,
+            "username": self.username,
+            "password": self.password,
+            "db_num": self.db_num,
+            "namespace": self.namespace,
+            "timestamp_field": self.timestamp_field,
+        }

--- a/python/feathub/online_stores/memory_online_store.py
+++ b/python/feathub/online_stores/memory_online_store.py
@@ -102,7 +102,7 @@ class MemoryOnlineStore(OnlineStore):
         self,
         table_name: str,
         input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = False,
     ) -> pd.DataFrame:
         table_info = self.table_infos[table_name]
@@ -131,10 +131,10 @@ class MemoryOnlineStore(OnlineStore):
         input_data = input_data.drop(columns=features.columns.tolist(), errors="ignore")
         features = input_data.join(features)
 
-        if feature_fields is not None:
+        if feature_names is not None:
             if table_info.timestamp_field is not None:
-                feature_fields.append(table_info.timestamp_field)
-            features = features[input_data.columns.values.tolist() + feature_fields]
+                feature_names.append(table_info.timestamp_field)
+            features = features[input_data.columns.values.tolist() + feature_names]
         if table_info.timestamp_field is not None and not include_timestamp_field:
             features = features.drop(columns=[field_to_drop])
         return features

--- a/python/feathub/online_stores/online_store.py
+++ b/python/feathub/online_stores/online_store.py
@@ -36,8 +36,9 @@ def instantiate_online_stores(props: Dict) -> Dict[str, "OnlineStore"]:
 
 class OnlineStore(ABC):
     """
-    An online feature store implements APIs to put and get features by keys. It can
-    provide a uniform interface to interact with kv stores such as Redis.
+    An online feature store implements APIs to put and get features by keys. It
+    provides the storage on its own and exposes a uniform interface to put and
+    get features.
     """
 
     def __init__(self) -> None:

--- a/python/feathub/online_stores/online_store.py
+++ b/python/feathub/online_stores/online_store.py
@@ -78,7 +78,7 @@ class OnlineStore(ABC):
         self,
         table_name: str,
         input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = False,
     ) -> pd.DataFrame:
         """
@@ -86,14 +86,14 @@ class OnlineStore(ABC):
 
         :param table_name: The name of the table containing the features.
         :param input_data: A DataFrame where each row contains the keys of this table.
-        :param feature_fields: Optional. The names of fields of values that should be
+        :param feature_names: Optional. The names of fields of values that should be
                                included in the output DataFrame. If it is None, all
                                fields of the specified table should be outputted.
         :param include_timestamp_field: If it is true, the table should have a timestamp
                                         field. And the timestamp field will be outputted
-                                        regardless of `feature_fields`.
+                                        regardless of `feature_names`.
         :return: A DataFrame consisting of the input_data and the requested
-                 feature_fields.
+                 feature_names.
         """
         pass
 

--- a/python/feathub/online_stores/online_store_client.py
+++ b/python/feathub/online_stores/online_store_client.py
@@ -35,20 +35,18 @@ class OnlineStoreClient(ABC):
     # TODO: replace input_data with keys.
     @abstractmethod
     def get(
-        self,
-        input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        self, input_data: pd.DataFrame, feature_names: Optional[List[str]] = None
     ) -> pd.DataFrame:
         """
         Gets values matching the given keys from the specified table in the kv store.
 
         :param input_data: A DataFrame where each row contains the keys of this table.
-        :param feature_fields: Optional. The names of fields of values that should be
+        :param feature_names: Optional. The names of fields of values that should be
                                included in the output DataFrame. If it is None, all
                                feature fields of the specified table should be
                                outputted.
         :return: A DataFrame consisting of the input_data and the requested
-                 feature_fields.
+                 feature_names.
         """
         pass
 

--- a/python/feathub/online_stores/online_store_client.py
+++ b/python/feathub/online_stores/online_store_client.py
@@ -1,0 +1,78 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+import pandas as pd
+
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sources.redis_source import RedisSource
+
+
+class OnlineStoreClient(ABC):
+    """
+    An online feature store client implements APIs to get features by keys. It can
+    provide a uniform interface to interact with kv stores such as Redis.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    # TODO: replace input_data with keys.
+    @abstractmethod
+    def get(
+        self,
+        input_data: pd.DataFrame,
+        feature_fields: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
+        """
+        Gets values matching the given keys from the specified table in the kv store.
+
+        :param input_data: A DataFrame where each row contains the keys of this table.
+        :param feature_fields: Optional. The names of fields of values that should be
+                               included in the output DataFrame. If it is None, all
+                               feature fields of the specified table should be
+                               outputted.
+        :return: A DataFrame consisting of the input_data and the requested
+                 feature_fields.
+        """
+        pass
+
+    @staticmethod
+    def instantiate(source: FeatureTable) -> OnlineStoreClient:
+        """
+        Instantiates an OnlineStoreClient from the provided source.
+        """
+
+        if isinstance(source, RedisSource):
+            from feathub.online_stores.redis_client import RedisClient
+
+            return RedisClient(
+                schema=source.schema,
+                host=source.host,
+                port=source.port,
+                username=source.username,
+                password=source.password,
+                db_num=source.db_num,
+                namespace=source.namespace,
+                keys=source.keys,
+                timestamp_field=source.timestamp_field,
+            )
+
+        raise RuntimeError(
+            f"Failed to instantiate online store client from source {source}."
+        )

--- a/python/feathub/online_stores/redis_client.py
+++ b/python/feathub/online_stores/redis_client.py
@@ -1,0 +1,104 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, List
+
+import pandas as pd
+import redis
+
+from feathub.common.utils import (
+    deserialize_object_with_protobuf,
+)
+from feathub.online_stores.online_store_client import OnlineStoreClient
+from feathub.processors.flink.table_builder.redis_utils import serialize_and_join_keys
+from feathub.table.schema import Schema
+
+
+class RedisClient(OnlineStoreClient):
+    """
+    An online store client that reads feature values from Redis.
+    """
+
+    def __init__(
+        self,
+        schema: Schema,
+        host: str,
+        port: int = 6379,
+        username: str = None,
+        password: str = None,
+        db_num: int = 0,
+        namespace: str = "default",
+        keys: Optional[List[str]] = None,
+        timestamp_field: Optional[str] = None,
+    ):
+        super().__init__()
+        self.namespace = namespace
+
+        self.key_names = keys
+        self.key_types = [schema.get_field_type(x) for x in self.key_names]
+
+        self.all_feature_names = [
+            x
+            for x in schema.field_names
+            if x not in self.key_names and x != timestamp_field
+        ]
+        self.encoded_feature_indices = {}
+        for i in range(len(self.all_feature_names)):
+            self.encoded_feature_indices[self.all_feature_names[i]] = i.to_bytes(
+                4, byteorder="big"
+            )
+
+        self.redis_client = redis.Redis(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            decode_responses=False,
+        )
+        self.redis_client.select(db_num)
+
+    def get(
+        self,
+        input_data: pd.DataFrame,
+        feature_fields: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
+        if not set(self.key_names) <= set(input_data.columns.values):
+            raise RuntimeError(
+                f"Input dataframe's column names {input_data.columns.values} "
+                f"should contain all of source key field names {self.key_names}."
+            )
+
+        if feature_fields is None:
+            feature_fields = self.all_feature_names
+
+        selected_feature_indices = [
+            self.encoded_feature_indices[field] for field in feature_fields
+        ]
+
+        results_list = []
+        for _, row in input_data.iterrows():
+            row_dict = row.to_dict()
+            key_value = serialize_and_join_keys(
+                [row_dict[x] for x in self.key_names], self.key_types
+            )
+            key_value = (self.namespace + ":").encode("utf-8") + key_value
+
+            result = []
+            raw_values = self.redis_client.hmget(key_value, selected_feature_indices)
+            for raw_value in raw_values:
+                result.append(deserialize_object_with_protobuf(bytes(raw_value)))
+            results_list.append(result)
+
+        features = pd.DataFrame(results_list, columns=feature_fields)
+        features = input_data.join(features)
+        return features

--- a/python/feathub/online_stores/redis_client.py
+++ b/python/feathub/online_stores/redis_client.py
@@ -68,9 +68,7 @@ class RedisClient(OnlineStoreClient):
         self.redis_client.select(db_num)
 
     def get(
-        self,
-        input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        self, input_data: pd.DataFrame, feature_names: Optional[List[str]] = None
     ) -> pd.DataFrame:
         if not set(self.key_names) <= set(input_data.columns.values):
             raise RuntimeError(
@@ -78,11 +76,11 @@ class RedisClient(OnlineStoreClient):
                 f"should contain all of source key field names {self.key_names}."
             )
 
-        if feature_fields is None:
-            feature_fields = self.all_feature_names
+        if feature_names is None:
+            feature_names = self.all_feature_names
 
         selected_feature_indices = [
-            self.encoded_feature_indices[field] for field in feature_fields
+            self.encoded_feature_indices[field] for field in feature_names
         ]
 
         results_list = []
@@ -99,6 +97,6 @@ class RedisClient(OnlineStoreClient):
                 result.append(deserialize_object_with_protobuf(bytes(raw_value)))
             results_list.append(result)
 
-        features = pd.DataFrame(results_list, columns=feature_fields)
+        features = pd.DataFrame(results_list, columns=feature_names)
         features = input_data.join(features)
         return features

--- a/python/feathub/online_stores/tests/test_redis_client.py
+++ b/python/feathub/online_stores/tests/test_redis_client.py
@@ -1,0 +1,168 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import DataTypes, StreamTableEnvironment
+from testcontainers.redis import RedisContainer
+
+from feathub.common import types
+from feathub.feathub_client import FeathubClient
+from feathub.feature_tables.sinks.redis_sink import RedisSink
+from feathub.feature_tables.sources.redis_source import RedisSource
+from feathub.feature_views.on_demand_feature_view import OnDemandFeatureView
+from feathub.processors.flink.table_builder.source_sink_utils import insert_into_sink
+from feathub.processors.flink.table_builder.tests.table_builder_test_utils import (
+    MockTableDescriptor,
+    FlinkTableBuilderTestBase,
+)
+from feathub.table.schema import Schema
+from feathub.table.table_descriptor import TableDescriptor
+
+
+class RedisClientTest(FlinkTableBuilderTestBase):
+    redis_container: RedisContainer = None
+
+    def __init__(self, method_name: str):
+        super().__init__(method_name)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.redis_container = RedisContainer()
+        cls.redis_container.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.redis_container.stop()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.host = RedisClientTest.redis_container.get_container_host_ip()
+        if self.host == "localhost":
+            self.host = "127.0.0.1"
+        self.port = RedisClientTest.redis_container.get_exposed_port(
+            RedisClientTest.redis_container.port_to_expose
+        )
+
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.t_env = StreamTableEnvironment.create(self.env)
+        self.test_time = datetime.now()
+
+        self.row_data = self._produce_data_to_redis(self.t_env)
+
+        self.client = FeathubClient(props={})
+
+        self.schema = (
+            Schema.new_builder()
+            .column("id", types.Int64)
+            .column("val", types.Int64)
+            .column("ts", types.String)
+            .build()
+        )
+
+        self.on_demand_feature_view = OnDemandFeatureView(
+            name="on_demand_feature_view",
+            features=[
+                "table_name_1.val",
+            ],
+            keep_source_fields=True,
+        )
+
+    def test_get_online_features(self):
+        source = RedisSource(
+            name="table_name_1",
+            host=self.host,
+            port=int(self.port),
+            schema=self.schema,
+            keys=["id"],
+            timestamp_field="ts",
+        )
+
+        self.client.build_features([source, self.on_demand_feature_view])
+
+        request_df = pd.DataFrame(np.array([[1], [2], [3]]), columns=["id"])
+        online_features = self.client.get_online_features(
+            request_df=request_df,
+            feature_view=self.on_demand_feature_view,
+        )
+
+        rows = [x for _, x in online_features.iterrows()]
+        self.assertEquals(3, len(rows))
+
+        for i in range(len(rows)):
+            row = rows[i]
+            self.assertEquals({"id": i + 1, "val": i + 2}, row.to_dict())
+
+    def test_more_input_column_than_keys(self):
+        source = RedisSource(
+            name="table_name_1",
+            host=self.host,
+            port=int(self.port),
+            schema=self.schema,
+            keys=["id"],
+            timestamp_field="ts",
+        )
+
+        self.client.build_features([source, self.on_demand_feature_view])
+
+        request_df = pd.DataFrame(
+            np.array([[1, "1"], [2, "2"], [3, "3"]]), columns=["id", "id_str"]
+        )
+        request_df["id"] = pd.to_numeric(request_df["id"])
+        online_features = self.client.get_online_features(
+            request_df=request_df,
+            feature_view=self.on_demand_feature_view,
+        )
+
+        rows = [x for _, x in online_features.iterrows()]
+        self.assertEquals(3, len(rows))
+
+        for i in range(len(rows)):
+            row = rows[i]
+            self.assertEquals(
+                {"id": i + 1, "id_str": str(i + 1), "val": i + 2}, row.to_dict()
+            )
+
+    def _produce_data_to_redis(self, t_env):
+        row_data = [
+            (1, 2, datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")),
+            (2, 3, datetime(2022, 1, 1, 0, 0, 1).strftime("%Y-%m-%d %H:%M:%S")),
+            (3, 4, datetime(2022, 1, 1, 0, 0, 2).strftime("%Y-%m-%d %H:%M:%S")),
+        ]
+        table = t_env.from_elements(
+            row_data,
+            DataTypes.ROW(
+                [
+                    DataTypes.FIELD("id", DataTypes.BIGINT()),
+                    DataTypes.FIELD("val", DataTypes.BIGINT()),
+                    DataTypes.FIELD("ts", DataTypes.STRING()),
+                ]
+            ),
+        )
+
+        sink = RedisSink(
+            host=self.host,
+            port=int(self.port),
+        )
+
+        descriptor: TableDescriptor = MockTableDescriptor(
+            keys=["id"], timestamp_field="ts", timestamp_format="%Y-%m-%d %H:%M:%S"
+        )
+
+        insert_into_sink(t_env, table, descriptor, sink).wait(30000)
+        return row_data

--- a/python/feathub/processors/flink/flink_processor.py
+++ b/python/feathub/processors/flink/flink_processor.py
@@ -208,7 +208,7 @@ class FlinkProcessor(Processor):
         self,
         table_name: str,
         input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = False,
         store_type: Optional[str] = None,
     ) -> pd.DataFrame:

--- a/python/feathub/processors/local/local_processor.py
+++ b/python/feathub/processors/local/local_processor.py
@@ -162,7 +162,7 @@ class LocalProcessor(Processor):
         self,
         table_name: str,
         input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = False,
         store_type: Optional[str] = None,
     ) -> pd.DataFrame:
@@ -177,7 +177,7 @@ class LocalProcessor(Processor):
         return store.get(
             table_name=table_name,
             input_data=input_data,
-            feature_fields=feature_fields,
+            feature_names=feature_names,
             include_timestamp_field=include_timestamp_field,
         )
 

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -256,7 +256,7 @@ class ProcessorTest(LocalProcessorTestCase):
             table_name="table_name_1",
             input_data=self.input_data,
             keys_to_get=pd.DataFrame(["Alex", "Emma"], columns=["name"]),
-            feature_fields=["cost"],
+            feature_names=["cost"],
         )
         expected_online_features = pd.DataFrame(
             [

--- a/python/feathub/processors/processor.py
+++ b/python/feathub/processors/processor.py
@@ -111,7 +111,7 @@ class Processor(ABC):
         self,
         table_name: str,
         input_data: pd.DataFrame,
-        feature_fields: Optional[List[str]] = None,
+        feature_names: Optional[List[str]] = None,
         include_timestamp_field: bool = False,
         store_type: Optional[str] = None,
     ) -> pd.DataFrame:
@@ -120,18 +120,18 @@ class Processor(ABC):
 
         :param table_name: The name of the table containing the features.
         :param input_data: A DataFrame where each row contains the keys of this table.
-        :param feature_fields: Optional. The names of fields of values that should be
+        :param feature_names: Optional. The names of fields of values that should be
                                included in the output DataFrame. If it is None, all
                                fields of the specified table should be outputted.
         :param include_timestamp_field: If it is true, the table should have a timestamp
                                         field. And the timestamp field will be outputted
-                                        regardless of `feature_fields`.
+                                        regardless of `feature_names`.
         :param store_type: Optional. If it is not None, gets features from the store
                            with the given type. Otherwise, there should be exactly one
                            store specified in the FeathubClient configuration. Gets
                            features from this store.
         :return: A DataFrame consisting of the input_data and the requested
-                 feature_fields.
+                 feature_names.
         """
         pass
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -108,6 +108,8 @@ try:
         "numpy>=1.14.3,<1.20",
         "apache-flink==1.15.2",
         "kubernetes~=24.2",
+        "protobuf~=3.17.3",
+        "redis==4.3.0",
     ]
 
     setup(


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds RedisSource to provide online serving based on feature values stored in Redis.

## Brief change log

- Introduce `OnlineStoreClient` interface that provides a uniform interface to interact with kv stores such as Redis.
- Add `RedisClient` that implements `OnlineStoreClient` and provides implementation details to read from Redis.
- Add `RedisSource` as public API for users to set up online serving from Redis-saved features.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API: yes

## Documentation

- Does this pull request introduce a new feature? Yes
- If yes, how is the feature documented? Python document