### PR TITLE
Support reordering of output features in feature view

### DIFF
--- a/python/feathub/feature_views/transforms/tests/test_expression_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_expression_transform.py
@@ -329,7 +329,9 @@ class ExpressionTransformITTest(ABC, FeathubITTestBase):
             .reset_index(drop=True)
         )
 
-        expected_result_df = self.input_data.copy()
+        expected_result_df = self.input_data.copy()[
+            ["name", "distance", "time", "cost"]
+        ]
         expected_result_df["cost"] = expected_result_df.apply(
             lambda row: row["cost"] + 1, axis=1
         )

--- a/python/feathub/feature_views/transforms/tests/test_join_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_join_transform.py
@@ -91,7 +91,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             [source_2, feature_view_2, feature_view_3]
         )
 
-        expected_result_df = df_1
+        expected_result_df = df_1[["name", "time", "cost", "distance"]]
         expected_result_df["avg_cost"] = pd.Series(
             [None, None, 200.0, 400.0, None, 200.0]
         )
@@ -193,7 +193,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             [source_2, feature_view_2]
         )
 
-        expected_result_df = df_1
+        expected_result_df = df_1[["name", "time", "cost", "distance"]]
         expected_result_df["avg_cost"] = pd.Series(
             [None, None, 200.0, 400.0, None, 200.0]
         )
@@ -305,7 +305,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
             [source_2, feature_view_2, feature_view_3]
         )
 
-        expected_result_df = df_1
+        expected_result_df = df_1[["name", "time", "cost", "distance"]]
         expected_result_df["avg_cost"] = pd.Series(
             [None, None, 100.0, 400.0, None, 200.0]
         )

--- a/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
@@ -937,7 +937,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             [source_2, feature_view_2]
         )
 
-        expected_result_df = df_1
+        expected_result_df = df_1[["name", "time", "cost", "distance"]]
         expected_result_df["avg_cost"] = pd.Series(
             [None, None, 100.0, 400.0, None, 200.0]
         )


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Feathub - we are happy that you want to help us improve Feathub. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
## Contribution Checklist
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review. 
  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support reordering of output features in feature view. The order of output fields would follow these principles:
* If `keep_source_fields` is not set, select all derived fields in the order that the user assigned.
* If `keep_source_fields` is set, select all source fields that are not overridden first, then select derived fields.

## Brief change log

  - Replace the current reordering logic with the above principles.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)