### PR TITLE
LocalProcessor supports filtering in Derived/SlidingFeatureView

### DIFF
--- a/python/feathub/feature_views/tests/test_derived_feature_view.py
+++ b/python/feathub/feature_views/tests/test_derived_feature_view.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import pandas as pd
 
-from feathub.common.types import String
+from feathub.common.types import String, Float64
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
 from feathub.feature_views.transforms.python_udf_transform import PythonUdfTransform
@@ -92,6 +92,51 @@ class DerivedFeatureViewITTest(ABC, FeathubITTestBase):
                 ["Jack", 500, 500, "2022-01-03 08:05:00", "Jack"],
             ],
             columns=["name", "cost", "distance", "time", "name_without_alex"],
+        )
+
+        expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(
+            drop=True
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_filter_float_is_null(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        def alex_cost_to_null(row: pd.Series) -> Optional[float]:
+            if row["name"] == "Alex":
+                return None
+            return float(row["cost"])
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                Feature(
+                    name="float_cost",
+                    dtype=Float64,
+                    transform=PythonUdfTransform(alex_cost_to_null),
+                    keys=["name"],
+                )
+            ],
+            keep_source_fields=True,
+            filter_expr="float_cost IS NOT NULL",
+        )
+
+        result_df = (
+            self.client.get_features(features)
+            .to_pandas()
+            .sort_values(by=["time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = pd.DataFrame(
+            [
+                ["Emma", 400, 250, "2022-01-01 08:02:00", 400.0],
+                ["Emma", 200, 250, "2022-01-02 08:04:00", 200.0],
+                ["Jack", 500, 500, "2022-01-03 08:05:00", 500.0],
+            ],
+            columns=["name", "cost", "distance", "time", "float_cost"],
         )
 
         expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(

--- a/python/feathub/processors/local/ast_evaluator/tests/test_local_ast_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/tests/test_local_ast_evaluator.py
@@ -15,6 +15,8 @@
 import unittest
 from datetime import datetime
 
+import numpy as np
+
 from feathub.common.exceptions import FeathubException, FeathubExpressionException
 from feathub.dsl.expr_parser import ExprParser
 from feathub.processors.local.ast_evaluator.local_ast_evaluator import LocalAstEvaluator
@@ -112,6 +114,9 @@ class LocalAstEvaluatorTest(unittest.TestCase):
         self.assertEqual(False, self._eval("a IS NULL", {"a": 1}))
         self.assertEqual(False, self._eval("a IS NOT NULL", {"a": None}))
         self.assertEqual(True, self._eval("a IS NOT NULL", {"a": 1}))
+        self.assertEqual(False, self._eval("a IS NOT NULL", {"a": np.NAN}))
+        self.assertEqual(True, self._eval("a IS NOT NULL", {"a": "123"}))
+        self.assertEqual(True, self._eval("a IS NOT NULL", {"a": {"k": 1}}))
 
     def test_case_op(self):
         expr = "CASE WHEN a > b THEN 1 WHEN a < b THEN 2 ELSE 3 END"

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -17,6 +17,12 @@ from feathub.feathub_client import FeathubClient
 from feathub.feature_tables.tests.test_file_system_source_sink import (
     FileSystemSourceSinkITTest,
 )
+from feathub.feature_views.tests.test_derived_feature_view import (
+    DerivedFeatureViewITTest,
+)
+from feathub.feature_views.tests.test_sliding_feature_view import (
+    SlidingFeatureViewITTest,
+)
 from feathub.feature_views.transforms.tests.test_expression_transform import (
     ExpressionTransformITTest,
 )
@@ -47,6 +53,8 @@ class LocalProcessorITTest(
     OverWindowTransformITTest,
     PythonUDFTransformITTest,
     SlidingWindowTransformITTest,
+    DerivedFeatureViewITTest,
+    SlidingFeatureViewITTest,
 ):
     __test__ = True
 


### PR DESCRIPTION
## What is the purpose of the change

Update LocalProcessor to support filtering in DerivedFeatureView and SlidingFeatureView.

## Brief change log

- Update LocalProcessor to support filtering in DerivedFeatureView and SlidingFeatureView
- Fix the bug in the LocalProcessor ast evaluator to handle IS NULL for numpy floating and python native float type

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable