### PR TITLE
Support Python UDF in SparkProcessor

### DIFF
--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -20,16 +20,19 @@ from feathub.feathub_client import FeathubClient
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
 from feathub.feature_tables.tests.test_black_hole_sink import BlackHoleSinkITTest
 from feathub.feature_tables.tests.test_datagen_source import DataGenSourceITTest
-from feathub.feature_views.transforms.tests.test_expression_transform import (
-    ExpressionTransformITTest,
-)
 from feathub.feature_tables.tests.test_file_system_source_sink import (
     FileSystemSourceSinkITTest,
+)
+from feathub.feature_tables.tests.test_print_sink import PrintSinkITTest
+from feathub.feature_views.transforms.tests.test_expression_transform import (
+    ExpressionTransformITTest,
 )
 from feathub.feature_views.transforms.tests.test_over_window_transform import (
     OverWindowTransformITTest,
 )
-from feathub.feature_tables.tests.test_print_sink import PrintSinkITTest
+from feathub.feature_views.transforms.tests.test_python_udf_transform import (
+    PythonUDFTransformITTest,
+)
 
 
 class SparkProcessorITTest(
@@ -39,6 +42,7 @@ class SparkProcessorITTest(
     FileSystemSourceSinkITTest,
     PrintSinkITTest,
     OverWindowTransformITTest,
+    PythonUDFTransformITTest,
 ):
     __test__ = True
 
@@ -88,9 +92,6 @@ class SparkProcessorITTest(
         self.assertTrue(self.input_data.equals(df))
 
     def test_over_window_on_join_field(self):
-        pass
-
-    def test_python_udf_transform_on_over_window_transform(self):
         pass
 
     def test_over_window_transform_value_counts(self):


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports using Python UDF in SparkProcessor.

## Brief change log

- Adds support for Python UDF when building DerivedFeatureView in SparkProcessor.
- Add integration tests for the functionality of Python UDF in SparkProcessor.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable