### PR TITLE
Support existing connectors with Spark local mode in LocalProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,11 @@ See [Basic Concepts](docs/content/concepts/basic-concepts.md) for more details a
 FeatHub supports the following compute engines to execute feature ETL pipeline:
 - [Apache Flink 1.15](docs/content/engines/flink.md)
 - [Aapche Spark 3.3](docs/content/engines/spark.md)
-- Local processor, which is implemented using the Pandas library and computes features in the given Python process.
+- Local processor, which is implemented using the Pandas library and computes
+  features in the given Python process. Additionally, if the
+  feathub-nightly[spark] is installed, the Local processor can utilize Spark's
+  local mode for accessing storages (e.g. HDFS) that it otherwise did not
+  support.
 
 
 ## FeatHub SDK Highlights
@@ -213,7 +217,8 @@ $ python -m pip install --upgrade feathub-nightly
 # Run the following command if you plan to use Apache Flink cluster
 $ python -m pip install --upgrade "feathub-nightly[flink]"
 
-# Run the following command if you plan to use Apache Spark cluster
+# Run the following command if you plan to use Apache Spark cluster, or to use
+# Spark-supported storage in a local process. 
 $ python -m pip install --upgrade "feathub-nightly[spark]"
 ```
 

--- a/docs/content/connectors/filesystem.md
+++ b/docs/content/connectors/filesystem.md
@@ -15,9 +15,11 @@ Various processors support different types of file systems, including popular on
 as local, HDFS, Amazon S3, and Aliyun OSS. Below are the file system types that have 
 been tested and supported by each processor.
 
-- Local: local
+- Local: local, HDFS<sup>1</sup>
 - Flink: local, HDFS, Amazon S3, Aliyun OSS
 - Spark: local, HDFS
+
+1. Supported via Spark's local mode.
 
 ## Examples
 

--- a/python/feathub/feature_tables/tests/test_print_sink.py
+++ b/python/feathub/feature_tables/tests/test_print_sink.py
@@ -28,3 +28,10 @@ class PrintSinkITTest(ABC, FeathubITTestBase):
             sink=sink,
             allow_overwrite=True,
         ).wait()
+
+    def test_print_sink_execute_insert(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        sink = PrintSink()
+
+        self.client.get_features(source).execute_insert(sink=sink, allow_overwrite=True)


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports in LocalProcessor all the connectors that have been supported in SparkProcessor.

## Brief change log

- Add support to read/write with SparkProcessor-supported connectors in LocalProcessor with Spark local mode.
- Add test for `DataGenSource`, `PrintSink` and `BlackHoleSink` in LocalProcessorITTest.

## Verifying the changes

- Most changes in this PR has been covered by the added it tests.
- LocalProcessor's ability to read/write HDFS is covered in the e2e example [here](https://github.com/yunfengzhou-hub/feathub-examples/tree/local-hdfs-example/local-read-write-hdfs).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs