### PR TITLE
Support UNIX_TIMESTAMP in SparkProcessor

### DIFF
--- a/docs/feathub_expression.md
+++ b/docs/feathub_expression.md
@@ -61,28 +61,36 @@ Comparison functions take numeric values as inputs and outputs a boolean value.
 
 Feathub expression supports the following data types: 
 
-BYTES, STRINGS, INTEGER, BIGINT, FLOAT, DOUBLE, BOOLEAN, TIMESTAMP
+BYTES, STRING, INTEGER, BIGINT, FLOAT, DOUBLE, BOOLEAN, TIMESTAMP
 
 The matrix below describes the supported cast between any two data types, where "Y" 
 means supported, "N" means unsupported, and "!" means fallible. If the cast is fallible 
 and the provided input is not valid, CAST will fail the job and TRY_CAST will return 
 NULL. 
 
-| Input\Target | BYTES | STRINGS | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | TIMESTAMP | 
-|--------------|-------|---------|---------|--------|-------|--------|---------|-----------|
-| BYTES        | Y     | Y       | N       | N      | N     | N      | N       | N         |
-| STRINGS      | N     | Y       | !       | !      | !     | !      | !       | !         |
-| INTEGER      | N     | Y       | Y       | Y      | Y     | Y      | Y       | N         |
-| BIGINT       | N     | Y       | Y       | Y      | Y     | Y      | Y       | N         |
-| FLOAT        | N     | Y       | Y       | Y      | Y     | Y      | Y       | N         |
-| DOUBLE       | N     | Y       | Y       | Y      | Y     | Y      | Y       | N         |
-| BOOLEAN      | N     | Y       | Y       | Y      | Y     | Y      | Y       | N         |
-| TIMESTAMP    | N     | Y       | N       | N      | N     | N      | N       | Y         |
+| Input\Target | BYTES | STRING | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | TIMESTAMP | 
+|--------------|-------|--------|---------|--------|-------|--------|---------|-----------|
+| BYTES        | Y     | Y      | N       | N      | N     | N      | N       | N         |
+| STRING       | N     | Y      | !       | !      | !     | !      | !       | !         |
+| INTEGER      | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
+| BIGINT       | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
+| FLOAT        | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
+| DOUBLE       | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
+| BOOLEAN      | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
+| TIMESTAMP    | N     | Y      | N       | N      | N     | N      | N       | Y         |
 
 ## Temporal Functions
 
-| Function                | Description                                                                                                                         |
-|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| UNIX_TIMESTAMP(string1) | Converts dateime string string1 in the format yyyy-MM-dd HH:mm:ss to Unix timestamp (in seconds). Returns NULL if in case of error. |
+### UNIX_TIMESTAMP
 
+`UNIX_TIMESTAMP(timeExp[, fmt])` - Returns the UNIX timestamp of the given time
+or NULL in case of error.
 
+Arguments:
+
+- `timeExp` - A string which will be returned as a UNIX timestamp.
+- `fmt` - Date/time format pattern to follow. Default value is "%Y-%m-%d
+  %H:%M:%S". The format codes required by the C standard (1989 version) are
+  regarded as valid format patterns. See [Python's strftime() and strptime()
+  Behavior](https://docs.python.org/3.7/library/datetime.html#strftime-strptime-behavior)
+  for a brief list of and introduction to these format patterns.

--- a/python/feathub/common/tests/test_config.py
+++ b/python/feathub/common/tests/test_config.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import unittest
-from typing import List
+from typing import List, Dict, Any
 
 from feathub.common.config import (
     ConfigDef,
@@ -21,6 +21,12 @@ from feathub.common.config import (
 )
 from feathub.common.exceptions import FeathubConfigurationException
 from feathub.common.validators import in_list, is_subset
+
+
+class MockConfig(BaseConfig):
+    def __init__(self, config_defs: List[ConfigDef], props: Dict[str, Any]):
+        super().__init__(props)
+        self.update_config_values(config_defs)
 
 
 class ConfigTest(unittest.TestCase):
@@ -75,10 +81,10 @@ class ConfigTest(unittest.TestCase):
                 validator=None,
             )
         ]
-        config = BaseConfig(config_options, {"a.b": 2})
+        config = MockConfig(config_options, {"a.b": 2})
         self.assertEqual(2, config.get("a.b"))
 
-        config = BaseConfig(config_options, {})
+        config = MockConfig(config_options, {})
         self.assertEqual(1, config.get("a.b"))
 
         with self.assertRaises(FeathubConfigurationException) as cm:
@@ -92,7 +98,7 @@ class ConfigTest(unittest.TestCase):
         ]
 
         with self.assertRaises(FeathubConfigurationException) as cm:
-            BaseConfig(config_options, {"a.b": "string"})
+            MockConfig(config_options, {"a.b": "string"})
 
         self.assertIn("Configuration type error:", cm.exception.args[0])
 
@@ -114,20 +120,20 @@ class ConfigTest(unittest.TestCase):
             ),
         ]
 
-        config = BaseConfig(config_options, {"a.b": "b"})
+        config = MockConfig(config_options, {"a.b": "b"})
         self.assertEqual("b", config.get("a.b"))
         self.assertEqual(["a", "b"], config.get("a.c"))
 
         with self.assertRaises(FeathubConfigurationException) as cm:
-            BaseConfig(config_options, {"a.b": "c"})
+            MockConfig(config_options, {"a.b": "c"})
         self.assertIn("Invalid value c of a.b", cm.exception.args[0])
 
         with self.assertRaises(FeathubConfigurationException) as cm:
-            BaseConfig(config_options, {"a.c": ["a", "b", "c"]})
+            MockConfig(config_options, {"a.c": ["a", "b", "c"]})
         self.assertIn("Invalid value c of a.c", cm.exception.args[0])
 
     def test_originals_with_prefix(self):
-        config = BaseConfig([], {"a.b": "b", "a.b.a": "a", "a.b.b": "b", "a.c.c": "c"})
+        config = MockConfig([], {"a.b": "b", "a.b.a": "a", "a.b.b": "b", "a.c.c": "c"})
         self.assertEqual(
             {"a": "a", "b": "b"}, config.original_props_with_prefix("a.b.", True)
         )

--- a/python/feathub/dsl/expr_parser.py
+++ b/python/feathub/dsl/expr_parser.py
@@ -120,7 +120,8 @@ class ExprParser:
                 | expression
         """
         if len(p) == 4:
-            p[0] = p[1].values.append(p[3])
+            p[0] = ArgListNode(p[1].values.copy())
+            p[0].values.append(p[3])
         else:
             p[0] = ArgListNode([p[1]])
 

--- a/python/feathub/dsl/tests/test_expr_parser.py
+++ b/python/feathub/dsl/tests/test_expr_parser.py
@@ -1,0 +1,52 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+from feathub.dsl.ast import FuncCallOp, ArgListNode, VariableNode, ValueNode
+from feathub.dsl.expr_parser import ExprParser
+
+
+class ExprParserTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parser = ExprParser()
+
+    def test_expr_parser(self):
+        expected_mappings = {
+            "UNIX_TIMESTAMP(time)": FuncCallOp(
+                func_name="UNIX_TIMESTAMP",
+                args=ArgListNode(
+                    values=[
+                        VariableNode(
+                            var_name="time",
+                        )
+                    ]
+                ),
+            ),
+            "UNIX_TIMESTAMP(time, '%Y-%m-%d %H:%M:%S.%f %z')": FuncCallOp(
+                func_name="UNIX_TIMESTAMP",
+                args=ArgListNode(
+                    values=[
+                        VariableNode(
+                            var_name="time",
+                        ),
+                        ValueNode(
+                            value="%Y-%m-%d %H:%M:%S.%f %z",
+                        ),
+                    ]
+                ),
+            ),
+        }
+
+        for expr, node in expected_mappings.items():
+            self.assertEqual(node.to_json(), self.parser.parse(expr).to_json())

--- a/python/feathub/feature_service/feature_service_config.py
+++ b/python/feathub/feature_service/feature_service_config.py
@@ -23,21 +23,24 @@ class FeatureServiceType(Enum):
     LOCAL = "local"
 
 
-FEATURE_SERVICE_TYPE_CONFIG = "feature_service.type"
+FEATURE_SERVICE_PREFIX = "feature_service."
+
+FEATURE_SERVICE_TYPE_CONFIG = FEATURE_SERVICE_PREFIX + "type"
 FEATURE_SERVICE_TYPE_DOC = "The type of the feature service to use."
 
 
+feature_service_config_defs = [
+    ConfigDef(
+        name=FEATURE_SERVICE_TYPE_CONFIG,
+        value_type=str,
+        description=FEATURE_SERVICE_TYPE_DOC,
+        default_value="local",
+        validator=in_list(*[t.value for t in FeatureServiceType]),
+    )
+]
+
+
 class FeatureServiceConfig(BaseConfig):
-    def __init__(self, props: Dict[str, Any]):
-        super().__init__(
-            [
-                ConfigDef(
-                    name=FEATURE_SERVICE_TYPE_CONFIG,
-                    value_type=str,
-                    description=FEATURE_SERVICE_TYPE_DOC,
-                    default_value="local",
-                    validator=in_list(*[t.value for t in FeatureServiceType]),
-                )
-            ],
-            props,
-        )
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(feature_service_config_defs)

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -13,10 +13,8 @@
 #  limitations under the License.
 from typing import Dict, Union, Sequence, Set, Any, Optional
 
-from feathub.common.config import BaseConfig, ConfigDef
-
 from feathub.common import types
-
+from feathub.common.config import BaseConfig, ConfigDef
 from feathub.common.exceptions import FeathubException, FeathubConfigurationException
 from feathub.feature_views.feature import Feature
 from feathub.feature_views.feature_view import FeatureView
@@ -28,8 +26,10 @@ from feathub.feature_views.transforms.sliding_window_transform import (
 from feathub.registries.registry import Registry
 from feathub.table.table_descriptor import TableDescriptor
 
+SLIDING_FEATURE_VIEW_PREFIX = "sdk.sliding_feature_view."
+
 ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG = (
-    "sdk.sliding_feature_view.enable_empty_window_output"
+    SLIDING_FEATURE_VIEW_PREFIX + "enable_empty_window_output"
 )
 ENABLE_EMPTY_WINDOW_OUTPUT_DOC = (
     "If it is True, when the sliding window becomes emtpy, it outputs zero value for "
@@ -38,33 +38,33 @@ ENABLE_EMPTY_WINDOW_OUTPUT_DOC = (
     "sliding window becomes empty."
 )
 
-SKIP_SAME_WINDOW_OUTPUT_CONFIG = "sdk.sliding_feature_view.skip_same_window_output"
+SKIP_SAME_WINDOW_OUTPUT_CONFIG = SLIDING_FEATURE_VIEW_PREFIX + "skip_same_window_output"
 SKIP_SAME_WINDOW_OUTPUT_DOC = (
     "If it is True, the sliding feature view only outputs when the result of the "
     "sliding window changes. If it is False, the sliding feature view outputs at every "
     "step size even if the result of the sliding window doesn't change."
 )
 
+sliding_feature_view_config_defs = [
+    ConfigDef(
+        name=ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
+        value_type=bool,
+        description=ENABLE_EMPTY_WINDOW_OUTPUT_DOC,
+        default_value=True,
+    ),
+    ConfigDef(
+        name=SKIP_SAME_WINDOW_OUTPUT_CONFIG,
+        value_type=bool,
+        description=SKIP_SAME_WINDOW_OUTPUT_DOC,
+        default_value=True,
+    ),
+]
+
 
 class SlidingFeatureViewConfig(BaseConfig):
-    def __init__(self, original_props: Dict[str, Any]):
-        super().__init__(
-            [
-                ConfigDef(
-                    name=ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
-                    value_type=bool,
-                    description=ENABLE_EMPTY_WINDOW_OUTPUT_DOC,
-                    default_value=True,
-                ),
-                ConfigDef(
-                    name=SKIP_SAME_WINDOW_OUTPUT_CONFIG,
-                    value_type=bool,
-                    description=SKIP_SAME_WINDOW_OUTPUT_DOC,
-                    default_value=True,
-                ),
-            ],
-            original_props,
-        )
+    def __init__(self, original_props: Dict[str, Any]) -> None:
+        super().__init__(original_props)
+        self.update_config_values(sliding_feature_view_config_defs)
 
 
 class SlidingFeatureView(FeatureView):

--- a/python/feathub/feature_views/transforms/tests/test_join_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_join_transform.py
@@ -219,3 +219,121 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
 
         self.assertListEqual(["name"], built_feature_view_2.keys)
         self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_join_transform_with_zoned_timestamp(self):
+        client = self.get_client(
+            {
+                "common": {
+                    "timeZone": "Asia/Shanghai",
+                }
+            }
+        )
+
+        df_1 = pd.DataFrame(
+            [
+                ["Alex", 100, 100, "2022-01-01 08:00:00.000"],
+                ["Emma", 400, 250, "2022-01-01 08:00:00.002"],
+                ["Alex", 300, 200, "2022-01-01 08:00:00.004"],
+                ["Emma", 200, 250, "2022-01-01 08:00:00.006"],
+                ["Jack", 500, 500, "2022-01-01 08:00:00.008"],
+                ["Alex", 600, 800, "2022-01-01 08:00:00.010"],
+            ],
+            columns=["name", "cost", "distance", "time"],
+        )
+        source = self.create_file_source(
+            df_1,
+            schema=Schema(
+                ["name", "cost", "distance", "time"], [String, Int64, Int64, String]
+            ),
+            timestamp_format="%Y-%m-%d %H:%M:%S.%f",
+        )
+        feature_view_1 = DerivedFeatureView(
+            name="feature_view_1",
+            source=source,
+            features=[
+                Feature(
+                    name="cost",
+                    dtype=Int64,
+                    transform="cost",
+                ),
+                Feature(
+                    name="distance",
+                    dtype=Int64,
+                    transform="distance",
+                ),
+            ],
+            keep_source_fields=True,
+        )
+
+        df_2 = pd.DataFrame(
+            [
+                ["Alex", 100.0, "2022-01-01 08:00:00.001 +0800"],
+                ["Emma", 400.0, "2022-01-01 00:00:00.003 +0000"],
+                ["Alex", 200.0, "2022-01-01 08:00:00.005 +0800"],
+                ["Emma", 300.0, "2022-01-01 00:00:00.007 +0000"],
+                ["Jack", 500.0, "2022-01-01 08:00:00.009 +0800"],
+                ["Alex", 450.0, "2022-01-01 00:00:00.011 +0000"],
+            ],
+            columns=["name", "avg_cost", "time"],
+        )
+        source_2 = self.create_file_source(
+            df_2,
+            schema=Schema(["name", "avg_cost", "time"], [String, Float64, String]),
+            timestamp_format="%Y-%m-%d %H:%M:%S.%f %z",
+            keys=["name"],
+        )
+
+        feature_view_2 = DerivedFeatureView(
+            name="feature_view_2",
+            source=feature_view_1,
+            features=[
+                Feature(
+                    name="cost",
+                    dtype=Int64,
+                    transform="cost",
+                ),
+                "distance",
+                f"{source_2.name}.avg_cost",
+            ],
+            keep_source_fields=False,
+        )
+
+        feature_view_3 = DerivedFeatureView(
+            name="feature_view_3",
+            source=feature_view_2,
+            features=[
+                Feature(
+                    name="derived_cost",
+                    dtype=Float64,
+                    transform="avg_cost * distance",
+                ),
+            ],
+            keep_source_fields=True,
+        )
+
+        [_, built_feature_view_2, built_feature_view_3] = client.build_features(
+            [source_2, feature_view_2, feature_view_3]
+        )
+
+        expected_result_df = df_1
+        expected_result_df["avg_cost"] = pd.Series(
+            [None, None, 100.0, 400.0, None, 200.0]
+        )
+        expected_result_df["derived_cost"] = pd.Series(
+            [None, None, 20000.0, 100000.0, None, 160000.0]
+        )
+        expected_result_df = expected_result_df.sort_values(
+            by=["name", "time"]
+        ).reset_index(drop=True)
+
+        result_df = (
+            client.get_features(features=built_feature_view_3)
+            .to_pandas()
+            .sort_values(by=["name", "time"])
+            .reset_index(drop=True)
+        )
+
+        self.assertIsNone(feature_view_1.keys)
+        self.assertListEqual(["name"], built_feature_view_2.keys)
+        self.assertListEqual(["name"], built_feature_view_3.keys)
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/processors/flink/ast_evaluator/flink_ast_evaluator.py
+++ b/python/feathub/processors/flink/ast_evaluator/flink_ast_evaluator.py
@@ -26,6 +26,7 @@ from feathub.dsl.ast import (
     BinaryOp,
     GroupNode,
 )
+from feathub.processors.flink.ast_evaluator.functions import evaluate_function
 
 
 class FlinkAstEvaluator(AbstractAstEvaluator):
@@ -57,7 +58,7 @@ class FlinkAstEvaluator(AbstractAstEvaluator):
 
     def eval_func_call_op(self, ast: FuncCallOp, variables: Optional[Dict]) -> Any:
         args = [self.eval(v, variables) for v in ast.args.values]
-        return f"{ast.func_name}({', '.join(args)})"
+        return evaluate_function(ast.func_name, args)
 
     def eval_variable_node(self, ast: VariableNode, variables: Optional[Dict]) -> Any:
         return f"`{ast.var_name}`"

--- a/python/feathub/processors/flink/ast_evaluator/functions.py
+++ b/python/feathub/processors/flink/ast_evaluator/functions.py
@@ -11,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Dict, Optional
+from typing import List, Any
 
-import feathub.common.utils as utils
-
-# TODO: add Flink's System (Built-in) Functions
-_FUNCTIONS: Dict[str, Callable] = {
-    "unix_timestamp": utils.to_unix_timestamp,
-}
+from feathub.common.utils import to_java_date_format
 
 
-def get_predefined_function(name: str) -> Optional[Callable]:
-    return _FUNCTIONS.get(name.lower(), None)
+def evaluate_function(func_name: str, args: List[Any]) -> str:
+    if func_name.upper() == "UNIX_TIMESTAMP" and len(args) > 1:
+        args[1] = to_java_date_format(args[1])
+    return f"{func_name}({', '.join(args)})"

--- a/python/feathub/processors/flink/flink_processor.py
+++ b/python/feathub/processors/flink/flink_processor.py
@@ -22,6 +22,7 @@ from pyflink.table import (
     StreamTableEnvironment,
 )
 
+from feathub.common.config import TIMEZONE_CONFIG
 from feathub.common.exceptions import (
     FeathubException,
 )
@@ -37,12 +38,12 @@ from feathub.processors.flink.flink_processor_config import (
     NATIVE_CONFIG_PREFIX,
 )
 from feathub.processors.flink.flink_table import FlinkTable
-from feathub.processors.flink.table_builder.flink_table_builder import (
-    FlinkTableBuilder,
-)
 from feathub.processors.flink.job_submitter.flink_job_submitter import FlinkJobSubmitter
 from feathub.processors.flink.job_submitter.flink_session_cluster_job_submitter import (
     FlinkSessionClusterJobSubmitter,
+)
+from feathub.processors.flink.table_builder.flink_table_builder import (
+    FlinkTableBuilder,
 )
 from feathub.processors.processor import Processor
 from feathub.processors.processor_job import ProcessorJob
@@ -211,6 +212,11 @@ class FlinkProcessor(Processor):
 
         env = StreamExecutionEnvironment.get_execution_environment()
         table_env = StreamTableEnvironment.create(env)
+
+        table_env.get_config().set(
+            "table.local-time-zone", self.config.get(TIMEZONE_CONFIG)
+        )
+
         # TODO: report error when processor configs conflict with native.* configs.
         for k, v in self.config.original_props_with_prefix(
             NATIVE_CONFIG_PREFIX, True

--- a/python/feathub/processors/flink/flink_processor_config.py
+++ b/python/feathub/processors/flink/flink_processor_config.py
@@ -14,39 +14,42 @@
 
 from typing import Dict, Any, List
 
-from feathub.common.config import ConfigDef, BaseConfig
+from feathub.common.config import ConfigDef
 from feathub.common.validators import in_list
 from feathub.processors.flink.flink_deployment_mode import DeploymentMode
+from feathub.processors.processor_config import ProcessorConfig, PROCESSOR_PREFIX
 
-DEPLOYMENT_MODE_CONFIG = "processor.flink.deployment_mode"
+FLINK_PROCESSOR_PREFIX = PROCESSOR_PREFIX + "flink."
+
+DEPLOYMENT_MODE_CONFIG = FLINK_PROCESSOR_PREFIX + "deployment_mode"
 DEPLOYMENT_MODE_DOC = "The flink job deployment mode."
 
-REST_ADDRESS_CONFIG = "processor.flink.rest.address"
+REST_ADDRESS_CONFIG = FLINK_PROCESSOR_PREFIX + "rest.address"
 REST_ADDRESS_DOC = "The ip or hostname where the JobManager runs."
 
-REST_PORT_CONFIG = "processor.flink.rest.port"
+REST_PORT_CONFIG = FLINK_PROCESSOR_PREFIX + "rest.port"
 REST_PORT_DOC = "The port where the JobManager runs."
 
-FLINK_HOME_CONFIG = "processor.flink.flink_home"
+FLINK_HOME_CONFIG = FLINK_PROCESSOR_PREFIX + "flink_home"
 FLINK_HOME_DOC = (
     "The path to the Flink distribution. If not specified, it uses the "
     "Flink's distribution in PyFlink."
 )
 
-KUBERNETES_IMAGE_CONFIG = "processor.flink.kubernetes.image"
+KUBERNETES_IMAGE_CONFIG = FLINK_PROCESSOR_PREFIX + "kubernetes.image"
 KUBERNETES_IMAGE_DOC = "The docker image to start the JobManager and TaskManager pod."
 
-KUBERNETES_NAMESPACE_CONFIG = "processor.flink.kubernetes.namespace"
+KUBERNETES_NAMESPACE_CONFIG = FLINK_PROCESSOR_PREFIX + "kubernetes.namespace"
 KUBERNETES_NAMESPACE_DOC = (
     "The namespace of the Kubernetes cluster to run the Flink job."
 )
 
-KUBERNETES_CONFIG_FILE_CONFIG = "processor.flink.kubernetes.config.file"
+KUBERNETES_CONFIG_FILE_CONFIG = FLINK_PROCESSOR_PREFIX + "kubernetes.config.file"
 KUBERNETES_CONFIG_FILE_DOC = (
     "The kubernetes config file is used to connector to the Kubernetes " "cluster."
 )
 
-NATIVE_CONFIG_PREFIX = "processor.flink.native."
+NATIVE_CONFIG_PREFIX = FLINK_PROCESSOR_PREFIX + "native."
 
 flink_processor_config_defs: List[ConfigDef] = [
     ConfigDef(
@@ -95,6 +98,7 @@ flink_processor_config_defs: List[ConfigDef] = [
 ]
 
 
-class FlinkProcessorConfig(BaseConfig):
+class FlinkProcessorConfig(ProcessorConfig):
     def __init__(self, props: Dict[str, Any]) -> None:
-        super().__init__(flink_processor_config_defs, props)
+        super().__init__(props)
+        self.update_config_values(flink_processor_config_defs)

--- a/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
@@ -11,17 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import tzinfo, timezone
+from typing import Any
 
-setuptools>=18.0
-wheel
-black==22.3.0
-autopep8>=1.6.0
-pytest==4.4.1
-flake8==4.0.1
-mypy==0.971
-testcontainers[kafka,redis]~=3.7.0
-protobuf~=3.17.3
-redis==4.3.0
-types-python-dateutil~=2.8
-types-redis~=4.3.21
-types-tzlocal~=4.2
+from feathub.common.utils import to_unix_timestamp
+
+
+class LocalFuncEvaluator:
+    def __init__(self, tz: tzinfo = timezone.utc):
+        self.tz = tz
+
+    def eval(self, func_name: str, values: Any) -> Any:
+        if func_name.upper() == "UNIX_TIMESTAMP":
+            if len(values) == 1:
+                return to_unix_timestamp(values[0], tz=self.tz)
+            else:
+                return to_unix_timestamp(values[0], values[1], self.tz)
+        raise RuntimeError(f"Unsupported function: {func_name}.")

--- a/python/feathub/processors/local/local_processor_config.py
+++ b/python/feathub/processors/local/local_processor_config.py
@@ -1,0 +1,19 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from feathub.processors.processor_config import ProcessorConfig
+
+
+class LocalProcessorConfig(ProcessorConfig):
+    pass

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -11,25 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from feathub.feathub_client import FeathubClient
+from typing import Optional, Dict
 
-from feathub.feature_views.transforms.tests.test_expression_transform import (
-    ExpressionTransformITTest,
-)
+from feathub.feathub_client import FeathubClient
 from feathub.feature_tables.tests.test_file_system_source_sink import (
     FileSystemSourceSinkITTest,
 )
-from feathub.tests.test_get_features import GetFeaturesITTest
+from feathub.feature_views.transforms.tests.test_expression_transform import (
+    ExpressionTransformITTest,
+)
 from feathub.feature_views.transforms.tests.test_join_transform import (
     JoinTransformITTest,
 )
-from feathub.tests.test_online_features import OnlineFeaturesITTest
 from feathub.feature_views.transforms.tests.test_over_window_transform import (
     OverWindowTransformITTest,
 )
 from feathub.feature_views.transforms.tests.test_python_udf_transform import (
     PythonUDFTransformITTest,
 )
+from feathub.tests.test_get_features import GetFeaturesITTest
+from feathub.tests.test_online_features import OnlineFeaturesITTest
 
 
 class LocalProcessorITTest(
@@ -57,11 +58,12 @@ class LocalProcessorITTest(
     def tearDownClass(cls) -> None:
         cls.invoke_all_base_class_teardownclass()
 
-    def get_client(self) -> FeathubClient:
-        return self.get_local_client(
+    def get_client(self, extra_config: Optional[Dict] = None) -> FeathubClient:
+        return self.get_client_with_local_registry(
             {
                 "type": "local",
-            }
+            },
+            extra_config,
         )
 
     def test_file_source(self):

--- a/python/feathub/processors/processor_config.py
+++ b/python/feathub/processors/processor_config.py
@@ -24,21 +24,23 @@ class ProcessorType(Enum):
     SPARK = "spark"
 
 
-PROCESSOR_TYPE_CONFIG = "processor.type"
+PROCESSOR_PREFIX = "processor."
+
+PROCESSOR_TYPE_CONFIG = PROCESSOR_PREFIX + "type"
 PROCESSOR_TYPE_DOC = "The type of the processor to use."
+
+processor_config_defs = [
+    ConfigDef(
+        name=PROCESSOR_TYPE_CONFIG,
+        value_type=str,
+        description=PROCESSOR_TYPE_DOC,
+        default_value="local",
+        validator=in_list(*[t.value for t in ProcessorType]),
+    ),
+]
 
 
 class ProcessorConfig(BaseConfig):
-    def __init__(self, props: Dict[str, Any]):
-        super().__init__(
-            [
-                ConfigDef(
-                    name=PROCESSOR_TYPE_CONFIG,
-                    value_type=str,
-                    description=PROCESSOR_TYPE_DOC,
-                    default_value="local",
-                    validator=in_list(*[t.value for t in ProcessorType]),
-                )
-            ],
-            props,
-        )
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(processor_config_defs)

--- a/python/feathub/processors/spark/ast_evaluator/functions.py
+++ b/python/feathub/processors/spark/ast_evaluator/functions.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List, Any
 
-import unittest
-
-from feathub.processors.local.ast_evaluator.functions import get_predefined_function
+from feathub.common.utils import to_java_date_format
 
 
-class FunctionsTest(unittest.TestCase):
-    def test_unix_timestamp(self):
-        func = get_predefined_function("unix_timestamp")
-        self.assertEqual(1.0, func("1970-01-01 00:00:01"))
+def evaluate_function(func_name: str, args: List[Any]) -> str:
+    if func_name.upper() == "UNIX_TIMESTAMP":
+        if len(args) > 1:
+            args[1] = to_java_date_format(args[1])
+        return f"TO_UNIX_TIMESTAMP({', '.join(args)})"
+    raise RuntimeError(f"Unsupported function: {func_name}.")

--- a/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
@@ -26,6 +26,7 @@ from feathub.dsl.ast import (
     BinaryOp,
     GroupNode,
 )
+from feathub.processors.spark.ast_evaluator.functions import evaluate_function
 
 
 class SparkAstEvaluator(AbstractAstEvaluator):
@@ -56,9 +57,8 @@ class SparkAstEvaluator(AbstractAstEvaluator):
         return str(ast.value)
 
     def eval_func_call_op(self, ast: FuncCallOp, variables: Optional[Dict]) -> Any:
-        # TODO: Add support for Feathub built-in functions.
         args = [self.eval(v, variables) for v in ast.args.values]
-        return f"{ast.func_name}({', '.join(args)})"
+        return evaluate_function(ast.func_name, args)
 
     def eval_variable_node(self, ast: VariableNode, variables: Optional[Dict]) -> Any:
         return f"`{ast.var_name}`"

--- a/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
@@ -68,8 +68,8 @@ class SparkAstEvaluatorTest(unittest.TestCase):
         UNIX_TIMESTAMP("2020-01-01 00:24:39") - UNIX_TIMESTAMP("2020-01-01 00:23:40")
         """
         self.assertEqual(
-            "UNIX_TIMESTAMP('2020-01-01 00:24:39') "
-            "- UNIX_TIMESTAMP('2020-01-01 00:23:40')",
+            "TO_UNIX_TIMESTAMP('2020-01-01 00:24:39') "
+            "- TO_UNIX_TIMESTAMP('2020-01-01 00:23:40')",
             self._eval(expr),
         )
 
@@ -77,7 +77,7 @@ class SparkAstEvaluatorTest(unittest.TestCase):
         UNIX_TIMESTAMP("2020-01-01 00:24:39") - UNIX_TIMESTAMP(ts)
         """
         self.assertEqual(
-            "UNIX_TIMESTAMP('2020-01-01 00:24:39') - UNIX_TIMESTAMP(`ts`)",
+            "TO_UNIX_TIMESTAMP('2020-01-01 00:24:39') - TO_UNIX_TIMESTAMP(`ts`)",
             self._eval(expr, {"ts": "2020-01-01 00:23:40"}),
         )
 

--- a/python/feathub/processors/spark/spark_processor_config.py
+++ b/python/feathub/processors/spark/spark_processor_config.py
@@ -13,10 +13,15 @@
 #  limitations under the License.
 from typing import List, Dict, Any
 
-from feathub.common.config import ConfigDef, BaseConfig
+from feathub.common.config import ConfigDef
+from feathub.processors.processor_config import ProcessorConfig, PROCESSOR_PREFIX
 
-MASTER_CONFIG = "processor.spark.master"
+SPARK_PROCESSOR_PREFIX = PROCESSOR_PREFIX + "spark."
+
+MASTER_CONFIG = SPARK_PROCESSOR_PREFIX + "master"
 MASTER_DOC = "The Spark master URL to connect to."
+
+NATIVE_CONFIG_PREFIX = SPARK_PROCESSOR_PREFIX + "native."
 
 # TODO: Add a validator class that are used to validate the legality of
 #  configuration values, and validate that spark master is not None.
@@ -29,6 +34,7 @@ spark_processor_config_defs: List[ConfigDef] = [
 ]
 
 
-class SparkProcessorConfig(BaseConfig):
+class SparkProcessorConfig(ProcessorConfig):
     def __init__(self, props: Dict[str, Any]) -> None:
-        super().__init__(spark_processor_config_defs, props)
+        super().__init__(props)
+        self.update_config_values(spark_processor_config_defs)

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import glob
 import tempfile
+from typing import Optional, Dict
 
 import pandas as pd
 
@@ -52,14 +53,15 @@ class SparkProcessorITTest(
     def tearDownClass(cls) -> None:
         cls.invoke_all_base_class_teardownclass()
 
-    def get_client(self) -> FeathubClient:
-        return self.get_local_client(
+    def get_client(self, extra_config: Optional[Dict] = None) -> FeathubClient:
+        return self.get_client_with_local_registry(
             {
                 "type": "spark",
                 "spark": {
                     "master": "local[1]",
                 },
-            }
+            },
+            extra_config,
         )
 
     def test_file_system_source_sink(self):

--- a/python/feathub/registries/local_registry.py
+++ b/python/feathub/registries/local_registry.py
@@ -14,28 +14,31 @@
 
 from typing import List, Dict, Any, Optional
 
-from feathub.common.config import BaseConfig, ConfigDef
+from feathub.common.config import ConfigDef
 from feathub.common.exceptions import FeathubException
-from feathub.table.table_descriptor import TableDescriptor
 from feathub.registries.registry import Registry
+from feathub.registries.registry_config import RegistryConfig, REGISTRY_PREFIX
+from feathub.table.table_descriptor import TableDescriptor
 
-NAMESPACE_CONFIG = "registry.local.namespace"
+LOCAL_REGISTRY_PREFIX = REGISTRY_PREFIX + "local."
+
+NAMESPACE_CONFIG = LOCAL_REGISTRY_PREFIX + "namespace"
 NAMESPACE_DOC = "The namespace of the local registry."
 
+local_registry_config_defs = [
+    ConfigDef(
+        name=NAMESPACE_CONFIG,
+        value_type=str,
+        description=NAMESPACE_DOC,
+        default_value="default",
+    )
+]
 
-class LocalRegistryConfig(BaseConfig):
+
+class LocalRegistryConfig(RegistryConfig):
     def __init__(self, props: Dict[str, Any]) -> None:
-        super().__init__(
-            [
-                ConfigDef(
-                    name=NAMESPACE_CONFIG,
-                    value_type=str,
-                    description=NAMESPACE_DOC,
-                    default_value="default",
-                )
-            ],
-            props,
-        )
+        super().__init__(props)
+        self.update_config_values(local_registry_config_defs)
 
 
 class LocalRegistry(Registry):

--- a/python/feathub/registries/registry_config.py
+++ b/python/feathub/registries/registry_config.py
@@ -23,21 +23,23 @@ class RegistryType(Enum):
     LOCAL = "local"
 
 
-REGISTRY_TYPE_CONFIG = "registry.type"
+REGISTRY_PREFIX = "registry."
+
+REGISTRY_TYPE_CONFIG = REGISTRY_PREFIX + "type"
 REGISTRY_TYPE_DOC = "The type of the registry to use."
+
+registry_config_defs = [
+    ConfigDef(
+        name=REGISTRY_TYPE_CONFIG,
+        value_type=str,
+        description=REGISTRY_TYPE_DOC,
+        default_value="local",
+        validator=in_list(*[t.value for t in RegistryType]),
+    )
+]
 
 
 class RegistryConfig(BaseConfig):
     def __init__(self, props: Dict[str, Any]) -> None:
-        super().__init__(
-            [
-                ConfigDef(
-                    name=REGISTRY_TYPE_CONFIG,
-                    value_type=str,
-                    description=REGISTRY_TYPE_DOC,
-                    default_value="local",
-                    validator=in_list(*[t.value for t in RegistryType]),
-                )
-            ],
-            props,
-        )
+        super().__init__(props)
+        self.update_config_values(registry_config_defs)

--- a/python/setup.py
+++ b/python/setup.py
@@ -134,7 +134,9 @@ try:
         "numpy>=1.14.3,<1.20",
         "kubernetes~=24.2",
         "protobuf~=3.17.3",
+        "python-dateutil~=2.8",
         "redis==4.3.0",
+        "tzlocal~=4.2",
     ]
 
     extras_require = {


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for Feathub's built-in UDF in the Spark processor.

## Brief change log

  - Adds support for native Spark configurations in the Spark processor.
  - Fixes the bug about parsing argument list with more than one argument and adds corresponding test cases.
  - Adds second parameter (format) to `UNIX_TIMESTAMP`.
  - Adds unit tests for `UNIX_TIMESTAMP`.
  - Adds support and unit tests for the `UNIX_TIMESTAMP` function in the Spark processor.
  - Adds support for common timezone configuration
  - Improves Feathub configuration class structure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs