### PR TITLE
Add DataGenSource and BlackHoleSink for SparkProcessor

### DIFF
--- a/python/feathub/feature_tables/tests/test_datagen_source.py
+++ b/python/feathub/feature_tables/tests/test_datagen_source.py
@@ -13,9 +13,20 @@
 #  limitations under the License.
 import unittest
 from abc import ABC
+from datetime import timedelta
 from typing import cast
 
-from feathub.common.types import Int32, Timestamp, Int64
+from feathub.common.types import (
+    Int32,
+    Timestamp,
+    Int64,
+    String,
+    Bool,
+    Float32,
+    Float64,
+    VectorType,
+    MapType,
+)
 from feathub.feature_tables.sources.datagen_source import (
     DataGenSource,
     RandomField,
@@ -72,6 +83,24 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
     def test_data_gen_source(self):
         source = DataGenSource(
             name="datagen_src",
+            number_of_rows=10,
+            field_configs={
+                "id": SequenceField(start=0, end=9),
+                "val": RandomField(minimum=0, maximum=100),
+            },
+            schema=Schema(["id", "val", "ts"], [Int32, Int32, Timestamp]),
+            timestamp_field="ts",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(10, df.shape[0])
+        self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
+
+    def test_num_of_rows_not_set(self):
+        source = DataGenSource(
+            name="datagen_src",
             rows_per_second=10,
             field_configs={
                 "id": SequenceField(start=0, end=9),
@@ -86,3 +115,114 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
+
+    def test_num_of_rows_larger_than_sequence_field_size(self):
+        source = DataGenSource(
+            name="datagen_src",
+            number_of_rows=100,
+            field_configs={
+                "id": SequenceField(start=0, end=9),
+                "val": RandomField(minimum=0, maximum=100),
+            },
+            schema=Schema(["id", "val", "ts"], [Int32, Int32, Timestamp]),
+            timestamp_field="ts",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(10, df.shape[0])
+        self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
+
+    def test_num_of_rows_smaller_than_sequence_field_size(self):
+        source = DataGenSource(
+            name="datagen_src",
+            number_of_rows=10,
+            field_configs={
+                "id": SequenceField(start=0, end=99),
+                "val": RandomField(minimum=0, maximum=100),
+            },
+            schema=Schema(["id", "val", "ts"], [Int32, Int32, Timestamp]),
+            timestamp_field="ts",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(10, df.shape[0])
+        self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
+
+    # TODO: Unify the naming of test cases in FeathubITTestBase's child classes,
+    #  so that when xxxProcessorITTest multi-inherit these child classes, test
+    #  methods would not have their names collide and override each other.
+    def test_all_supported_data_and_field_types(self):
+        source = DataGenSource(
+            name="datagen_src",
+            number_of_rows=10,
+            field_configs={
+                "sequence_int32_value": SequenceField(start=0, end=9),
+                "sequence_int64_value": SequenceField(start=0, end=9),
+                "sequence_float32_value": SequenceField(start=0, end=9),
+                "sequence_float64_value": SequenceField(start=0, end=9),
+                "sequence_string_value": SequenceField(start=0, end=9),
+            },
+            schema=(
+                Schema.new_builder()
+                .column("random_string_value", String)
+                .column("random_bool_value", Bool)
+                .column("random_int32_value", Int32)
+                .column("random_int64_value", Int64)
+                .column("random_float32_value", Float32)
+                .column("random_float64_value", Float64)
+                .column("random_timestamp_value", Timestamp)
+                .column("random_vector_value", VectorType(Int64))
+                .column("random_map_value", MapType(Int64, String))
+                .column("sequence_int32_value", Int32)
+                .column("sequence_int64_value", Int64)
+                .column("sequence_float32_value", Float32)
+                .column("sequence_float64_value", Float64)
+                .column("sequence_string_value", String)
+                .build()
+            ),
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(10, df.shape[0])
+
+    def test_random_field_max_past(self):
+        source = DataGenSource(
+            name="datagen_src",
+            rows_per_second=1000,
+            field_configs={
+                "id": SequenceField(start=0, end=999),
+                "ts": RandomField(max_past=timedelta(seconds=1)),
+            },
+            schema=Schema(["id", "ts"], [Int32, Timestamp]),
+            timestamp_field="ts",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(1000, df.shape[0])
+        self.assertTrue((df["ts"].max() - df["ts"].min()) <= timedelta(seconds=1))
+
+    def test_random_field_length(self):
+        source = DataGenSource(
+            name="datagen_src",
+            number_of_rows=10,
+            field_configs={
+                "string_value": RandomField(length=101),
+                "vector_value": RandomField(length=101),
+            },
+            schema=Schema(
+                ["string_value", "vector_value"], [String, VectorType(Int64)]
+            ),
+        )
+
+        df = self.client.get_features(features=source).to_pandas()
+
+        self.assertEquals(10, df.shape[0])
+        self.assertTrue((df["string_value"].str.len() == 101).all())
+        self.assertTrue((df["vector_value"].str.len() == 101).all())

--- a/python/feathub/processors/flink/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/tests/test_flink_processor.py
@@ -600,3 +600,9 @@ class FlinkProcessorITTest(
 
     def test_over_window_transform_value_counts(self):
         pass
+
+    def test_random_field_max_past(self):
+        pass
+
+    def test_random_field_length(self):
+        pass

--- a/python/feathub/processors/spark/dataframe_builder/datagen_utils.py
+++ b/python/feathub/processors/spark/dataframe_builder/datagen_utils.py
@@ -1,0 +1,156 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import random
+import string
+from datetime import datetime, timedelta
+from typing import Callable, Any, List, Union
+
+import numpy as np
+from pyspark.sql import DataFrame as NativeSparkDataFrame, SparkSession
+from pyspark.sql.functions import udf, col
+
+from feathub.common import types
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.sources.datagen_source import (
+    DataGenSource,
+    RandomField,
+    SequenceField,
+)
+from feathub.processors.spark.spark_types_utils import to_spark_type
+
+
+def _generate_random_field_name(occupied_field_names: List[str]) -> str:
+    prefix = "seed"
+    affix = 0
+    while True:
+        field_name = prefix + str(affix)
+        if field_name in occupied_field_names:
+            affix += 1
+            continue
+        return field_name
+
+
+def _get_udf_mapping(
+    field_type: types.DType, field_config: Union[RandomField, SequenceField]
+) -> Callable[[int], Any]:
+    if isinstance(field_config, SequenceField):
+        offset = field_config.start
+        if field_type == types.Int64 or field_type == types.Int32:
+            return lambda x: x + offset
+        elif field_type == types.Float64 or field_type == types.Float32:
+            return lambda x: float(x + offset)
+        elif field_type == types.String:
+            return lambda x: str(x + offset)
+        else:
+            raise FeathubException(f"Unsupported data type {field_type}")
+    elif isinstance(field_config, RandomField):
+        if field_type == types.Int64:
+            minimum = (
+                np.iinfo(np.int64).min
+                if field_config.minimum is None
+                else field_config.minimum
+            )
+            maximum = (
+                np.iinfo(np.int64).max
+                if field_config.maximum is None
+                else field_config.maximum
+            )
+            return lambda seed: random.Random(seed).randint(minimum, maximum)
+        elif field_type == types.Int32:
+            minimum = (
+                np.iinfo(np.int32).min
+                if field_config.minimum is None
+                else field_config.minimum
+            )
+            maximum = (
+                np.iinfo(np.int32).max
+                if field_config.maximum is None
+                else field_config.maximum
+            )
+            return lambda seed: random.Random(seed).randint(minimum, maximum)
+        elif field_type == types.Float64:
+            minimum = float(
+                np.finfo(np.float64).min
+                if field_config.minimum is None
+                else field_config.minimum
+            )
+            maximum = float(
+                np.finfo(np.float64).max
+                if field_config.maximum is None
+                else field_config.maximum
+            )
+            return lambda seed: random.Random(seed).uniform(minimum, maximum)
+        elif field_type == types.Float32:
+            minimum = float(
+                np.finfo(np.float32).min
+                if field_config.minimum is None
+                else field_config.minimum
+            )
+            maximum = float(
+                np.finfo(np.float32).max
+                if field_config.maximum is None
+                else field_config.maximum
+            )
+            return lambda seed: random.Random(seed).uniform(minimum, maximum)
+        elif field_type == types.String:
+            size = field_config.length
+            return lambda seed: "".join(
+                random.Random(seed).choices(
+                    string.ascii_letters + string.digits, k=size
+                )
+            )
+        elif field_type == types.Bool:
+            return lambda seed: bool(random.Random(seed).getrandbits(1))
+        elif field_type == types.Timestamp:
+            seconds = field_config.max_past / timedelta(seconds=1)
+            return lambda seed: datetime.fromtimestamp(
+                random.Random(seed).uniform(0, seconds)
+            )
+        elif isinstance(field_type, types.VectorType):
+            element_mapping = _get_udf_mapping(field_type.dtype, field_config)
+            size = field_config.length
+            return lambda seed: [element_mapping(i) for i in range(size)]
+        elif isinstance(field_type, types.MapType):
+            key_mapping = _get_udf_mapping(field_type.key_dtype, field_config)
+            value_mapping = _get_udf_mapping(field_type.value_dtype, field_config)
+            return lambda seed: {key_mapping(seed): value_mapping(seed)}
+        else:
+            raise FeathubException(f"Unsupported data type {field_type}")
+
+
+def get_dataframe_from_data_gen_source(
+    spark_session: SparkSession, source: DataGenSource
+) -> NativeSparkDataFrame:
+    if source.number_of_rows is None:
+        raise FeathubException(
+            "SparkProcessor does not support generating unbounded data."
+        )
+
+    seed_field_name = _generate_random_field_name(source.schema.field_names)
+    df = spark_session.range(source.number_of_rows).select(
+        col("id").alias(seed_field_name)
+    )
+
+    for field_name in source.schema.field_names:
+        field_type = source.schema.get_field_type(field_name)
+        field_config = source.field_configs.get(field_name)
+
+        mapper = _get_udf_mapping(field_type, field_config)
+
+        mapper_udf = udf(mapper, returnType=to_spark_type(field_type))
+        df = df.withColumn(field_name, mapper_udf(seed_field_name))
+
+    df = df.drop(seed_field_name)
+
+    return df

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -18,6 +18,8 @@ import pandas as pd
 
 from feathub.feathub_client import FeathubClient
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
+from feathub.feature_tables.tests.test_black_hole_sink import BlackHoleSinkITTest
+from feathub.feature_tables.tests.test_datagen_source import DataGenSourceITTest
 from feathub.feature_views.transforms.tests.test_expression_transform import (
     ExpressionTransformITTest,
 )
@@ -28,6 +30,8 @@ from feathub.feature_tables.tests.test_print_sink import PrintSinkITTest
 
 
 class SparkProcessorITTest(
+    BlackHoleSinkITTest,
+    DataGenSourceITTest,
     ExpressionTransformITTest,
     FileSystemSourceSinkITTest,
     PrintSinkITTest,


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds DataGenSource and BlackHoleSink for SparkProcessor

## Brief change log

  - Supports DataGenSource in SparkProcessor
  - Supports BlackHoleSink in SparkProcessor

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? python docs