### PR TITLE
Make Feature dtype optional

### DIFF
--- a/python/feathub/dsl/expr_parser.py
+++ b/python/feathub/dsl/expr_parser.py
@@ -46,7 +46,7 @@ class ExprParser:
     precedence = (
         ("left", "OR"),
         ("left", "AND"),
-        ("left", "LT", "LE", "GT", "GE", "EQ", "NE"),
+        ("left", "LT", "LE", "GT", "GE", "EQ", "NE", "IS", "NOT"),
         ("left", "+", "-"),
         ("left", "*", "/"),
         ("right", "UMINUS"),

--- a/python/feathub/dsl/tests/test_ast_type_derive.py
+++ b/python/feathub/dsl/tests/test_ast_type_derive.py
@@ -1,0 +1,162 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+from feathub.common.exceptions import FeathubExpressionException
+from feathub.common.types import (
+    Int32,
+    Bool,
+    Float64,
+    String,
+    Int64,
+    Float32,
+    Bytes,
+    Timestamp,
+    DType,
+)
+from feathub.dsl.expr_parser import ExprParser
+
+
+class AstTypeDeriverTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.expr_parser = ExprParser()
+
+    def test_binary_op_type_derive(self):
+        expected_types = [
+            # (LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE)
+            (Int32, Int32, Int32),
+            (Int32, Int64, Int64),
+            (Int32, Float32, Float32),
+            (Int32, Float64, Float64),
+            (Int64, Int64, Int64),
+            (Int64, Float32, Float32),
+            (Int64, Float64, Float64),
+            (Float32, Float32, Float32),
+            (Float32, Float64, Float64),
+            (Float64, Float64, Float64),
+        ]
+
+        for left_type, right_type, result_type in expected_types:
+            ast = self.expr_parser.parse("a + b")
+            actual_result_type = ast.eval_dtype({"a": left_type, "b": right_type})
+            self.assertEqual(result_type, actual_result_type)
+
+        with self.assertRaises(FeathubExpressionException):
+            ast = self.expr_parser.parse("a + b")
+            ast.eval_dtype({"a": Int32, "b": String})
+
+    def test_variable_node_type_derive(self):
+        ast = self.expr_parser.parse("a")
+        self.assertEqual(Int32, ast.eval_dtype({"a": Int32}))
+
+    def test_uminus_node_type_derive(self):
+        ast = self.expr_parser.parse("-a")
+        self.assertEqual(Int32, ast.eval_dtype({"a": Int32}))
+
+    def test_compare_node_type_derive(self):
+        ast = self.expr_parser.parse("a < 1")
+        self.assertEqual(Bool, ast.eval_dtype({"a": Int32}))
+
+    def test_value_node_type_derive(self):
+        ast = self.expr_parser.parse("1")
+        self.assertEqual(Int32, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("1.0")
+        self.assertEqual(Float64, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("true")
+        self.assertEqual(Bool, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("'Feathub'")
+        self.assertEqual(String, ast.eval_dtype({}))
+
+    def test_type_cast_type_derive(self):
+        ast = self.expr_parser.parse("CAST(1 AS INTEGER)")
+        self.assertEqual(Int32, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS BIGINT)")
+        self.assertEqual(Int64, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS FLOAT)")
+        self.assertEqual(Float32, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS DOUBLE)")
+        self.assertEqual(Float64, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS STRING)")
+        self.assertEqual(String, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS BYTES)")
+        self.assertEqual(Bytes, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS BOOLEAN)")
+        self.assertEqual(Bool, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CAST(1 AS TIMESTAMP)")
+        self.assertEqual(Timestamp, ast.eval_dtype({}))
+
+    def test_logical_op_type_derive(self):
+        ast = self.expr_parser.parse("true or False")
+        self.assertEqual(Bool, ast.eval_dtype({}))
+
+    def test_is_op_result_type(self):
+        ast = self.expr_parser.parse("a is NULL")
+        self.assertEqual(Bool, ast.eval_dtype({}))
+
+    def test_function_call_result_type(self):
+        ast = self.expr_parser.parse("LOWER('ABC')")
+        self.assertEqual(String, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("UNIX_TIMESTAMP('2022-01-01 00:00:00')")
+        self.assertEqual(Int64, ast.eval_dtype({}))
+
+    def test_group_node_result_type(self):
+        ast = self.expr_parser.parse("a * (b + c)")
+        self.assertEqual(
+            Int64,
+            ast.eval_dtype({"a": Int32, "b": Int64, "c": Int64}),
+        )
+
+    def test_case_op_result_type(self):
+        ast = self.expr_parser.parse("CASE WHEN TRUE THEN a ELSE b END")
+        self.assertEqual(
+            Int32,
+            ast.eval_dtype({"a": Int32, "b": Int32}),
+        )
+        self.assertEqual(
+            Float32,
+            ast.eval_dtype({"a": Int32, "b": Float32}),
+        )
+
+        with self.assertRaises(FeathubExpressionException):
+            ast.eval_dtype({"a": Int32, "b": String})
+
+        ast = self.expr_parser.parse(
+            "CASE WHEN TRUE THEN a WHEN TRUE THEN b WHEN TRUE THEN c END"
+        )
+        self.assertEqual(
+            Float32, ast.eval_dtype({"a": Int32, "b": Int64, "c": Float32})
+        )
+
+    def _to_sql_type(self, dtype: DType) -> str:
+        if dtype == Int32:
+            return "INTEGER"
+        elif dtype == Int64:
+            return "BIGINT"
+        elif dtype == Float32:
+            return "FLOAT"
+        elif dtype == Float64:
+            return "DOUBLE"
+        else:
+            raise RuntimeError("Unknown type.")

--- a/python/feathub/feature_tables/feature_table.py
+++ b/python/feathub/feature_tables/feature_table.py
@@ -74,7 +74,7 @@ class FeatureTable(TableDescriptor, ABC):
         self.properties = properties
         self.schema = schema
 
-    def get_feature(self, feature_name: str) -> Feature:
+    def get_output_features(self) -> List[Feature]:
         if self.schema is None:
             raise FeathubException(
                 "The feature table does not have schema. Feature can not be derived. "
@@ -82,17 +82,15 @@ class FeatureTable(TableDescriptor, ABC):
                 "and define the features explicitly in the FeatureView."
             )
 
-        if feature_name not in self.schema.field_names:
-            raise FeathubException(
-                f"Failed to find the feature '{feature_name}' in {self.to_json()}."
+        return [
+            Feature(
+                name=field_name,
+                dtype=self.schema.get_field_type(field_name),
+                transform=field_name,
+                keys=self.keys,
             )
-
-        return Feature(
-            name=feature_name,
-            dtype=self.schema.get_field_type(feature_name),
-            transform=feature_name,
-            keys=self.keys,
-        )
+            for field_name in self.schema.field_names
+        ]
 
     def is_bounded(self) -> bool:
         # FeatureTable is bounded by default unless subclass overwrite the method.

--- a/python/feathub/feature_views/feature.py
+++ b/python/feathub/feature_views/feature.py
@@ -35,8 +35,8 @@ class Feature:
     def __init__(
         self,
         name: str,
-        dtype: DType,
         transform: Union[str, Transformation],
+        dtype: Optional[DType] = None,
         keys: Optional[Sequence[str]] = None,
         input_features: Sequence[Feature] = (),
     ):
@@ -79,7 +79,7 @@ class Feature:
     def to_json(self) -> Dict:
         return {
             "name": self.name,
-            "dtype": self.dtype.to_json(),
+            "dtype": None if self.dtype is None else self.dtype.to_json(),
             "transform": self.transform.to_json(),
             "keys": self.keys,
             "input_features": [feature.to_json() for feature in self.input_features],

--- a/python/feathub/feature_views/transforms/agg_func.py
+++ b/python/feathub/feature_views/transforms/agg_func.py
@@ -16,6 +16,10 @@ from enum import Enum
 
 
 # TODO: Add docs about the supported AggFunc to README.
+from feathub.common.exceptions import FeathubException
+from feathub.common.types import DType, Float64, Int64, MapType
+
+
 class AggFunc(Enum):
     """Supported aggregation function for over/sliding window transform."""
 
@@ -28,3 +32,21 @@ class AggFunc(Enum):
     ROW_NUMBER = "ROW_NUMBER"
     COUNT = "COUNT"
     VALUE_COUNTS = "VALUE_COUNTS"
+
+    def get_result_type(self, input_type: DType) -> DType:
+        if self == AggFunc.AVG:
+            return Float64
+        elif (
+            self == AggFunc.SUM
+            or self == AggFunc.MAX
+            or self == AggFunc.MIN
+            or self == AggFunc.FIRST_VALUE
+            or self == AggFunc.LAST_VALUE
+        ):
+            return input_type
+        elif self == AggFunc.ROW_NUMBER or self == AggFunc.COUNT:
+            return Int64
+        elif self == AggFunc.VALUE_COUNTS:
+            return MapType(input_type, Int64)
+
+        raise FeathubException(f"Unknown AggFunc {self}.")

--- a/python/feathub/feature_views/transforms/tests/test_agg_func.py
+++ b/python/feathub/feature_views/transforms/tests/test_agg_func.py
@@ -1,0 +1,32 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+from feathub.common.types import Int32, Float64, Int64, MapType
+from feathub.feature_views.transforms.agg_func import AggFunc
+
+
+class AggFuncTest(unittest.TestCase):
+    def test_get_result_type(self):
+        self.assertEqual(Int32, AggFunc.SUM.get_result_type(Int32))
+        self.assertEqual(Int32, AggFunc.MIN.get_result_type(Int32))
+        self.assertEqual(Int32, AggFunc.MAX.get_result_type(Int32))
+        self.assertEqual(Int32, AggFunc.FIRST_VALUE.get_result_type(Int32))
+        self.assertEqual(Int32, AggFunc.LAST_VALUE.get_result_type(Int32))
+        self.assertEqual(Float64, AggFunc.AVG.get_result_type(Int32))
+        self.assertEqual(Int64, AggFunc.ROW_NUMBER.get_result_type(Int32))
+        self.assertEqual(Int64, AggFunc.COUNT.get_result_type(Int32))
+        self.assertEqual(
+            MapType(Int32, Int64), AggFunc.VALUE_COUNTS.get_result_type(Int32)
+        )

--- a/python/feathub/feature_views/transforms/tests/test_join_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_join_transform.py
@@ -34,12 +34,10 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 Feature(
                     name="distance",
-                    dtype=Int64,
                     transform="distance",
                 ),
             ],
@@ -69,7 +67,6 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 "distance",
@@ -84,7 +81,6 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="derived_cost",
-                    dtype=Float64,
                     transform="avg_cost * distance",
                 ),
             ],
@@ -181,14 +177,12 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 "distance",
                 f"{source_2.name}.avg_cost",
                 Feature(
                     name="derived_cost",
-                    dtype=Float64,
                     transform="avg_cost * distance",
                 ),
             ],
@@ -253,12 +247,10 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 Feature(
                     name="distance",
-                    dtype=Int64,
                     transform="distance",
                 ),
             ],
@@ -289,7 +281,6 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 "distance",
@@ -304,7 +295,6 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="derived_cost",
-                    dtype=Float64,
                     transform="avg_cost * distance",
                 ),
             ],

--- a/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
@@ -17,7 +17,7 @@ from math import sqrt
 
 import pandas as pd
 
-from feathub.common.types import Int64, String, Float64, MapType
+from feathub.common.types import Int64, String, Float64
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
 from feathub.feature_views.transforms.over_window_transform import OverWindowTransform
@@ -33,13 +33,11 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_cost_per_mile = Feature(
             name="cost_per_mile",
-            dtype=Float64,
             transform="CAST(cost AS DOUBLE) / CAST(distance AS DOUBLE) + 10",
         )
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -49,7 +47,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
         f_avg_cost = Feature(
             name="avg_cost",
-            dtype=Float64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="AVG",
@@ -59,7 +56,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
         f_max_cost = Feature(
             name="max_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="MAX",
@@ -69,7 +65,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
         f_min_cost = Feature(
             name="min_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="MIN",
@@ -121,7 +116,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         with self.assertRaises(ValueError):
             Feature(
                 name="feature_1",
-                dtype=Int64,
                 transform=OverWindowTransform(
                     "cost", "unsupported_agg", window_size=timedelta(days=2)
                 ),
@@ -133,7 +127,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -168,7 +161,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost", agg_func="SUM", group_by_keys=["name"]
             ),
@@ -201,7 +193,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost", agg_func="SUM", group_by_keys=["name"], limit=2
             ),
@@ -241,7 +232,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost_sum",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",
@@ -297,7 +287,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost_sum",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",
@@ -336,7 +325,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost_sum",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",
@@ -344,7 +332,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                         window_size=timedelta(milliseconds=3),
                     ),
                 ),
-                Feature(name="double_cost_sum", dtype=Int64, transform="cost_sum * 2"),
+                Feature(name="double_cost_sum", transform="cost_sum * 2"),
             ],
         )
 
@@ -384,7 +372,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="cost_sum",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",
@@ -431,15 +418,14 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     "avg_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
-                        expr="cost",
+                        expr="CAST(cost AS DOUBLE)",
                         agg_func="AVG",
                         group_by_keys=["name"],
                         window_size=timedelta(days=2),
                     ),
                 ),
-                Feature("ten_times_cost", dtype=Int64, transform="10 * cost"),
+                Feature("ten_times_cost", transform="10 * cost"),
             ],
             keep_source_fields=True,
         )
@@ -516,7 +502,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="last_2_last_2_minute_total_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",
@@ -527,7 +512,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="last_2_last_2_minute_avg_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="AVG",
@@ -538,7 +522,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="last_2_last_2_minute_max_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="MAX",
@@ -549,7 +532,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="last_2_last_2_minute_min_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="MIN",
@@ -669,7 +651,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="row_num",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="ROW_NUMBER",
@@ -717,7 +698,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost_value_counts_limit",
-                    dtype=MapType(String, Int64),
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="VALUE_COUNTS",
@@ -728,7 +708,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="cost_value_counts",
-                    dtype=MapType(String, Int64),
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="VALUE_COUNTS",
@@ -742,24 +721,24 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         expected_df = df.copy()
         expected_df["cost_value_counts_limit"] = pd.Series(
             [
-                {"100": 1},
-                {"100": 2},
-                {"400": 1},
-                {"100": 2},
-                {"200": 1, "400": 1},
-                {"500": 1},
-                {"100": 1, "600": 1},
+                {100: 1},
+                {100: 2},
+                {400: 1},
+                {100: 2},
+                {200: 1, 400: 1},
+                {500: 1},
+                {100: 1, 600: 1},
             ]
         )
         expected_df["cost_value_counts"] = pd.Series(
             [
-                {"100": 1},
-                {"100": 2},
-                {"400": 1},
-                {"100": 3},
-                {"200": 1, "400": 1},
-                {"500": 1},
-                {"100": 1, "600": 1},
+                {100: 1},
+                {100: 2},
+                {400: 1},
+                {100: 3},
+                {200: 1, 400: 1},
+                {500: 1},
+                {100: 1, 600: 1},
             ]
         )
         expected_df.drop(["cost", "distance"], axis=1, inplace=True)
@@ -822,7 +801,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_all_total_cost = Feature(
             name="all_total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -831,14 +809,12 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
         f_not_ranged_total_cost = Feature(
             name="not_ranged_total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost", agg_func="SUM", group_by_keys=["name"]
             ),
         )
         f_time_window_total_cost = Feature(
             name="time_window_total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -848,14 +824,12 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
         f_row_limit_total_cost = Feature(
             name="row_limit_total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost", agg_func="SUM", group_by_keys=["name"], limit=2
             ),
         )
         f_time_window_row_limit_total_cost = Feature(
             name="time_window_row_limit_total_cost",
-            dtype=Int64,
             transform=OverWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -933,19 +907,16 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="cost",
-                    dtype=Int64,
                     transform="cost",
                 ),
                 "distance",
                 f"{source_2.name}.avg_cost",
                 Feature(
                     name="derived_cost",
-                    dtype=Float64,
                     transform="avg_cost * distance",
                 ),
                 Feature(
                     name="last_avg_cost",
-                    dtype=Int64,
                     transform=OverWindowTransform(
                         expr="avg_cost",
                         agg_func="LAST_VALUE",
@@ -956,7 +927,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="double_last_avg_cost",
-                    dtype=Float64,
                     transform="last_avg_cost * 2",
                 ),
             ],
@@ -994,6 +964,47 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         self.assertListEqual(["name"], built_feature_view_2.keys)
         self.assertTrue(expected_result_df.equals(result_df))
 
+    def test_over_window_transform_feature_with_dtype(self):
+        df = self.input_data.copy()
+        source = self.create_file_source(df)
+
+        feature_view = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                Feature(
+                    name="cost_sum",
+                    transform=OverWindowTransform(
+                        expr="cost",
+                        agg_func="SUM",
+                        group_by_keys=["name"],
+                        window_size=timedelta(days=2),
+                    ),
+                    dtype=Float64,
+                ),
+            ],
+        )
+
+        expected_df = df.copy()
+        expected_df["cost_sum"] = pd.Series([100, 400, 400, 600, 500, 900]).astype(
+            "Float64"
+        )
+        expected_df.drop(["cost", "distance"], axis=1, inplace=True)
+        expected_df = expected_df.sort_values(by=["name", "time"]).reset_index(
+            drop=True
+        )
+
+        result_df = (
+            self.client.get_features(feature_view)
+            .to_pandas()
+            .sort_values(by=["name", "time"])
+            .reset_index(drop=True)
+        )
+        self.assertTrue(
+            expected_df.equals(result_df),
+            f"Expected: {expected_df}\n Actual: {result_df}",
+        )
+
     def _over_window_transform_first_last_value(
         self,
         window_size=None,
@@ -1008,7 +1019,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="first_time",
-                    dtype=String,
                     transform=OverWindowTransform(
                         expr="`time`",
                         agg_func="FIRST_VALUE",
@@ -1019,7 +1029,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
                 ),
                 Feature(
                     name="last_time",
-                    dtype=String,
                     transform=OverWindowTransform(
                         expr="`time`",
                         agg_func="LAST_VALUE",
@@ -1068,7 +1077,6 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             features=[
                 Feature(
                     name="last_2_pay_last_2_minute_total_cost",
-                    dtype=Float64,
                     transform=OverWindowTransform(
                         expr="cost",
                         agg_func="SUM",

--- a/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
@@ -18,7 +18,7 @@ from math import sqrt
 import pandas as pd
 
 from feathub.common.test_utils import to_epoch_millis, to_epoch
-from feathub.common.types import Int64, String, Float64, MapType, Float32
+from feathub.common.types import Int64, String, Float64, Float32
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
 from feathub.feature_views.sliding_feature_view import (
@@ -54,7 +54,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=SlidingWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -131,7 +130,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=SlidingWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -244,7 +242,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=SlidingWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -683,7 +680,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                 features=[
                     Feature(
                         name="last_2_minute_total_pay",
-                        dtype=Float64,
                         transform=SlidingWindowTransform(
                             expr="cost",
                             agg_func="SUM",
@@ -707,7 +703,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="pay_count",
-                        dtype=Int64,
                         transform=SlidingWindowTransform(
                             expr="0",
                             agg_func="COUNT",
@@ -1098,7 +1093,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                 features=[
                     Feature(
                         name="first_time",
-                        dtype=String,
                         transform=SlidingWindowTransform(
                             expr="`time`",
                             agg_func="FIRST_VALUE",
@@ -1109,7 +1103,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="last_time",
-                        dtype=String,
                         transform=SlidingWindowTransform(
                             expr="`time`",
                             agg_func="LAST_VALUE",
@@ -1127,7 +1120,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="cnt",
-                        dtype=Int64,
                         transform=SlidingWindowTransform(
                             expr="0",
                             agg_func="COUNT",
@@ -1244,7 +1236,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                 features=[
                     Feature(
                         name="last_2_minute_total_cost",
-                        dtype=Float64,
                         transform=SlidingWindowTransform(
                             expr="cost",
                             agg_func="SUM",
@@ -1255,7 +1246,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="cnt",
-                        dtype=Int64,
                         transform=SlidingWindowTransform(
                             expr="1",
                             agg_func="COUNT",
@@ -1317,19 +1307,19 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:01:59.999"),
-                            {"100.0": 2},
+                            {100.0: 2},
                             2,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:02:59.999"),
-                            {"200.0": 2, "100.0": 1},
+                            {200.0: 2, 100.0: 1},
                             3,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:03:59.999"),
-                            {"200.0": 2},
+                            {200.0: 2},
                             2,
                         ],
                         ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
@@ -1349,19 +1339,19 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:01:59.999"),
-                            {"100.0": 2},
+                            {100.0: 2},
                             2,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:02:59.999"),
-                            {"200.0": 2, "100.0": 1},
+                            {200.0: 2, 100.0: 1},
                             3,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:03:59.999"),
-                            {"200.0": 2},
+                            {200.0: 2},
                             2,
                         ],
                     ],
@@ -1380,19 +1370,19 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:01:59.999"),
-                            {"100.0": 2},
+                            {100.0: 2},
                             2,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:02:59.999"),
-                            {"200.0": 2, "100.0": 1},
+                            {200.0: 2, 100.0: 1},
                             3,
                         ],
                         [
                             "Alex",
                             to_epoch_millis("2022-01-01 09:03:59.999"),
-                            {"200.0": 2},
+                            {200.0: 2},
                             2,
                         ],
                         ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
@@ -1414,7 +1404,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                 features=[
                     Feature(
                         name="last_2_minute_cost_value_counts",
-                        dtype=MapType(String, Int64),
                         transform=SlidingWindowTransform(
                             expr="cost",
                             agg_func="VALUE_COUNTS",
@@ -1426,7 +1415,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="cnt",
-                        dtype=Int64,
                         transform=SlidingWindowTransform(
                             expr="1",
                             agg_func="COUNT",
@@ -1588,7 +1576,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                 features=[
                     Feature(
                         name="cnt",
-                        dtype=Int64,
                         transform=SlidingWindowTransform(
                             expr="1",
                             agg_func="COUNT",
@@ -1600,7 +1587,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                     ),
                     Feature(
                         name="epoch_window_time",
-                        dtype=Int64,
                         transform="UNIX_TIMESTAMP(sliding_window_timestamp)",
                     ),
                 ],
@@ -1634,12 +1620,13 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             return row["name"].lower()
 
         f_lower_name = Feature(
-            name="lower_name", dtype=String, transform=PythonUdfTransform(name_to_lower)
+            name="lower_name",
+            dtype=String,
+            transform=PythonUdfTransform(name_to_lower),
         )
 
         f_total_cost = Feature(
             name="total_cost",
-            dtype=Int64,
             transform=SlidingWindowTransform(
                 expr="cost",
                 agg_func="SUM",
@@ -2015,7 +2002,6 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
 
         f_cost_value_counts_two_days = Feature(
             name="cost_value_counts_two_days",
-            dtype=MapType(Int64, Int64),
             transform=SlidingWindowTransform(
                 expr="cost",
                 agg_func="VALUE_COUNTS",
@@ -2251,3 +2237,91 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             expected_result_df.equals(result_df),
             f"expected: {expected_result_df}\n" f"actual: {result_df}",
         )
+
+    def test_sliding_window_feature_with_dtype(self):
+        df = self.input_data.copy()
+        source = self.create_file_source(df)
+
+        f_total_cost = Feature(
+            name="total_cost",
+            transform=SlidingWindowTransform(
+                expr="cost",
+                agg_func="SUM",
+                window_size=timedelta(days=1),
+                step_size=timedelta(days=1),
+                group_by_keys=["name"],
+            ),
+            dtype=Float64,
+        )
+
+        expected_results = [
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100.0],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 300.0],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 600.0],
+                        ["Alex", to_epoch_millis("2022-01-04 23:59:59.999"), 0.0],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400.0],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 200.0],
+                        ["Emma", to_epoch_millis("2022-01-03 23:59:59.999"), 0.0],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500.0],
+                        ["Jack", to_epoch_millis("2022-01-04 23:59:59.999"), 0.0],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+            (
+                DISABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100.0],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 300.0],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 600.0],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400.0],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 200.0],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500.0],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+            (
+                ENABLE_EMPTY_WINDOW_OUTPUT_WITHOUT_SKIP_SAME_WINDOW_OUTPUT,
+                pd.DataFrame(
+                    [
+                        ["Alex", to_epoch_millis("2022-01-01 23:59:59.999"), 100.0],
+                        ["Alex", to_epoch_millis("2022-01-02 23:59:59.999"), 300.0],
+                        ["Alex", to_epoch_millis("2022-01-03 23:59:59.999"), 600.0],
+                        ["Alex", to_epoch_millis("2022-01-04 23:59:59.999"), 0.0],
+                        ["Emma", to_epoch_millis("2022-01-01 23:59:59.999"), 400.0],
+                        ["Emma", to_epoch_millis("2022-01-02 23:59:59.999"), 200.0],
+                        ["Emma", to_epoch_millis("2022-01-03 23:59:59.999"), 0.0],
+                        ["Jack", to_epoch_millis("2022-01-03 23:59:59.999"), 500.0],
+                        ["Jack", to_epoch_millis("2022-01-04 23:59:59.999"), 0.0],
+                    ],
+                    columns=["name", "window_time", "total_cost"],
+                ),
+            ),
+        ]
+
+        for props, expected_result_df in expected_results:
+            features = SlidingFeatureView(
+                name="features",
+                source=source,
+                features=[f_total_cost],
+                props=props,
+            )
+
+            result_df = (
+                self.client.get_features(features=features)
+                .to_pandas()
+                .sort_values(by=["name", "window_time"])
+                .reset_index(drop=True)
+            )
+
+            self.assertTrue(
+                expected_result_df.equals(result_df),
+                f"Failed with props: {props}\nexpected: {expected_result_df}\n"
+                f"actual: {result_df}",
+            )

--- a/python/feathub/processors/flink/table_builder/tests/mock_table_descriptor.py
+++ b/python/feathub/processors/flink/table_builder/tests/mock_table_descriptor.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from abc import ABC
 from typing import Optional, List, Dict
 
 from feathub.feature_views.feature import Feature
@@ -22,7 +21,7 @@ from feathub.processors.flink.table_builder.source_sink_utils_common import (
 from feathub.table.table_descriptor import TableDescriptor
 
 
-class MockTableDescriptor(TableDescriptor, ABC):
+class MockTableDescriptor(TableDescriptor):
     def __init__(
         self,
         name: str = generate_random_table_name("mock_descriptor"),
@@ -37,7 +36,7 @@ class MockTableDescriptor(TableDescriptor, ABC):
             timestamp_format=timestamp_format,
         )
 
-    def get_feature(self, feature_name: str) -> Feature:
+    def get_output_features(self) -> List[Feature]:
         raise RuntimeError("Unsupported operation.")
 
     def is_bounded(self) -> bool:

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -255,26 +255,30 @@ class FlinkProcessorTest(unittest.TestCase):
             registry=self.registry,
         )
 
-        dim_source = FileSystemSource("dim_source", "/path", "csv", Schema([], []))
+        dim_source = FileSystemSource(
+            "dim_source", "/path", "csv", Schema(["a", "id"], [Int32, Int32])
+        )
         dim_feature_view = DerivedFeatureView(
             "dim_feature_view",
             source=dim_source,
             features=[Feature(name="a", dtype=Int32, transform="a", keys=["id"])],
         )
 
-        dim_source2 = FileSystemSource("dim_source2", "/path", "csv", Schema([], []))
+        dim_source2 = FileSystemSource(
+            "dim_source2", "/path", "csv", Schema(["b", "id"], [Int32, Int32])
+        )
         dim_feature_view_2 = DerivedFeatureView(
             "dim_feature_view_2",
             source=dim_source2,
             features=[Feature(name="b", dtype=Int32, transform="b", keys=["id"])],
         )
 
-        source = FileSystemSource("source", "/path", "csv", Schema([], []))
+        source = FileSystemSource("source", "/path", "csv", Schema(["id"], [Int32]))
         joined_feature_view = DerivedFeatureView(
             "joined_feature_view", source, features=["dim_feature_view.a"]
         )
 
-        source_2 = FileSystemSource("source2", "/path", "csv", Schema([], []))
+        source_2 = FileSystemSource("source2", "/path", "csv", Schema(["id"], [Int32]))
         joined_feature_view_2 = DerivedFeatureView(
             "joined_feature_view_2", source_2, features=["dim_feature_view_2.b"]
         )

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Optional, List, TYPE_CHECKING, Dict
 from abc import abstractmethod
 
+from feathub.common.exceptions import FeathubException
 from feathub.registries.entity import Entity
 from feathub.feature_views.feature import Feature
 
@@ -74,16 +75,27 @@ class TableDescriptor(Entity):
                       used to configure the given table descriptors.
         :return: A resolved table descriptor.
         """
-
         return self
 
-    @abstractmethod
     def get_feature(self, feature_name: str) -> Feature:
         """
         Returns the feature whose name matches the given feature name.
 
         :param feature_name: The name of the feature to look for.
         :return: The feature with the given name.
+        """
+        for feature in self.get_output_features():
+            if feature_name == feature.name:
+                return feature
+
+        raise FeathubException(
+            f"Failed to find the feature '{feature_name}' in {self.to_json()}."
+        )
+
+    @abstractmethod
+    def get_output_features(self) -> List[Feature]:
+        """
+        Return a list of output features of the table.
         """
         pass
 


### PR DESCRIPTION
## What is the purpose of the change

This PR makes dtype of Feature optional. Fix #68.

## Brief change log

- Make dtype of Feature optional.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Python docstring