### PR TITLE
Support LOWER, NULL, CASE syntax and filtering Derived/SlidingFeatureView in FlinkProcessor

### DIFF
--- a/docs/feathub_expression.md
+++ b/docs/feathub_expression.md
@@ -34,14 +34,16 @@ Arithmetic functions take numeric values as inputs and outputs a numeric value.
 
 Comparison functions take numeric values as inputs and outputs a boolean value.
 
-| Function | Description |
-| --- | --- |
-| x > y | Returns TRUE iff `x > y`. Returns NULL if in case of error. |
-| x >= y | Returns TRUE iff `x >= y`. Returns NULL if in case of error. |
-| x < y | Returns TRUE iff `x < y`. Returns NULL if in case of error. |
-| x <= y | Returns TRUE iff `x <= y`. Returns NULL if in case of error. |
-| x = y | Returns TRUE iff `x` is equal to `y`. Returns NULL if in case of error. |
-| x <> y | Returns TRUE iff `x` is not equal to `y`. Returns NULL if in case of error. |
+| Function      | Description                                                              |
+|---------------|--------------------------------------------------------------------------|
+| x > y         | Returns TRUE iff `x > y`. Returns NULL in case of error.                 |
+| x >= y        | Returns TRUE iff `x >= y`. Returns NULL in case of error.                |
+| x < y         | Returns TRUE iff `x < y`. Returns NULL in case of error.                 |
+| x <= y        | Returns TRUE iff `x <= y`. Returns NULL in case of error.                |
+| x = y         | Returns TRUE iff `x` is equal to `y`. Returns NULL in case of error.     |
+| x <> y        | Returns TRUE iff `x` is not equal to `y`. Returns NULL in case of error. |
+| x IS NULL     | Returns TRUE iff `x` is NULL.                                            |
+| x IS NOT NULL | Returns TRUE iff `x` is not NULL.                                        |
 
 ## Logical Functions
 
@@ -55,7 +57,7 @@ Comparison functions take numeric values as inputs and outputs a boolean value.
 | Function             | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|
 | CAST(x AS DTYPE)     | Returns a new value being casted to a the given DTYPE. Throws exception in case of error. |
-| TRY_CAST(x AS DTYPE) | Returns a new value being casted to a the given DTYPE. Returns NULL if in case of error.  |
+| TRY_CAST(x AS DTYPE) | Returns a new value being casted to a the given DTYPE. Returns NULL in case of error.     |
 
 ### Data Types
 
@@ -78,6 +80,27 @@ NULL.
 | DOUBLE       | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
 | BOOLEAN      | N     | Y      | Y       | Y      | Y     | Y      | Y       | N         |
 | TIMESTAMP    | N     | Y      | N       | N      | N     | N      | N       | Y         |
+
+## Conditional Functions
+
+### CASE
+
+`CASE WHEN expr1 THEN expr2 [WHEN expr3 THEN expr4]* [ELSE expr5] END` - When
+`expr1` = true, returns `expr2`; else when `expr3` = true, returns `expr4`; else
+returns `expr5`.
+
+Arguments:
+
+- `expr1`, `expr3` - the branch condition expressions should all be boolean
+  type.
+- `expr2`, `expr4`, `expr5` - the branch value expressions and else value
+  expression should all be same type or coercible to a common type.
+
+## String Functions
+
+### LOWER
+
+`LOWER(str)` - Returns `str` with all characters changed to lowercase.
 
 ## Temporal Functions
 

--- a/python/feathub/dsl/abstract_ast_evaluator.py
+++ b/python/feathub/dsl/abstract_ast_evaluator.py
@@ -28,6 +28,9 @@ from feathub.dsl.ast import (
     CastOp,
     LogicalOp,
     GroupNode,
+    IsOp,
+    NullNode,
+    CaseOp,
 )
 
 
@@ -65,6 +68,12 @@ class AbstractAstEvaluator(ABC):
             return self.eval_logical_op(ast, variables)
         if isinstance(ast, GroupNode):
             return self.eval_group_node(ast, variables)
+        if isinstance(ast, IsOp):
+            return self.eval_is_op(ast, variables)
+        if isinstance(ast, NullNode):
+            return self.eval_null_node(ast, variables)
+        if isinstance(ast, CaseOp):
+            return self.eval_case_op(ast, variables)
 
         raise FeathubExpressionException(f"Unknown AST node {type(ast)}.")
 
@@ -106,4 +115,16 @@ class AbstractAstEvaluator(ABC):
 
     @abc.abstractmethod
     def eval_group_node(self, ast: GroupNode, variables: Optional[Dict]) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def eval_is_op(self, ast: IsOp, variables: Optional[Dict]) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def eval_null_node(self, ast: NullNode, variables: Optional[Dict]) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def eval_case_op(self, ast: CaseOp, variables: Optional[Dict]) -> Any:
         pass

--- a/python/feathub/dsl/expr_lexer_rules.py
+++ b/python/feathub/dsl/expr_lexer_rules.py
@@ -41,6 +41,16 @@ class ExprLexerRules:
         "cast": ("CAST", "CAST"),
         "try_cast": ("TRY_CAST", "TRY_CAST"),
         "as": ("AS", "AS"),
+        "is": ("IS", "IS"),
+        "not": ("NOT", "NOT"),
+        "null": ("NULL", "NULL"),
+        "case": ("CASE", "CASE"),
+        "when": ("WHEN", "WHEN"),
+        "then": ("THEN", "THEN"),
+        "else": ("ELSE", "ELSE"),
+        "end": ("END", "END"),
+        "and": ("AND", "AND"),
+        "or": ("OR", "OR"),
         **{dtype: ("DTYPE", dtype.upper()) for dtype in data_types},
     }
 
@@ -54,8 +64,6 @@ class ExprLexerRules:
         "GE",
         "EQ",
         "NE",
-        "OR",
-        "AND",
         "COMMA",
         "FLOAT",
         "INTEGER",
@@ -72,8 +80,6 @@ class ExprLexerRules:
     t_GE = r">="
     t_EQ = r"="
     t_NE = r"<>"
-    t_OR = r"\|\|"
-    t_AND = r"\&\&"
     t_COMMA = r"\,"
     t_STRING = r"(\".*?\"|\'.*?\')"
 

--- a/python/feathub/dsl/tests/test_expr_lexer_rules.py
+++ b/python/feathub/dsl/tests/test_expr_lexer_rules.py
@@ -59,15 +59,15 @@ class TestExprLexerRules(unittest.TestCase):
 
     def test_lexer_complex(self):
         expr = """
-        cast ("0.1" AS FLOAT) + CAST("1" AS INTEGER) || "abc" = "abc" && `integer` <> 1
+        cast ("0.1" AS FLOAT) + CAST("1" AS INTEGER) OR "abc" = "abc" AND `integer` <> 1
         """
         token_types = (
             "CAST LPAREN STRING AS DTYPE RPAREN + CAST LPAREN STRING "
             "AS DTYPE RPAREN OR STRING EQ STRING AND ID NE INTEGER"
         ).split(" ")
         token_values: List[Any] = (
-            'CAST ( "0.1" AS FLOAT ) + CAST ( "1" AS INTEGER ) || '
-            '"abc" = "abc" && integer <>'
+            'CAST ( "0.1" AS FLOAT ) + CAST ( "1" AS INTEGER ) OR '
+            '"abc" = "abc" AND integer <>'
         ).split(" ")
         token_values.append(1)
         self.check_token_types_values(
@@ -104,18 +104,18 @@ class TestExprLexerRules(unittest.TestCase):
 
     def test_logical_op(self):
         self.check_token_types_values(
-            ["ID", "OR", "ID"], ["a", "||", "b"], self.tokenize("a || b")
+            ["ID", "OR", "ID"], ["a", "OR", "b"], self.tokenize("a OR b")
         )
         self.check_token_types_values(
-            ["ID", "AND", "ID"], ["a", "&&", "b"], self.tokenize("a && b")
+            ["ID", "AND", "ID"], ["a", "AND", "b"], self.tokenize("a AND b")
         )
         self.check_token_types_values(
             ["FALSE", "OR", "TRUE"],
-            [False, "||", True],
-            self.tokenize("false || true"),
+            [False, "OR", True],
+            self.tokenize("false OR true"),
         )
         self.check_token_types_values(
             ["TRUE", "AND", "FALSE"],
-            [True, "&&", False],
-            self.tokenize("true && false"),
+            [True, "AND", False],
+            self.tokenize("true AND false"),
         )

--- a/python/feathub/dsl/tests/test_expr_parser.py
+++ b/python/feathub/dsl/tests/test_expr_parser.py
@@ -13,7 +13,17 @@
 #  limitations under the License.
 import unittest
 
-from feathub.dsl.ast import FuncCallOp, ArgListNode, VariableNode, ValueNode
+from feathub.dsl.ast import (
+    FuncCallOp,
+    ArgListNode,
+    VariableNode,
+    ValueNode,
+    LogicalOp,
+    IsOp,
+    NullNode,
+    CaseOp,
+    CompareOp,
+)
 from feathub.dsl.expr_parser import ExprParser
 
 
@@ -25,26 +35,64 @@ class ExprParserTest(unittest.TestCase):
         expected_mappings = {
             "UNIX_TIMESTAMP(time)": FuncCallOp(
                 func_name="UNIX_TIMESTAMP",
-                args=ArgListNode(
-                    values=[
-                        VariableNode(
-                            var_name="time",
-                        )
-                    ]
-                ),
+                args=ArgListNode(values=[VariableNode(var_name="time")]),
             ),
             "UNIX_TIMESTAMP(time, '%Y-%m-%d %H:%M:%S.%f %z')": FuncCallOp(
                 func_name="UNIX_TIMESTAMP",
                 args=ArgListNode(
                     values=[
-                        VariableNode(
-                            var_name="time",
-                        ),
-                        ValueNode(
-                            value="%Y-%m-%d %H:%M:%S.%f %z",
-                        ),
+                        VariableNode(var_name="time"),
+                        ValueNode(value="%Y-%m-%d %H:%M:%S.%f %z"),
                     ]
                 ),
+            ),
+            "a AND b": LogicalOp(
+                op_type="AND",
+                left_child=VariableNode(var_name="a"),
+                right_child=VariableNode(var_name="b"),
+            ),
+            "a and b": LogicalOp(
+                op_type="AND",
+                left_child=VariableNode(var_name="a"),
+                right_child=VariableNode(var_name="b"),
+            ),
+            "a IS NULL": IsOp(
+                left_child=VariableNode(var_name="a"),
+                right_child=NullNode(),
+            ),
+            "a IS NOT NULL": IsOp(
+                left_child=VariableNode(var_name="a"),
+                right_child=NullNode(),
+                is_not=True,
+            ),
+            "CASE WHEN a > b THEN 1 WHEN a < b THEN 2 ELSE 3 END": CaseOp(
+                conditions=[
+                    CompareOp(
+                        op_type=">",
+                        left_child=VariableNode(var_name="a"),
+                        right_child=VariableNode(var_name="b"),
+                    ),
+                    CompareOp(
+                        op_type="<",
+                        left_child=VariableNode(var_name="a"),
+                        right_child=VariableNode(var_name="b"),
+                    ),
+                ],
+                results=[
+                    ValueNode(value=1),
+                    ValueNode(value=2),
+                ],
+                default=ValueNode(value=3),
+            ),
+            "CASE WHEN a IS NULL THEN 1 END": CaseOp(
+                conditions=[
+                    IsOp(
+                        left_child=VariableNode(var_name="a"),
+                        right_child=NullNode(),
+                    ),
+                ],
+                results=[ValueNode(value=1)],
+                default=NullNode(),
             ),
         }
 

--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -36,6 +36,7 @@ class DerivedFeatureView(FeatureView):
         source: Union[str, TableDescriptor],
         features: Sequence[Union[str, Feature]],
         keep_source_fields: bool = False,
+        filter_expr: Optional[str] = None,
     ):
         """
         :param name: The unique identifier of this feature view in the registry.
@@ -52,6 +53,11 @@ class DerivedFeatureView(FeatureView):
                          this list and the features in the source table.
         :param keep_source_fields: True iff all fields in the source table should be
                                    included in this table.
+        :param filter_expr: Optional. If it is not None, it represents a Feathub
+                            expression which evaluates to a boolean value. The filter
+                            expression is evaluated after other transformations in the
+                            feature view, and only those rows which evaluate to True
+                            will be outputted by the feature view.
         """
         super().__init__(
             name=name,
@@ -59,6 +65,7 @@ class DerivedFeatureView(FeatureView):
             features=features,
             keep_source_fields=keep_source_fields,
         )
+        self.filter_expr = filter_expr
 
     def build(
         self, registry: Registry, props: Optional[Dict] = None
@@ -115,6 +122,7 @@ class DerivedFeatureView(FeatureView):
             source=source,
             features=features,
             keep_source_fields=self.keep_source_fields,
+            filter_expr=self.filter_expr,
         )
 
     def to_json(self) -> Dict:
@@ -129,4 +137,5 @@ class DerivedFeatureView(FeatureView):
                 for feature in self.features
             ],
             "keep_source_fields": self.keep_source_fields,
+            "filter_expr": self.filter_expr,
         }

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -111,6 +111,7 @@ class SlidingFeatureView(FeatureView):
         features: Sequence[Union[str, Feature]],
         timestamp_field: str = "window_time",
         timestamp_format: str = "epoch_millis",
+        filter_expr: Optional[str] = None,
         props: Optional[Dict] = None,
     ):
         """
@@ -133,6 +134,11 @@ class SlidingFeatureView(FeatureView):
                                 SlidingFeatureView that represents the closed window end
                                 time for each row.
         :param timestamp_format: The format of the timestamp field.
+        :param filter_expr: Optional. If it is not None, it represents a Feathub
+                            expression which evaluates to a boolean value. The filter
+                            expression is evaluated after other transformations in the
+                            feature view, and only those rows which evaluate to True
+                            will be outputted by the feature view.
         :param props: Optional. It is not None, it is the properties of the
                       SlidingFeatureView.
         """
@@ -147,6 +153,8 @@ class SlidingFeatureView(FeatureView):
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,
         )
+
+        self.filter_expr = filter_expr
 
         self._validate(features)
 
@@ -213,6 +221,7 @@ class SlidingFeatureView(FeatureView):
             features=features,
             timestamp_field=self.timestamp_field,
             timestamp_format=self.timestamp_format,
+            filter_expr=self.filter_expr,
             props={**props, **self.config.original_props},
         )
         return feature_view
@@ -230,6 +239,7 @@ class SlidingFeatureView(FeatureView):
             ],
             "timestamp_field": self.timestamp_field,
             "timestamp_format": self.timestamp_format,
+            "filter_expr": self.filter_expr,
         }
 
     @staticmethod

--- a/python/feathub/feature_views/tests/test_derived_feature_view.py
+++ b/python/feathub/feature_views/tests/test_derived_feature_view.py
@@ -1,0 +1,101 @@
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC
+from typing import Optional
+
+import pandas as pd
+
+from feathub.common.types import String
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature import Feature
+from feathub.feature_views.transforms.python_udf_transform import PythonUdfTransform
+from feathub.tests.feathub_it_test_base import FeathubITTestBase
+
+
+class DerivedFeatureViewITTest(ABC, FeathubITTestBase):
+    def test_derived_feature_view_filter_expr(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[],
+            keep_source_fields=True,
+            filter_expr="name = 'Alex' AND cost > 200",
+        )
+
+        result_df = (
+            self.client.get_features(features)
+            .to_pandas()
+            .sort_values(by=["time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = pd.DataFrame(
+            [
+                ["Alex", 300, 200, "2022-01-02 08:03:00"],
+                ["Alex", 600, 800, "2022-01-03 08:06:00"],
+            ],
+            columns=["name", "cost", "distance", "time"],
+        )
+        expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(
+            drop=True
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_filter_is_null(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        def alex_to_null(row: pd.Series) -> Optional[str]:
+            if row["name"] == "Alex":
+                return None
+            return row["name"]
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                Feature(
+                    name="name_without_alex",
+                    dtype=String,
+                    transform=PythonUdfTransform(alex_to_null),
+                    keys=["name"],
+                )
+            ],
+            keep_source_fields=True,
+            filter_expr="name_without_alex IS NOT NULL",
+        )
+
+        result_df = (
+            self.client.get_features(features)
+            .to_pandas()
+            .sort_values(by=["time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = pd.DataFrame(
+            [
+                ["Emma", 400, 250, "2022-01-01 08:02:00", "Emma"],
+                ["Emma", 200, 250, "2022-01-02 08:04:00", "Emma"],
+                ["Jack", 500, 500, "2022-01-03 08:05:00", "Jack"],
+            ],
+            columns=["name", "cost", "distance", "time", "name_without_alex"],
+        )
+
+        expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(
+            drop=True
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
@@ -235,8 +235,11 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
         df = self.input_data.copy()
         source = self.create_file_source(df)
 
+        def repeat_name(row: pd.Series) -> str:
+            return row["name"] + "_" + row["name"]
+
         f_name_name = Feature(
-            name="name_name", dtype=String, transform="name || '_' || name"
+            name="name_name", dtype=String, transform=PythonUdfTransform(repeat_name)
         )
 
         f_total_cost = Feature(

--- a/python/feathub/processors/flink/ast_evaluator/functions.py
+++ b/python/feathub/processors/flink/ast_evaluator/functions.py
@@ -16,7 +16,18 @@ from typing import List, Any
 from feathub.common.utils import to_java_date_format
 
 
+"""
+This set contains the name of the built-in functions whose name
+and argument list is the same between Feathub and in Flink.
+"""
+_functions_with_equal_signature = {"LOWER"}
+
+
 def evaluate_function(func_name: str, args: List[Any]) -> str:
-    if func_name.upper() == "UNIX_TIMESTAMP" and len(args) > 1:
-        args[1] = to_java_date_format(args[1])
-    return f"{func_name}({', '.join(args)})"
+    if func_name in _functions_with_equal_signature:
+        return f"{func_name}({', '.join(args)})"
+    elif func_name == "UNIX_TIMESTAMP":
+        if len(args) > 1:
+            args[1] = to_java_date_format(args[1])
+        return f"{func_name}({', '.join(args)})"
+    raise RuntimeError(f"Unsupported function: {func_name}.")

--- a/python/feathub/processors/flink/ast_evaluator/tests/test_flink_ast_evaluator.py
+++ b/python/feathub/processors/flink/ast_evaluator/tests/test_flink_ast_evaluator.py
@@ -107,6 +107,6 @@ class FlinkAstEvaluatorTest(unittest.TestCase):
         self.assertEqual("TRY_CAST(59 AS STRING)", self._eval("TRY_CAST(59 AS STRING)"))
 
     def test_logical_op(self):
-        self.assertEqual("FALSE || TRUE", self._eval("false || True"))
-        self.assertEqual("`a` || TRUE", self._eval("a || True"))
-        self.assertEqual("TRUE && FALSE", self._eval("true && FALSE"))
+        self.assertEqual("FALSE OR TRUE", self._eval("false or True"))
+        self.assertEqual("`a` OR TRUE", self._eval("a OR True"))
+        self.assertEqual("TRUE AND FALSE", self._eval("true and FALSE"))

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -45,6 +45,12 @@ from feathub.feature_tables.tests.test_redis_source_sink import (
 )
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
+from feathub.feature_views.tests.test_derived_feature_view import (
+    DerivedFeatureViewITTest,
+)
+from feathub.feature_views.tests.test_sliding_feature_view import (
+    SlidingFeatureViewITTest,
+)
 from feathub.feature_views.transforms.tests.test_expression_transform import (
     ExpressionTransformITTest,
 )
@@ -366,6 +372,7 @@ class FlinkProcessorTest(unittest.TestCase):
 
 class FlinkProcessorITTest(
     DataGenSourceITTest,
+    DerivedFeatureViewITTest,
     ExpressionTransformITTest,
     FileSystemSourceSinkITTest,
     JoinTransformITTest,
@@ -375,6 +382,7 @@ class FlinkProcessorITTest(
     PythonUDFTransformITTest,
     RedisSourceSinkITTest,
     SlidingWindowTransformITTest,
+    SlidingFeatureViewITTest,
     BlackHoleSinkITTest,
 ):
     __test__ = True

--- a/python/feathub/processors/local/ast_evaluator/local_ast_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_ast_evaluator.py
@@ -27,6 +27,9 @@ from feathub.dsl.ast import (
     LogicalOp,
     CastOp,
     GroupNode,
+    IsOp,
+    NullNode,
+    CaseOp,
 )
 from feathub.processors.local.ast_evaluator.local_func_evaluator import (
     LocalFuncEvaluator,
@@ -137,10 +140,19 @@ class LocalAstEvaluator(AbstractAstEvaluator):
         left_value = self.eval(ast.left_child, variables)
         right_value = self.eval(ast.right_child, variables)
 
-        if ast.op_type == "&&":
+        if ast.op_type == "AND":
             return left_value and right_value
-        elif ast.op_type == "||":
+        elif ast.op_type == "OR":
             return left_value or right_value
 
     def eval_group_node(self, ast: GroupNode, variables: Optional[Dict]) -> Any:
         return self.eval(ast.child, variables)
+
+    def eval_is_op(self, ast: IsOp, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("IS/IS NOT operation is not supported.")
+
+    def eval_null_node(self, ast: NullNode, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("NULL operation is not supported.")
+
+    def eval_case_op(self, ast: CaseOp, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("CASE operation is not supported.")

--- a/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
@@ -22,7 +22,9 @@ class LocalFuncEvaluator:
         self.tz = tz
 
     def eval(self, func_name: str, values: Any) -> Any:
-        if func_name.upper() == "UNIX_TIMESTAMP":
+        if func_name == "LOWER":
+            return values[0].lower()
+        elif func_name == "UNIX_TIMESTAMP":
             if len(values) == 1:
                 return to_unix_timestamp(values[0], tz=self.tz)
             else:

--- a/python/feathub/processors/local/ast_evaluator/tests/test_local_ast_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/tests/test_local_ast_evaluator.py
@@ -100,6 +100,6 @@ class LocalAstEvaluatorTest(unittest.TestCase):
         self.assertEqual(None, self._eval('TRY_CAST("INVALID" AS DOUBLE)'))
 
     def test_logical_op(self):
-        self.assertEqual(True, self._eval("false || True"))
-        self.assertEqual(True, self._eval("a || True", {"a": True}))
-        self.assertEqual(False, self._eval("true && FALSE"))
+        self.assertEqual(True, self._eval("false OR True"))
+        self.assertEqual(True, self._eval("a OR True", {"a": True}))
+        self.assertEqual(False, self._eval("true AND FALSE"))

--- a/python/feathub/processors/local/local_processor.py
+++ b/python/feathub/processors/local/local_processor.py
@@ -227,6 +227,12 @@ class LocalProcessor(Processor):
     def _get_table_from_derived_feature_view(
         self, feature_view: DerivedFeatureView
     ) -> LocalTable:
+        # TODO: Support filtering DerivedFeatureView in LocalProcessor.
+        if feature_view.filter_expr is not None:
+            raise FeathubException(
+                "LocalProcessor does not support filtering DerivedFeatureView."
+            )
+
         source_table = self._get_table(feature_view.source)
         source_df = source_table.df
         source_fields = list(source_table.get_schema().field_names)

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -91,3 +91,9 @@ class LocalProcessorITTest(
     # TODO: Support Map type conversion in local processor.
     def test_over_window_transform_value_counts(self):
         pass
+
+    def test_case(self):
+        pass
+
+    def test_case_else(self):
+        pass

--- a/python/feathub/processors/spark/ast_evaluator/functions.py
+++ b/python/feathub/processors/spark/ast_evaluator/functions.py
@@ -16,8 +16,17 @@ from typing import List, Any
 from feathub.common.utils import to_java_date_format
 
 
+"""
+This set contains the name of the built-in functions whose name
+and argument list is the same between Feathub and in Spark.
+"""
+_functions_with_equal_signature = {"LOWER"}
+
+
 def evaluate_function(func_name: str, args: List[Any]) -> str:
-    if func_name.upper() == "UNIX_TIMESTAMP":
+    if func_name in _functions_with_equal_signature:
+        return f"{func_name}({', '.join(args)})"
+    elif func_name == "UNIX_TIMESTAMP":
         if len(args) > 1:
             args[1] = to_java_date_format(args[1])
         return f"TO_UNIX_TIMESTAMP({', '.join(args)})"

--- a/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
@@ -25,6 +25,9 @@ from feathub.dsl.ast import (
     UminusOp,
     BinaryOp,
     GroupNode,
+    IsOp,
+    NullNode,
+    CaseOp,
 )
 from feathub.processors.spark.ast_evaluator.functions import evaluate_function
 
@@ -80,3 +83,12 @@ class SparkAstEvaluator(AbstractAstEvaluator):
 
     def eval_group_node(self, ast: GroupNode, variables: Optional[Dict]) -> Any:
         return f"({self.eval(ast.child, variables)})"
+
+    def eval_is_op(self, ast: IsOp, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("IS/IS NOT operation is not supported.")
+
+    def eval_null_node(self, ast: NullNode, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("NULL operation is not supported.")
+
+    def eval_case_op(self, ast: CaseOp, variables: Optional[Dict]) -> Any:
+        raise RuntimeError("CASE operation is not supported.")

--- a/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
@@ -107,6 +107,6 @@ class SparkAstEvaluatorTest(unittest.TestCase):
         self.assertEqual("TRY_CAST(59 AS STRING)", self._eval("TRY_CAST(59 AS STRING)"))
 
     def test_logical_op(self):
-        self.assertEqual("false || true", self._eval("false || True"))
-        self.assertEqual("`a` || true", self._eval("a || True"))
-        self.assertEqual("true && false", self._eval("true && FALSE"))
+        self.assertEqual("false OR true", self._eval("false or True"))
+        self.assertEqual("`a` OR true", self._eval("a or True"))
+        self.assertEqual("true AND false", self._eval("true and FALSE"))

--- a/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
+++ b/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
@@ -120,6 +120,12 @@ class SparkDataFrameBuilder:
     def _get_dataframe_from_derived_feature_view(
         self, feature_view: DerivedFeatureView
     ) -> NativeSparkDataFrame:
+        # TODO: Support filtering DerivedFeatureView in SparkProcessor.
+        if feature_view.filter_expr is not None:
+            raise FeathubException(
+                "SparkProcessor does not support filtering DerivedFeatureView."
+            )
+
         source_dataframe = self._get_spark_dataframe(feature_view.get_resolved_source())
         tmp_dataframe = source_dataframe
 

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -113,3 +113,9 @@ class SparkProcessorITTest(
 
     def test_over_window_transform_filter_expr_with_window_size_and_limit(self):
         pass
+
+    def test_case(self):
+        pass
+
+    def test_case_else(self):
+        pass


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for several expression syntaxes and filtering in Derived/SlidingFeatureView in FlinkProcessor.

## Brief change log

- Support the following syntaxes in Feathub's parser and FlinkProcessor.
  - `LOWER(str)`
  - `CASE WHEN expr1 THEN expr2 [WHEN expr3 THEN expr4]* [ELSE expr5] END`
  - `x IS[ NOT] NULL`
- Add API to filter features in `DerivedFeatureView` and `SlidingFeatureView`, and add corresponding support in FlinkProcessor.
- Fix the keyword of logical operations in Feathub(`&&/||` -> `AND/OR`).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs and python docs.