### PR TITLE
Add SparkProcessor with ExpressionTransform and DerivedFeatureView

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,10 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           python -m pip install -r python/dev-requirements.txt
+          # TODO: Add workflow to seperately test each processor.
           python -m pip install ./python
+          python -m pip install ./python[flink]
+          python -m pip install ./python[spark]
           
           # Re-install black here because its pip dependency conflicts with
           # apache-flink 1.15.2.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@ Prerequisites for building python packages:
 ### Install Feathub
 
 #### Install Nightly Build
-Run the following command to install preview(nightly) version of Feathub.
+According to the processor you plan to use, run any of the following commands to
+install the preview(nightly) version of Feathub and the corresponding extra
+requirements.
 ```bash
+# If you are using local processor, run the following command
 $ python -m pip install --upgrade feathub-nightly
+
+# If you are using Flink processor, run the following command
+$ python -m pip install --upgrade "feathub-nightly[flink]"
+
+# If you are using Spark processor, run the following command
+$ python -m pip install --upgrade "feathub-nightly[spark]"
 ```
 
 #### Install From Source
@@ -73,6 +82,7 @@ engine. Here is a list of supported processors and versions:
 
 - Local
 - Flink 1.15.2
+- Spark 3.3.1
 
 ### Quickstart
 
@@ -93,6 +103,7 @@ Flink cluster, you can see the following quickstart with different deployment mo
 - [Flink Processor Session Mode Quickstart](docs/quickstarts/flink_processor_session_quickstart.md)
 - [Flink Processor Cli Mode Quickstart](docs/quickstarts/flink_processor_cli_quickstart.md)
 
+<!-- TODO: add nyc_example and quickstart document for Spark processor -->
 
 ## Highlighted Capabilities
 
@@ -204,10 +215,11 @@ $ ulimit -n 1024
    to install protoc.
 
 ### Building Feathub Project
-
+<!-- TODO: Add instruction to install "./python[all]" after the dependency confliction in PyFlink and PySpark is resolved. -->
 ```bash
 $ mvn clean package -DskipTests -f ./java
-$ python -m pip install ./python
+$ python -m pip install "./python[flink]"
+$ python -m pip install "./python[spark]"
 ```
 
 ### Running All Python Tests
@@ -243,6 +255,7 @@ Here is a list of key features that we plan to support. Stay tuned!
 
 - [x] Support all FeatureView transformations with FlinkProcessor
 - [ ] Support all FeatureView transformations with LocalProcessor
+- [ ] Support all FeatureView transformations with SparkProcessor
 - [ ] Support common online and offline feature storages (e.g. MaxCompute, Redis, HDFS)
 - [ ] Support online transformation with feature service
 - [ ] Support integration with Notebook

--- a/docs/feathub_expression.md
+++ b/docs/feathub_expression.md
@@ -81,8 +81,8 @@ NULL.
 
 ## Temporal Functions
 
-| Function               | Description                                                                                                                         |
-|------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| UNIX_TIMESTAMP(sring1) | Converts dateime string string1 in the format yyyy-MM-dd HH:mm:ss to Unix timestamp (in seconds). Returns NULL if in case of error. |
+| Function                | Description                                                                                                                         |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| UNIX_TIMESTAMP(string1) | Converts dateime string string1 in the format yyyy-MM-dd HH:mm:ss to Unix timestamp (in seconds). Returns NULL if in case of error. |
 
 

--- a/python/feathub/processors/flink/flink_processor.py
+++ b/python/feathub/processors/flink/flink_processor.py
@@ -84,8 +84,6 @@ class FlinkProcessor(Processor):
                                 the Kubernetes cluster. Default to "~/.kube/config".
     """
 
-    PROCESSOR_TYPE = "flink"
-
     def __init__(self, props: Dict, registry: Registry) -> None:
         """
         Instantiate the FlinkProcessor.

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -113,7 +113,7 @@ class FlinkTableBuilder:
         If the given features is a FeatureView, it must be resolved, otherwise
         exception will be thrown.
 
-        :param features: The feature to converts to native Flink table.
+        :param features: The feature to convert to native Flink table.
         :param keys: Optional. If it is not none, then the returned table only includes
                      rows whose key fields match at least one row of the keys.
         :param start_datetime: Optional. If it is not None, the `features` table should
@@ -131,7 +131,7 @@ class FlinkTableBuilder:
         """
         if isinstance(features, FeatureView) and features.is_unresolved():
             raise FeathubException(
-                "Trying to convert a unresolved FeatureView to native Flink table."
+                "Trying to convert an unresolved FeatureView to native Flink table."
             )
 
         table = self._get_table(features)

--- a/python/feathub/processors/local/local_processor.py
+++ b/python/feathub/processors/local/local_processor.py
@@ -49,8 +49,6 @@ class LocalProcessor(Processor):
     DataFrame to store tabular data in memory.
     """
 
-    PROCESSOR_TYPE = "local"
-
     # TODO: Support agg function LAST_VALUE, FIRST_VALUE, ROW_NUMBER, VALUE_COUNTS
     _AGG_FUNCTIONS = {
         AggFunc.AVG: np.mean,

--- a/python/feathub/processors/processor.py
+++ b/python/feathub/processors/processor.py
@@ -125,5 +125,9 @@ class Processor(ABC):
             from feathub.processors.flink.flink_processor import FlinkProcessor
 
             return FlinkProcessor(props=props, registry=registry)
+        elif processor_type == ProcessorType.SPARK:
+            from feathub.processors.spark.spark_processor import SparkProcessor
+
+            return SparkProcessor(props=props, registry=registry)
 
         raise RuntimeError(f"Failed to instantiate processor with props={props}.")

--- a/python/feathub/processors/processor_config.py
+++ b/python/feathub/processors/processor_config.py
@@ -21,6 +21,7 @@ from feathub.common.validators import in_list
 class ProcessorType(Enum):
     LOCAL = "local"
     FLINK = "flink"
+    SPARK = "spark"
 
 
 PROCESSOR_TYPE_CONFIG = "processor.type"

--- a/python/feathub/processors/spark/__init__.py
+++ b/python/feathub/processors/spark/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/python/feathub/processors/spark/ast_evaluator/__init__.py
+++ b/python/feathub/processors/spark/ast_evaluator/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
@@ -1,0 +1,82 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Optional, Dict, Any
+
+from feathub.dsl.abstract_ast_evaluator import AbstractAstEvaluator
+from feathub.dsl.ast import (
+    LogicalOp,
+    CastOp,
+    ArgListNode,
+    VariableNode,
+    FuncCallOp,
+    ValueNode,
+    CompareOp,
+    UminusOp,
+    BinaryOp,
+    GroupNode,
+)
+
+
+class SparkAstEvaluator(AbstractAstEvaluator):
+    """
+    AST Evaluator for Spark processor.
+
+    The result is the Spark SQL expression string.
+    """
+
+    def eval_binary_op(self, ast: BinaryOp, variables: Optional[Dict]) -> Any:
+        left_val = self.eval(ast.left_child, variables)
+        right_val = self.eval(ast.right_child, variables)
+        return f"{left_val} {ast.op_type} {right_val}"
+
+    def eval_uminus_op(self, ast: UminusOp, variables: Optional[Dict]) -> Any:
+        return f"-{self.eval(ast.child, variables)}"
+
+    def eval_compare_op(self, ast: CompareOp, variables: Optional[Dict]) -> Any:
+        left_val = self.eval(ast.left_child, variables)
+        right_val = self.eval(ast.right_child, variables)
+        return f"{left_val} {ast.op_type} {right_val}"
+
+    def eval_value_node(self, ast: ValueNode, variables: Optional[Dict]) -> Any:
+        if isinstance(ast.value, str):
+            return f"'{ast.value}'"
+        if isinstance(ast.value, bool):
+            return str(ast.value).lower()
+        return str(ast.value)
+
+    def eval_func_call_op(self, ast: FuncCallOp, variables: Optional[Dict]) -> Any:
+        # TODO: Add support for Feathub built-in functions.
+        args = [self.eval(v, variables) for v in ast.args.values]
+        return f"{ast.func_name}({', '.join(args)})"
+
+    def eval_variable_node(self, ast: VariableNode, variables: Optional[Dict]) -> Any:
+        return f"`{ast.var_name}`"
+
+    def eval_arglist_node(self, ast: ArgListNode, variables: Optional[Dict]) -> Any:
+        return ", ".join([self.eval(value, variables) for value in ast.values])
+
+    def eval_cast_node(self, ast: CastOp, variables: Optional[Dict]) -> Any:
+        if ast.exception_on_failure:
+            return f"CAST({self.eval(ast.child, variables)} AS {ast.type_name})"
+        # TODO: Add document explaining that TRY_CAST is not available in community
+        #  version of Spark, and code to check the availability of the UDFs.
+        return f"TRY_CAST({self.eval(ast.child, variables)} AS {ast.type_name})"
+
+    def eval_logical_op(self, ast: LogicalOp, variables: Optional[Dict]) -> Any:
+        left_val = self.eval(ast.left_child, variables)
+        right_val = self.eval(ast.right_child, variables)
+        return f"{left_val} {ast.op_type} {right_val}"
+
+    def eval_group_node(self, ast: GroupNode, variables: Optional[Dict]) -> Any:
+        return f"({self.eval(ast.child, variables)})"

--- a/python/feathub/processors/spark/ast_evaluator/tests/__init__.py
+++ b/python/feathub/processors/spark/ast_evaluator/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
@@ -1,0 +1,112 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+from feathub.dsl.expr_parser import ExprParser
+from feathub.processors.spark.ast_evaluator.spark_ast_evaluator import SparkAstEvaluator
+
+
+class TestSparkAstEvaluator(unittest.TestCase):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.parser = ExprParser()
+        self.ast_evaluator = SparkAstEvaluator()
+
+    def _eval(self, expr, variables=None):
+        ast = self.parser.parse(expr)
+        return self.ast_evaluator.eval(ast, variables)
+
+    def test_binary_op(self):
+        expr = "1 +2 * 3 - 6"
+        self.assertEqual("1 + 2 * 3 - 6", self._eval(expr))
+        expr = "(1 +2) *3 - 6"
+        self.assertEqual("(1 + 2) * 3 - 6", self._eval(expr))
+        expr = "2 * 3 /5"
+        self.assertEqual("2 * 3 / 5", self._eval(expr))
+
+    def test_uminus(self):
+        expr = "-6 + 9"
+        self.assertEqual("-6 + 9", self._eval(expr))
+        expr = "-a + 9"
+        self.assertEqual("-`a` + 9", self._eval(expr))
+
+    def test_compare_op(self):
+        expr = "(1 + 2) > 3"
+        self.assertEqual("(1 + 2) > 3", self._eval(expr))
+        expr = "(1 + 2) >= 3"
+        self.assertEqual("(1 + 2) >= 3", self._eval(expr))
+        expr = "(1 + 2) < 3"
+        self.assertEqual("(1 + 2) < 3", self._eval(expr))
+        expr = "(1 + 2) <= 3"
+        self.assertEqual("(1 + 2) <= 3", self._eval(expr))
+        expr = "(1 + 2) == 3"
+        self.assertEqual("(1 + 2) == 3", self._eval(expr))
+        expr = "(1 + 2) <> 3"
+        self.assertEqual("(1 + 2) <> 3", self._eval(expr))
+        expr = "(a + b) <> 3"
+        self.assertEqual("(`a` + `b`) <> 3", self._eval(expr))
+
+    def test_variable(self):
+        expr = "1 + 2 * x"
+        self.assertEqual("1 + 2 * `x`", self._eval(expr))
+        expr = "x * x - y"
+        self.assertEqual("`x` * `x` - `y`", self._eval(expr))
+
+    def test_func_call(self):
+        expr = """
+        UNIX_TIMESTAMP("2020-01-01 00:24:39") - UNIX_TIMESTAMP("2020-01-01 00:23:40")
+        """
+        self.assertEqual(
+            "UNIX_TIMESTAMP('2020-01-01 00:24:39') "
+            "- UNIX_TIMESTAMP('2020-01-01 00:23:40')",
+            self._eval(expr),
+        )
+
+        expr = """
+        UNIX_TIMESTAMP("2020-01-01 00:24:39") - UNIX_TIMESTAMP(ts)
+        """
+        self.assertEqual(
+            "UNIX_TIMESTAMP('2020-01-01 00:24:39') - UNIX_TIMESTAMP(`ts`)",
+            self._eval(expr, {"ts": "2020-01-01 00:23:40"}),
+        )
+
+    def test_cast(self):
+        self.assertEqual("CAST('59' AS BYTES)", self._eval('cast("59" AS bytes)'))
+        self.assertEqual("CAST(0.1 AS STRING)", self._eval("CAST(0.1 AS STRING)"))
+        self.assertEqual("CAST('59' AS INTEGER)", self._eval('CAST("59" AS INTEGER)'))
+        self.assertEqual("CAST(`a` AS INTEGER)", self._eval("CAST(a AS INTEGER)"))
+        self.assertEqual("CAST('59' AS BIGINT)", self._eval('CAST("59" AS BIGINT)'))
+        self.assertEqual("CAST('59' AS FLOAT)", self._eval('CAST("59" AS FLOAT)'))
+        self.assertEqual("CAST('59' AS DOUBLE)", self._eval('CAST("59" AS DOUBLE)'))
+        self.assertEqual(
+            "CAST('true' AS BOOLEAN)", self._eval('CAST("true" AS BOOLEAN)')
+        )
+        self.assertEqual("CAST(1 AS BOOLEAN)", self._eval("CAST(1 AS BOOLEAN)"))
+        self.assertEqual(
+            "CAST('false' AS BOOLEAN)", self._eval('CAST("false" AS BOOLEAN)')
+        )
+        self.assertEqual(
+            "CAST('invalid' AS BOOLEAN)", self._eval('CAST("invalid" AS BOOLEAN)')
+        )
+        self.assertEqual(
+            "CAST('2022-01-01 00:00:00.001' AS TIMESTAMP)",
+            self._eval('CAST("2022-01-01 00:00:00.001" AS TIMESTAMP)'),
+        )
+
+        self.assertEqual("TRY_CAST(59 AS STRING)", self._eval("TRY_CAST(59 AS STRING)"))
+
+    def test_logical_op(self):
+        self.assertEqual("false || true", self._eval("false || True"))
+        self.assertEqual("`a` || true", self._eval("a || True"))
+        self.assertEqual("true && false", self._eval("true && FALSE"))

--- a/python/feathub/processors/spark/dataframe_builder/__init__.py
+++ b/python/feathub/processors/spark/dataframe_builder/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/python/feathub/processors/spark/dataframe_builder/source_sink_utils.py
+++ b/python/feathub/processors/spark/dataframe_builder/source_sink_utils.py
@@ -1,0 +1,73 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from concurrent.futures import Executor, Future
+
+from pyspark.sql import DataFrame as NativeSparkDataFrame, SparkSession
+
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
+from feathub.feature_tables.sinks.print_sink import PrintSink
+from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.processors.spark.spark_types_utils import to_spark_struct_type
+
+
+def get_dataframe_from_source(
+    spark_session: SparkSession, source: FeatureTable
+) -> NativeSparkDataFrame:
+    """
+    Get the Spark DataFrame from the given source.
+
+    :param spark_session: The SparkSession where the source table will be created.
+    :param source: The Feature Table describing the source.
+
+    :return: The Spark DataFrame.
+    """
+    if isinstance(source, FileSystemSource):
+        return (
+            spark_session.read.format(source.data_format)
+            .schema(to_spark_struct_type(source.schema))
+            .load(source.path)
+        )
+    else:
+        raise FeathubException(f"Unsupported source type {type(source)}.")
+
+
+def insert_into_sink(
+    executor: Executor,
+    dataframe: NativeSparkDataFrame,
+    sink: FeatureTable,
+) -> Future:
+    """
+    Insert the Spark DataFrame to the given sink. The process would be executed
+    asynchronously by the provided executor.
+
+    :param executor: The executor to handle the execution of Spark jobs
+                     asynchronously.
+    :param dataframe: The Spark DataFrame to be inserted into a sink.
+    :param sink: The FeatureTable describing the sink.
+
+    :return: The Future holding the asynchronously executed Spark job.
+    """
+
+    if isinstance(sink, FileSystemSink):
+        future = executor.submit(
+            dataframe.write.format(sink.data_format).save, path=sink.path
+        )
+    elif isinstance(sink, PrintSink):
+        future = executor.submit(dataframe.show)
+    else:
+        raise FeathubException(f"Unsupported sink type {type(sink)}.")
+
+    return future

--- a/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
+++ b/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
@@ -1,0 +1,143 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Dict, Tuple
+
+from pyspark.sql import DataFrame as NativeSparkDataFrame
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import expr as native_spark_expr
+
+from feathub.common.exceptions import FeathubException
+from feathub.common.types import DType
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature_view import FeatureView
+from feathub.feature_views.transforms.expression_transform import ExpressionTransform
+from feathub.processors.spark.dataframe_builder.source_sink_utils import (
+    get_dataframe_from_source,
+)
+from feathub.processors.spark.dataframe_builder.spark_sql_expr_utils import (
+    to_spark_sql_expr,
+)
+from feathub.processors.spark.spark_types_utils import (
+    to_spark_type,
+)
+from feathub.registries.registry import Registry
+from feathub.table.table_descriptor import TableDescriptor
+
+
+class SparkDataFrameBuilder:
+    """SparkDataFrameBuilder is used to convert Feathub feature to a Spark DataFrame."""
+
+    def __init__(self, spark_session: SparkSession, registry: Registry):
+        """
+        Instantiate the SparkDataFrameBuilder.
+
+        :param spark_session: The SparkSession where the DataFrames are created.
+        """
+        self._spark_session = spark_session
+        self._registry = registry
+
+        self._built_dataframes: Dict[
+            str, Tuple[TableDescriptor, NativeSparkDataFrame]
+        ] = {}
+
+    def build(
+        self,
+        features: TableDescriptor,
+    ) -> NativeSparkDataFrame:
+        """
+        Convert the given features to native Spark DataFrame.
+
+        If the given features is a FeatureView, it must be resolved, otherwise
+        exception will be thrown.
+
+        :param features: The feature to convert to Spark DataFrame.
+        :return: The native Spark DataFrame that represents the given features.
+        """
+
+        if isinstance(features, FeatureView) and features.is_unresolved():
+            raise FeathubException(
+                "Trying to convert an unresolved FeatureView to native Spark DataFrame."
+            )
+
+        dataframe = self._get_spark_dataframe(features)
+
+        self._built_dataframes.clear()
+
+        return dataframe
+
+    def _get_spark_dataframe(self, features: TableDescriptor) -> NativeSparkDataFrame:
+        if features.name in self._built_dataframes:
+            if features != self._built_dataframes[features.name][0]:
+                raise FeathubException(
+                    f"Encounter different TableDescriptor with same name. {features} "
+                    f"and {self._built_dataframes[features.name][0]}."
+                )
+            return self._built_dataframes[features.name][1]
+
+        if isinstance(features, FeatureTable):
+            spark_dataframe = get_dataframe_from_source(self._spark_session, features)
+        elif isinstance(features, DerivedFeatureView):
+            spark_dataframe = self._get_dataframe_from_derived_feature_view(features)
+        else:
+            raise FeathubException(
+                f"Unsupported type '{type(features).__name__}' for '{features}'."
+            )
+
+        self._built_dataframes[features.name] = (features, spark_dataframe)
+
+        return spark_dataframe
+
+    def _get_dataframe_from_derived_feature_view(
+        self, feature_view: DerivedFeatureView
+    ) -> NativeSparkDataFrame:
+        tmp_dataframe = self._get_spark_dataframe(feature_view.get_resolved_source())
+
+        dependent_features = []
+        for feature in feature_view.get_resolved_features():
+            for input_feature in feature.input_features:
+                if input_feature not in dependent_features:
+                    dependent_features.append(input_feature)
+            if feature not in dependent_features:
+                dependent_features.append(feature)
+
+        for feature in dependent_features:
+            if isinstance(feature.transform, ExpressionTransform):
+                tmp_dataframe = self._evaluate_expression_transform(
+                    tmp_dataframe,
+                    feature.transform,
+                    feature.name,
+                    feature.dtype,
+                )
+            else:
+                raise RuntimeError(
+                    f"Unsupported transformation type "
+                    f"{type(feature.transform).__name__} for feature {feature.name}."
+                )
+
+        return tmp_dataframe
+
+    @staticmethod
+    def _evaluate_expression_transform(
+        source_dataframe: NativeSparkDataFrame,
+        transform: ExpressionTransform,
+        result_field_name: str,
+        result_type: DType,
+    ) -> NativeSparkDataFrame:
+        spark_sql_expr = to_spark_sql_expr(transform.expr)
+        result_spark_type = to_spark_type(result_type)
+
+        return source_dataframe.withColumn(
+            result_field_name, native_spark_expr(spark_sql_expr).cast(result_spark_type)
+        )

--- a/python/feathub/processors/spark/dataframe_builder/spark_sql_expr_utils.py
+++ b/python/feathub/processors/spark/dataframe_builder/spark_sql_expr_utils.py
@@ -1,0 +1,30 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import logging
+
+from feathub.dsl.expr_parser import ExprParser
+from feathub.processors.spark.ast_evaluator.spark_ast_evaluator import SparkAstEvaluator
+
+_parser = ExprParser()
+_ast_evaluator = SparkAstEvaluator()
+
+logger = logging.getLogger(__file__)
+
+
+def to_spark_sql_expr(feathub_expr: str) -> str:
+    logger.debug(f"Parsing Feathub expr: {feathub_expr}")
+    ast = _parser.parse(feathub_expr)
+    spark_sql_expr = _ast_evaluator.eval(ast, {})
+    logger.debug(f"Result Spark Sql expr: {spark_sql_expr}")
+    return spark_sql_expr

--- a/python/feathub/processors/spark/spark_job.py
+++ b/python/feathub/processors/spark/spark_job.py
@@ -1,0 +1,50 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from concurrent.futures import Future
+from typing import Optional, Callable
+
+from feathub.processors.processor_job import ProcessorJob
+
+
+class SparkJob(ProcessorJob):
+    """Represent a Spark job."""
+
+    def __init__(
+        self,
+        job_future: Future,
+    ) -> None:
+        super().__init__()
+        self._job_future = job_future
+
+    # TODO: Add test case to verify this method's behavior when job future
+    #  is completed exceptionally.
+    def cancel(self) -> Future:
+        cancel_future: Future = Future()
+        job_future_callback = self._get_job_future_callback(cancel_future)
+        self._job_future.add_done_callback(job_future_callback)
+        return cancel_future
+
+    def wait(self, timeout_ms: Optional[int] = None) -> None:
+        timeout_sec = None if timeout_ms is None else timeout_ms / 1000
+        self._job_future.result(timeout=timeout_sec)
+
+    @staticmethod
+    def _get_job_future_callback(cancel_future: Future) -> Callable[[Future], None]:
+        def job_future_callback(job_future: Future) -> None:
+            if job_future.cancelled() or job_future.exception() is None:
+                cancel_future.set_result(None)
+            else:
+                cancel_future.set_exception(job_future.exception())
+
+        return job_future_callback

--- a/python/feathub/processors/spark/spark_processor.py
+++ b/python/feathub/processors/spark/spark_processor.py
@@ -1,0 +1,141 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta, datetime
+from typing import Union, Optional, Dict
+
+import pandas as pd
+from pyspark.sql import DataFrame as NativeSparkDataFrame
+from pyspark.sql import SparkSession
+
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_views.feature_view import FeatureView
+from feathub.processors.processor import Processor
+from feathub.processors.spark.dataframe_builder.source_sink_utils import (
+    insert_into_sink,
+)
+from feathub.processors.spark.dataframe_builder.spark_dataframe_builder import (
+    SparkDataFrameBuilder,
+)
+from feathub.processors.spark.spark_job import SparkJob
+from feathub.processors.spark.spark_processor_config import (
+    SparkProcessorConfig,
+    MASTER_CONFIG,
+)
+from feathub.processors.spark.spark_table import SparkTable
+from feathub.registries.registry import Registry
+from feathub.table.table_descriptor import TableDescriptor
+
+
+class SparkProcessor(Processor):
+    """
+    The SparkProcessor does feature ETL using Spark as the processing engine.
+
+    In the following we describe the keys accepted by the `config` dict passed to the
+    SparkProcessor constructor.
+
+    master: The Spark master URL to connect to.
+    """
+
+    def __init__(self, props: Dict, registry: Registry):
+        """
+        Instantiate the SparkProcessor.
+
+        :param props: The processor properties.
+        :param registry: An entity registry.
+        """
+        super().__init__()
+        self._registry = registry
+
+        config = SparkProcessorConfig(props)
+
+        spark_session = SparkSession.builder.master(
+            config.get(MASTER_CONFIG)
+        ).getOrCreate()
+
+        self._dataframe_builder = SparkDataFrameBuilder(spark_session, self._registry)
+
+        self._executor = ThreadPoolExecutor()
+
+    def get_table(
+        self,
+        features: Union[str, TableDescriptor],
+        keys: Union[pd.DataFrame, TableDescriptor, None] = None,
+        start_datetime: Optional[datetime] = None,
+        end_datetime: Optional[datetime] = None,
+    ) -> SparkTable:
+        if keys is not None:
+            # TODO: Add support for keys after Spark processor supports join transform.
+            raise FeathubException(
+                "Spark processor does not support features with keys."
+            )
+
+        if start_datetime is not None or end_datetime is not None:
+            # TODO: Add support for timestamp and watermark with window transform.
+            raise FeathubException(
+                "Spark processor does not support filtering features with "
+                "start/end datetime."
+            )
+
+        features = self._resolve_table_descriptor(features)
+
+        return SparkTable(
+            feature=features,
+            spark_processor=self,
+        )
+
+    def materialize_features(
+        self,
+        features: Union[str, TableDescriptor],
+        sink: FeatureTable,
+        ttl: Optional[timedelta] = None,
+        start_datetime: Optional[datetime] = None,
+        end_datetime: Optional[datetime] = None,
+        allow_overwrite: bool = False,
+    ) -> SparkJob:
+        if ttl is not None:
+            # TODO: Add support for sinks with ttl.
+            raise FeathubException(
+                "Spark processor does not support inserting features with ttl."
+            )
+
+        if allow_overwrite:
+            # TODO: Add support for sinks that allow overwrite.
+            raise FeathubException(
+                "Spark processor does not support overwriting features."
+            )
+
+        resolved_features = self._resolve_table_descriptor(features)
+
+        dataframe = self.get_spark_dataframe(resolved_features)
+
+        future = insert_into_sink(
+            executor=self._executor, dataframe=dataframe, sink=sink
+        )
+
+        return SparkJob(future)
+
+    def _resolve_table_descriptor(
+        self, features: Union[str, TableDescriptor]
+    ) -> TableDescriptor:
+        if isinstance(features, str):
+            features = self._registry.get_features(name=features)
+        elif isinstance(features, FeatureView) and features.is_unresolved():
+            features = self._registry.get_features(name=features.name)
+
+        return features
+
+    def get_spark_dataframe(self, feature: TableDescriptor) -> NativeSparkDataFrame:
+        return self._dataframe_builder.build(feature)

--- a/python/feathub/processors/spark/spark_processor_config.py
+++ b/python/feathub/processors/spark/spark_processor_config.py
@@ -1,0 +1,34 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import List, Dict, Any
+
+from feathub.common.config import ConfigDef, BaseConfig
+
+MASTER_CONFIG = "processor.spark.master"
+MASTER_DOC = "The Spark master URL to connect to."
+
+# TODO: Add a validator class that are used to validate the legality of
+#  configuration values, and validate that spark master is not None.
+spark_processor_config_defs: List[ConfigDef] = [
+    ConfigDef(
+        name=MASTER_CONFIG,
+        value_type=str,
+        description=MASTER_DOC,
+    ),
+]
+
+
+class SparkProcessorConfig(BaseConfig):
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(spark_processor_config_defs, props)

--- a/python/feathub/processors/spark/spark_table.py
+++ b/python/feathub/processors/spark/spark_table.py
@@ -1,0 +1,95 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import typing
+from datetime import timedelta
+from typing import Optional
+
+import pandas as pd
+
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.feature_table import FeatureTable
+from feathub.processors.spark.spark_job import SparkJob
+from feathub.processors.spark.spark_types_utils import (
+    to_feathub_schema,
+)
+from feathub.table.schema import Schema
+from feathub.table.table import Table
+from feathub.table.table_descriptor import TableDescriptor
+
+if typing.TYPE_CHECKING:
+    from feathub.processors.spark.spark_processor import SparkProcessor
+
+
+class SparkTable(Table):
+    """
+    The implementation of Feathub Table for Spark.
+
+    It can only be instantiated and processed by SparkProcessor. It converts the feature
+    to native Spark DataFrame internally with the SparkDataFrameBuilder.
+    """
+
+    def __init__(
+        self,
+        feature: TableDescriptor,
+        spark_processor: "SparkProcessor",
+    ) -> None:
+        """
+        Instantiate the SparkTable.
+
+        :param feature: Describes the features to be included in the table. If it is a
+                        FeatureView, it must be resolved.
+        :param spark_processor: The spark processor to materialize features.
+        """
+        super().__init__(feature.timestamp_field, feature.timestamp_format)
+        self._feature = feature
+        self._spark_processor = spark_processor
+
+    def get_schema(self) -> Schema:
+        return to_feathub_schema(
+            self._spark_processor.get_spark_dataframe(self._feature).schema
+        )
+
+    def to_pandas(self, force_bounded: bool = False) -> pd.DataFrame:
+        feature = self._feature
+        if not feature.is_bounded():
+            if not force_bounded:
+                raise FeathubException(
+                    "Unbounded table cannot be converted to Pandas DataFrame. You can "
+                    "set force_bounded to True to convert the Table to DataFrame."
+                )
+            feature = feature.get_bounded_view()
+
+        dataframe = self._spark_processor.get_spark_dataframe(feature)
+
+        return dataframe.toPandas()
+
+    def execute_insert(
+        self,
+        sink: FeatureTable,
+        ttl: Optional[timedelta] = None,
+        allow_overwrite: bool = False,
+    ) -> SparkJob:
+        return self._spark_processor.materialize_features(
+            features=self._feature,
+            sink=sink,
+            ttl=ttl,
+            allow_overwrite=allow_overwrite,
+        )
+
+    def __eq__(self, other: typing.Any) -> bool:
+        return (
+            isinstance(other, SparkTable)
+            and self._feature == other._feature
+            and self._spark_processor == other._spark_processor
+        )

--- a/python/feathub/processors/spark/spark_types_utils.py
+++ b/python/feathub/processors/spark/spark_types_utils.py
@@ -1,0 +1,165 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict, Type
+
+from pyspark.sql import types as native_spark_types
+
+from feathub.common.exceptions import FeathubTypeException
+from feathub.common import types
+from feathub.table.schema import Schema
+
+type_mapping: Dict[types.BasicDType, native_spark_types.AtomicType] = {
+    types.BasicDType.BYTES: native_spark_types.BinaryType(),
+    types.BasicDType.STRING: native_spark_types.StringType(),
+    types.BasicDType.INT32: native_spark_types.IntegerType(),
+    types.BasicDType.INT64: native_spark_types.LongType(),
+    types.BasicDType.FLOAT32: native_spark_types.FloatType(),
+    types.BasicDType.FLOAT64: native_spark_types.DoubleType(),
+    types.BasicDType.BOOL: native_spark_types.BooleanType(),
+    types.BasicDType.TIMESTAMP: native_spark_types.TimestampType(),
+}
+
+inverse_type_mapping: Dict[Type[native_spark_types.AtomicType], types.BasicDType] = {
+    type(atomic_type): basic_type for basic_type, atomic_type in type_mapping.items()
+}
+
+
+def to_spark_struct_type(schema: Schema) -> native_spark_types.StructType:
+    """
+    Convert Feathub schema to native Spark StructType.
+
+    :param schema: The Feathub schema.
+    :return: The native Spark StructType.
+    """
+
+    fields = [
+        native_spark_types.StructField(field_name, to_spark_type(field_type))
+        for field_name, field_type in zip(schema.field_names, schema.field_types)
+    ]
+
+    return native_spark_types.StructType(fields)
+
+
+def to_feathub_schema(struct_type: native_spark_types.StructType) -> Schema:
+    """
+    Convert Spark StructType to Feathub schema.
+
+    :param struct_type: The Spark StructType.
+    :return: The Feathub schema.
+    """
+
+    field_names = []
+    field_types = []
+    for field in struct_type.fields:
+        field_names.append(field.name)
+        field_types.append(to_feathub_type(field.dataType))
+    return Schema(field_names, field_types)
+
+
+def to_spark_type(feathub_type: types.DType) -> native_spark_types.DataType:
+    """
+    Convert Feathub DType to Spark DataType.
+
+    :param feathub_type: The Feathub DType.
+    :return: The Spark DataType.
+    """
+    if isinstance(feathub_type, types.BasicDType):
+        return _basic_type_to_spark_type(feathub_type)
+    elif isinstance(feathub_type, types.PrimitiveType):
+        return _primitive_type_to_spark_type(feathub_type)
+    elif isinstance(feathub_type, types.VectorType):
+        return _vector_type_to_spark_type(feathub_type)
+    elif isinstance(feathub_type, types.MapType):
+        return _map_type_to_spark_type(feathub_type)
+
+    raise FeathubTypeException(
+        f"Type {feathub_type} is not supported by SparkProcessor."
+    )
+
+
+def to_feathub_type(spark_type: native_spark_types.DataType) -> types.DType:
+    """
+    Convert Spark DataType to Feathub DType.
+
+    :param spark_type: The Spark DataType.
+    :return: The Feathub DType.
+    """
+    if isinstance(spark_type, native_spark_types.AtomicType):
+        return _atomic_type_to_feathub_type(spark_type)
+    elif isinstance(spark_type, native_spark_types.ArrayType):
+        return _array_type_to_feathub_type(spark_type)
+    elif isinstance(spark_type, native_spark_types.MapType):
+        return _map_type_to_feathub_type(spark_type)
+
+    raise FeathubTypeException(f"Spark type {spark_type} is not supported by Feathub.")
+
+
+def _primitive_type_to_spark_type(
+    feathub_type: types.PrimitiveType,
+) -> native_spark_types.DataType:
+    return _basic_type_to_spark_type(feathub_type.basic_dtype)
+
+
+def _vector_type_to_spark_type(
+    feathub_type: types.VectorType,
+) -> native_spark_types.DataType:
+    return native_spark_types.ArrayType(to_spark_type(feathub_type.dtype))
+
+
+def _map_type_to_spark_type(feathub_type: types.MapType) -> native_spark_types.MapType:
+    return native_spark_types.MapType(
+        to_spark_type(feathub_type.key_dtype),
+        to_spark_type(feathub_type.value_dtype),
+    )
+
+
+def _basic_type_to_spark_type(
+    basic_type: types.BasicDType,
+) -> native_spark_types.AtomicType:
+    if basic_type not in type_mapping:
+        raise FeathubTypeException(
+            f"Type {basic_type} is not supported by SparkProcessor."
+        )
+    return type_mapping[basic_type]
+
+
+def _atomic_type_to_feathub_type(
+    spark_type: native_spark_types.AtomicType,
+) -> types.DType:
+    return types.PrimitiveType(_atomic_type_to_basic_type(spark_type))
+
+
+def _array_type_to_feathub_type(
+    spark_type: native_spark_types.ArrayType,
+) -> types.DType:
+    element_type = spark_type.elementType
+    if not isinstance(element_type, native_spark_types.AtomicType):
+        raise FeathubTypeException(f"Unexpected element type {element_type}.")
+    return types.VectorType(to_feathub_type(element_type))
+
+
+def _atomic_type_to_basic_type(
+    spark_type: native_spark_types.AtomicType,
+) -> types.BasicDType:
+    if type(spark_type) not in inverse_type_mapping:
+        raise FeathubTypeException(
+            f"Spark type {spark_type} is not supported by Feathub."
+        )
+    return inverse_type_mapping[type(spark_type)]
+
+
+def _map_type_to_feathub_type(spark_type: native_spark_types.MapType) -> types.DType:
+    return types.MapType(
+        to_feathub_type(spark_type.keyType), to_feathub_type(spark_type.valueType)
+    )

--- a/python/feathub/processors/spark/tests/__init__.py
+++ b/python/feathub/processors/spark/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/feathub/processors/spark/tests/spark_test_utils.py
+++ b/python/feathub/processors/spark/tests/spark_test_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import shutil
+import tempfile
+import unittest
+from typing import Optional, List
+
+import pandas as pd
+
+from feathub.common import types
+from feathub.common.types import from_numpy_dtype
+from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.online_stores.memory_online_store import MemoryOnlineStore
+from feathub.registries.local_registry import LocalRegistry
+from feathub.table.schema import Schema
+
+
+class SparkProcessorTestBase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+        self.registry = LocalRegistry(props={})
+
+        self.input_data = pd.DataFrame(
+            [
+                ["Alex", 100, 100, "2022-01-01 08:01:00"],
+                ["Emma", 400, 250, "2022-01-01 08:02:00"],
+                ["Alex", 300, 200, "2022-01-02 08:03:00"],
+                ["Emma", 200, 250, "2022-01-02 08:04:00"],
+                ["Jack", 500, 500, "2022-01-03 08:05:00"],
+                ["Alex", 600, 800, "2022-01-03 08:06:00"],
+            ],
+            columns=["name", "cost", "distance", "time"],
+        )
+
+        self.schema = (
+            Schema.new_builder()
+            .column("name", types.String)
+            .column("cost", types.Int32)
+            .column("distance", types.Int32)
+            .column("time", types.String)
+            .build()
+        )
+
+    def tearDown(self) -> None:
+        MemoryOnlineStore.get_instance().reset()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # TODO: Add a python package to provide utility methods like this
+    #  for all Feathub processor test cases.
+    def _create_file_source(
+        self,
+        df: pd.DataFrame,
+        keys: Optional[List[str]] = None,
+        schema: Schema = None,
+        timestamp_field: str = "time",
+        timestamp_format: str = "%Y-%m-%d %H:%M:%S",
+    ) -> FileSystemSource:
+        path = tempfile.NamedTemporaryFile(dir=self.temp_dir).name
+        if schema is None:
+            schema = Schema(
+                field_names=df.keys().tolist(),
+                field_types=[from_numpy_dtype(dtype) for dtype in df.dtypes],
+            )
+        df.to_csv(path, index=False, header=False)
+
+        return FileSystemSource(
+            name="source",
+            path=path,
+            data_format="csv",
+            schema=schema,
+            keys=keys,
+            timestamp_field=timestamp_field,
+            timestamp_format=timestamp_format,
+        )

--- a/python/feathub/processors/spark/tests/test_spark_derived_feature_view.py
+++ b/python/feathub/processors/spark/tests/test_spark_derived_feature_view.py
@@ -1,0 +1,66 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from feathub.processors.spark.spark_processor import SparkProcessor
+
+from feathub.common.types import Float64
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature import Feature
+from feathub.processors.spark.tests.spark_test_utils import SparkProcessorTestBase
+
+
+class SparkDerivedFeatureViewTest(SparkProcessorTestBase):
+    def test_derived_feature_view(self):
+        processor = SparkProcessor(
+            props={"processor.spark.master": "local[1]"},
+            registry=self.registry,
+        )
+
+        source = self._create_file_source(self.input_data.copy(), schema=self.schema)
+
+        f_cost_per_mile = Feature(
+            name="cost_per_mile",
+            dtype=Float64,
+            transform="CAST(cost AS DOUBLE) / CAST(distance AS DOUBLE) + 10",
+        )
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                f_cost_per_mile,
+            ],
+            keep_source_fields=False,
+        )
+
+        result_df = (
+            processor.get_table(features)
+            .to_pandas()
+            .sort_values(by=["name", "time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = self.input_data
+        expected_result_df["cost_per_mile"] = expected_result_df.apply(
+            lambda row: row["cost"] / row["distance"] + 10, axis=1
+        )
+        expected_result_df = expected_result_df.sort_values(
+            by=["name", "time"]
+        ).reset_index(drop=True)
+        expected_result_df["cost"] = expected_result_df["cost"].astype("int32")
+        expected_result_df["distance"] = expected_result_df["distance"].astype("int32")
+
+        self.assertIsNone(source.keys)
+        self.assertIsNone(features.keys)
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -1,0 +1,48 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import tempfile
+
+import pandas as pd
+
+from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
+from feathub.processors.spark.spark_processor import SparkProcessor
+from feathub.processors.spark.tests.spark_test_utils import SparkProcessorTestBase
+
+
+class SparkProcessorTest(SparkProcessorTestBase):
+    def test_materialize_features(self) -> None:
+        processor = SparkProcessor(
+            props={"processor.spark.master": "local[1]"},
+            registry=self.registry,
+        )
+
+        source = self._create_file_source(self.input_data, schema=self.schema)
+
+        sink_path = tempfile.NamedTemporaryFile(dir=self.temp_dir).name
+
+        sink = FileSystemSink(sink_path, "csv")
+
+        processor.materialize_features(
+            features=source,
+            sink=sink,
+        ).wait()
+
+        files = glob.glob(f"{sink_path}/*.csv")
+        df = pd.DataFrame()
+        for f in files:
+            csv = pd.read_csv(f, names=["name", "cost", "distance", "time"])
+            df = df.append(csv)
+        df = df.sort_values(by=["time"]).reset_index(drop=True)
+        self.assertTrue(self.input_data.equals(df))

--- a/python/feathub/processors/spark/tests/test_spark_type_utils.py
+++ b/python/feathub/processors/spark/tests/test_spark_type_utils.py
@@ -1,0 +1,78 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from typing import Dict
+
+from pyspark.sql import types as native_spark_types
+
+from feathub.common.exceptions import FeathubTypeException
+from feathub.common import types
+from feathub.processors.spark.spark_types_utils import (
+    to_spark_struct_type,
+    to_feathub_schema,
+    to_feathub_type,
+    to_spark_type,
+)
+from feathub.table.schema import Schema
+
+
+class SparkTypeUtilsTest(unittest.TestCase):
+    def test_schema_conversion(self):
+        field_names = [
+            "bytes",
+            "string",
+            "int32",
+            "int64",
+            "float32",
+            "float64",
+            "bool",
+            "int32vector",
+            "map",
+        ]
+        field_types = [
+            types.Bytes,
+            types.String,
+            types.Int32,
+            types.Int64,
+            types.Float32,
+            types.Float64,
+            types.Bool,
+            types.Int32Vector,
+            types.MapType(types.String, types.Int64),
+        ]
+        schema = Schema(field_names, field_types)
+
+        self.assertEqual(schema, to_feathub_schema(to_spark_struct_type(schema)))
+
+    def test_unsupported_spark_type_throw_exception(self):
+        byte_type = native_spark_types.ByteType()
+        with self.assertRaises(FeathubTypeException):
+            to_feathub_type(byte_type)
+
+        nested_array = native_spark_types.ArrayType(
+            native_spark_types.ArrayType(native_spark_types.IntegerType())
+        )
+        with self.assertRaises(FeathubTypeException):
+            to_feathub_type(nested_array)
+
+    def test_unsupported_feathub_type_throw_exception(self):
+        with self.assertRaises(FeathubTypeException):
+            to_spark_type(types.Unknown)
+
+        class InvalidType(types.DType):
+            def to_json(self) -> Dict:
+                return {}
+
+        with self.assertRaises(FeathubTypeException):
+            to_spark_type(InvalidType())

--- a/python/setup.py
+++ b/python/setup.py
@@ -132,11 +132,19 @@ try:
         "ply>=3.11",
         "pandas>=1.1.5",
         "numpy>=1.14.3,<1.20",
-        "apache-flink==1.15.2",
         "kubernetes~=24.2",
         "protobuf~=3.17.3",
         "redis==4.3.0",
     ]
+
+    extras_require = {
+        "flink": [
+            "apache-flink==1.15.2",
+        ],
+        "spark": [
+            "pyspark==3.3.1",
+        ],
+    }
 
     setup(
         name=PACKAGE_NAME,
@@ -162,6 +170,7 @@ try:
         author="Feathub Authors",
         python_requires=">=3.6",
         install_requires=install_requires,
+        extras_require=extras_require,
         tests_require=["pytest==4.4.1"],
         zip_safe=True,
     )

--- a/tools/ci/run-examples.sh
+++ b/tools/ci/run-examples.sh
@@ -25,7 +25,10 @@ FLINK_VERSION=1.15.2
 
 cd "${PROJECT_DIR}"
 
-python -m pip install ./wheels/*
+wheel_files=`ls ./wheels/*`
+wheel_file=${wheel_files[0]}
+python -m pip install "${wheel_file}"
+python -m pip install "${wheel_file}[flink]"
 
 echo "Running local processor quickstart."
 python python/feathub/examples/nyc_taxi.py
@@ -59,3 +62,5 @@ done
 
 echo "Stopping standalone Flink cluster."
 ./flink-"${FLINK_VERSION}"/bin/stop-cluster.sh
+
+# TODO: Add execution for Spark processor quickstart


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces Spark Processor along with its ExpressionTransform and DerivedFeatureView.

## Brief change log

- Add the basic framework for Spark Processor.
- Add local filesystem source/sink and print sink for Spark Processor.
- Add `ExpressionTransform` and `DerivedFeatureView` for Spark Processor.
- Modify the setup process of Feathub such that Flink/Spark processor can be optionally installed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs