### PR TITLE
Fix FlinkProcessor IT failures by reorg file structure

### DIFF
--- a/python/feathub/feature_tables/tests/test_kafka_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_kafka_source_sink.py
@@ -54,6 +54,17 @@ class KafkaSourceTest(unittest.TestCase):
 class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
     kafka_container = None
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.kafka_container = KafkaContainer()
+        cls.kafka_container.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.kafka_container.stop()
+
     def test_kafka_source_sink(self):
         input_data = pd.DataFrame(
             [
@@ -77,7 +88,7 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         # Consume data with kafka source
         source = KafkaSource(
             "kafka_source",
-            bootstrap_server=self._get_kafka_bootstrap_servers(),
+            bootstrap_server=self.kafka_container.get_bootstrap_server(),
             topic=topic_name,
             key_format="json",
             value_format="json",
@@ -125,7 +136,7 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         # Consume data with kafka source
         source = KafkaSource(
             "kafka_source",
-            bootstrap_server=self._get_kafka_bootstrap_servers(),
+            bootstrap_server=self.kafka_container.get_bootstrap_server(),
             topic=topic_name,
             key_format="json",
             value_format="json",
@@ -155,19 +166,6 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         )
         self.assertTrue(expected_result_df.equals(result_df))
 
-    @classmethod
-    def _get_kafka_bootstrap_servers(cls):
-        if cls.kafka_container is None:
-            cls.kafka_container = KafkaContainer()
-            cls.kafka_container.start()
-        return cls.kafka_container.get_bootstrap_server()
-
-    @classmethod
-    def _tear_down_kafka(cls) -> None:
-        if cls.kafka_container is not None:
-            cls.kafka_container.stop()
-            cls.kafka_container = None
-
     def _produce_data_to_kafka(self, input_data: pd.DataFrame, schema: Schema):
         source = self.create_file_source(
             input_data,
@@ -180,7 +178,7 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         topic_name = self.generate_random_name("kafka")
 
         sink = KafkaSink(
-            bootstrap_server=self._get_kafka_bootstrap_servers(),
+            bootstrap_server=self.kafka_container.get_bootstrap_server(),
             topic=topic_name,
             key_format="json",
             value_format="json",

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -43,6 +43,20 @@ class LocalProcessorITTest(
 ):
     __test__ = True
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.invoke_all_base_class_setupclass()
+
+    def setUp(self):
+        self.invoke_base_class_setup()
+
+    def tearDown(self) -> None:
+        self.invoke_base_class_teardown()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.invoke_all_base_class_teardownclass()
+
     def get_client(self) -> FeathubClient:
         return self.get_local_client(
             {

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -38,6 +38,20 @@ class SparkProcessorITTest(
 ):
     __test__ = True
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.invoke_all_base_class_setupclass()
+
+    def setUp(self):
+        self.invoke_base_class_setup()
+
+    def tearDown(self) -> None:
+        self.invoke_base_class_teardown()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.invoke_all_base_class_teardownclass()
+
     def get_client(self) -> FeathubClient:
         return self.get_local_client(
             {


### PR DESCRIPTION
## What is the purpose of the change

This pull request mainly provides a temporary fix for the failures in FlinkProcessor's integration tests.

## Brief change log

- Moves `test_flink_processor.py` from `python/feathub/processors/flink/tests` to `python/feathub/processors/flink/table_builder/tests`
- Moves `test_redis_client.py` from `python/feathub/online_stores/tests` to `python/feathub/processors/flink/tests`
- Adds cleanup of java gateway in `test_redis_client.py`.
- Removes `GetFeaturesITTest` from `FlinkProcessorITTest`
  - flink processor has not been tested against these test cases before commit 34fad8.
- Moves container setup/teardown process to `setUpClass()`/`tearDownClass()` methods in kafka and redis it test class.
- Makes `xxxProcessorITTest` executes base class's `setUp()`/`tearDown()`/`setUpClass()`/`tearDownClass()` methods.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable