### PR TITLE
FlinkProcessor FileSystem/Kakfa source/sink support protobuf format

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ $ python -m pip install "./python[spark]"
 ### Run Tests
 
 ```bash
-$ mvn test -f ./java
+$ mvn clean package -f ./java
 $ pytest --tb=line -W ignore::DeprecationWarning ./python
 ```
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -18,6 +18,7 @@ applications.
 	- [Apache Spark](engines/spark.md)
 - [Connectors](connectors/_index.md)
   - [Overview](connectors/overview.md) 
+  - [Formats](connectors/formats/_index.md)
   - [FileSystem](connectors/filesystem.md)
   - [MySql](connectors/mysql.md)
   - [Kafka](connectors/kafka.md)

--- a/docs/content/connectors/_index.md
+++ b/docs/content/connectors/_index.md
@@ -1,9 +1,8 @@
 # Connectors
 
 - [Overview](overview.md)
+- [Formats](formats/_index.md)
 - [FileSystem](filesystem.md)
 - [MySql](mysql.md)
 - [Kafka](kafka.md)
 - [Redis](redis.md)
-
-<!-- TODO: Add documentations for all the connectors -->

--- a/docs/content/connectors/filesystem.md
+++ b/docs/content/connectors/filesystem.md
@@ -21,6 +21,12 @@ been tested and supported by each processor.
 
 1. Supported via Spark's local mode.
 
+## Supported format
+
+- Local: CSV, JSON
+- Flink: CSV, JSON, Protobuf
+- Spark: CSV, JSON
+
 ## Examples
 
 Here are the examples of using `FileSystemSource` and `FileSystemSink`:

--- a/docs/content/connectors/formats/_index.md
+++ b/docs/content/connectors/formats/_index.md
@@ -1,0 +1,5 @@
+# Formats
+
+- [CSV](csv.md)
+- [JSON](json.md)
+- [Protobuf](protobuf.md)

--- a/docs/content/connectors/formats/csv.md
+++ b/docs/content/connectors/formats/csv.md
@@ -1,0 +1,27 @@
+# CSV Format
+
+The CSV format allows to read and write CSV data based on an CSV schema. The CSV schema 
+is derived from table schema.
+
+## Format Options
+
+| key                | Required | default | type    | Description                                                                                          |
+|--------------------|----------|---------|---------|------------------------------------------------------------------------------------------------------|
+| ignore_parse_error | Optional | True    | boolean | Skip fields and rows with parse errors instead of failing. Fields are set to null in case of errors. |
+
+
+## Data Type Mapping
+
+The following table lists the type mapping from Feathub type to CSV type.
+
+| Feathub type | Csv type                      |
+|--------------|-------------------------------|
+| Bytes        | string with encoding: base64  |
+| String       | string                        |
+| Int32        | number                        |
+| Int64        | number                        |
+| Float32      | number                        |
+| Float64      | number                        |
+| Bool         | boolean                       |
+| Timestamp    | string with format: date-time |
+| VectorType   | array                         |

--- a/docs/content/connectors/formats/json.md
+++ b/docs/content/connectors/formats/json.md
@@ -1,0 +1,27 @@
+# JSON Format
+
+The JSON format allows to read and write JSON data based on an JSON schema. The JSON 
+schema is derived from table schema.
+
+## Format Options
+
+| key                | Required | default | type    | Description                                                                                          |
+|--------------------|----------|---------|---------|------------------------------------------------------------------------------------------------------|
+| ignore_parse_error | Optional | True    | boolean | Skip fields and rows with parse errors instead of failing. Fields are set to null in case of errors. |
+
+## Data Type Mapping
+
+The following table lists the type mapping from Feathub type to JSON type.
+
+| Feathub type | JSON type                     |
+|--------------|-------------------------------|
+| Bytes        | string with encoding: base64  |
+| String       | string                        |
+| Int32        | number                        |
+| Int64        | number                        |
+| Float32      | number                        |
+| Float64      | number                        |
+| Bool         | boolean                       |
+| Timestamp    | string with format: date-time |
+| VectorType   | array                         | 
+| MapType      | object                        | 

--- a/docs/content/connectors/formats/protobuf.md
+++ b/docs/content/connectors/formats/protobuf.md
@@ -1,0 +1,97 @@
+# Protobuf Format
+
+The Protocol Buffers [Protobuf](https://developers.google.com/protocol-buffers) format 
+allows you to read and write Protobuf data, based on Protobuf generated classes.
+
+## Format Options
+
+| key                 | Required | default | type    | Description                                                                                                                                                                                       |
+|---------------------|----------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| protobuf.jar_path   | Required | (none)  | string  | The path to the jar that contains the Protobuf generated classes.                                                                                                                                 |
+| protobuf.class_name | Required | (none)  | string  | The full name of a Protobuf generated class. The name must match the message name in the proto definition file. $ is supported for inner class names, like 'com.exmample.OuterClass$MessageClass' |
+| ignore_parse_error  | Optional | True    | boolean | Skip fields and rows with parse errors instead of failing. Fields are set to null in case of errors.                                                                                              |
+
+## How to create a table with Protobuf format
+
+Here is an example to create a table using the Kafka connector and Protobuf format.
+
+Below is the proto definition file.
+
+```protobuf
+syntax = "proto3";
+
+package org.feathub.proto;
+option java_package = "org.feathub.proto";
+option java_multiple_files = true;
+
+message KafkaTestMessage {
+  int64 id = 1;
+  int64 val = 2;
+  string ts = 3;
+}
+```
+
+1. Use [protoc](https://developers.google.com/protocol-buffers/docs/javatutorial#compiling-your-protocol-buffers)
+   command to compile the .proto file to java classes.
+2. Compile and package the classes. 
+   [feathub-test-proto](../../../../java/feathub-test-proto) is an example that use 
+   maven to compile and package the .proto file.
+
+Then you can use Feathub connector to use the protobuf format.
+
+```python
+schema = (
+    Schema.new_builder()
+    .column("id", types.Int64)
+    .column("val", types.Int64)
+    .column("ts", types.String)
+    .build()
+)
+
+source = KafkaSource(
+    "kafka_source",
+    bootstrap_server="bootstrap_server",
+    topic="topic_name",
+    key_format=None,
+    value_format="protobuf",
+    schema=schema,
+    consumer_group="test-group",
+    keys=["id"],
+    timestamp_field="ts",
+    timestamp_format="%Y-%m-%d %H:%M:%S",
+    value_format_config={
+        "protobuf.jar_path": "jar_path",  # The path to the jar packaged above.
+        "protobuf.class_name": "org.feathub.proto.KafkaTestMessage"
+    },
+)
+```
+
+## Data Type Mapping
+
+The following table lists the type mapping from Feathub type to Protobuf type.
+
+| Feathub type | Protobuf type |
+|--------------|---------------|
+| Bytes        | bytes         |                               
+| String       | string        |                               
+| Int32        | int32         |                               
+| Int64        | int64         |                               
+| Float32      | float         |                               
+| Float64      | double        |                              
+| Bool         | bool          |                               
+| VectorType   | repeated      |
+
+
+## Null Values
+
+As protobuf does not permit null values in maps and array, we need to auto-generate 
+default values when converting from Flink Rows to Protobuf.
+
+| Protobuf Data Type             | Default Value                |
+|--------------------------------|------------------------------|
+| int32 / int64 / float / double | 0                            |
+| string                         | ""                           |
+| bool                           | false                        |
+| enum                           | first element of enum        |
+| binary                         | ByteString.EMPTY             |
+| message                        | MESSAGE.getDefaultInstance() |

--- a/docs/content/connectors/kafka.md
+++ b/docs/content/connectors/kafka.md
@@ -7,6 +7,10 @@ materialize feature view to a Kafka topic.
 
 - Flink: Streaming Scan, Streaming Append
 
+## Supported format
+
+- Flink: CSV, JSON, Protobuf
+
 ## Examples
 
 Here are the examples of using `KafkaSource` and `KafkaSink`:

--- a/docs/content/connectors/overview.md
+++ b/docs/content/connectors/overview.md
@@ -46,3 +46,14 @@ where "Y" means supported, "Y/N" means partially supported, "N" means unsupporte
 | Connector\Modes             | Batch Scan | Streaming Scan | Streaming CDC | Lookup          | Batch Append | Streaming Append | Streaming Upsert |
 |-----------------------------|------------|----------------|---------------|-----------------|--------------|------------------|------------------|
 | [FileSystem](filesystem.md) | Y          | N              | N             | N               | Y            | N                | N                |
+
+
+## Data Format
+
+Data format define how information is encoded in an external storage. A data format is
+typically used for a storage system that doesn't have schema for its data, e.g. 
+FileSystem, Kafka, etc. Feature currently supports the following formats.
+
+- [CSV](formats/csv.md)
+- [JSON](formats/json.md)
+- [Protobuf](formats/protobuf.md)

--- a/java/feathub-dist/pom.xml
+++ b/java/feathub-dist/pom.xml
@@ -32,6 +32,8 @@
     </properties>
 
     <dependencies>
+
+        <!-- Flink connectors -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-sql-connector-kafka</artifactId>
@@ -70,6 +72,13 @@
                     <artifactId>json</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Flink format -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-protobuf</artifactId>
+            <version>${flink.version}</version>
         </dependency>
 
         <dependency>

--- a/java/feathub-test-proto/pom.xml
+++ b/java/feathub-test-proto/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 The FeatHub Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.feathub</groupId>
+        <artifactId>feathub-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>feathub-test-proto</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <protoc.version>3.21.2</protoc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protoc.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>3.11.4</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${protoc.version}</protocArtifact>
+                            <inputDirectories>
+                                <include>src/proto</include>
+                            </inputDirectories>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java/feathub-test-proto/src/proto/message.proto
+++ b/java/feathub-test-proto/src/proto/message.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package org.feathub.proto;
+option java_package = "org.feathub.proto";
+option java_multiple_files = true;
+
+message FileSystemTestMessage {
+  // TODO: We have to add a dummy field with type int64 at the beginning,
+  //  otherwise exception will be thrown.
+  //  https://issues.apache.org/jira/browse/FLINK-31944
+  int64 dummy = 1;
+  string name = 2;
+  int64 cost = 3;
+  int64 distance = 4;
+  string time = 5;
+}
+
+message AllTypesTest {
+  // TODO: We have to add a dummy field with type int64 at the beginning,
+  //  otherwise exception will be thrown.
+  //  https://issues.apache.org/jira/browse/FLINK-31944
+  int64 dummy = 1;
+  bytes bytes_v = 2;
+  string string_v = 3;
+  int32 int32_v = 4;
+  int64 int64_v = 5;
+  float float32_v = 6;
+  double float64_v = 7;
+  bool bool_v = 8;
+  repeated int32 vector_v = 9;
+
+  // TODO: Flink protobuf format has problem with map datatype
+  // https://issues.apache.org/jira/browse/FLINK-32008
+}
+
+message KafkaTestMessage {
+  int64 id = 1;
+  int64 val = 2;
+  string ts = 3;
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,6 +28,7 @@
         <module>feathub-dist</module>
         <module>feathub-udf</module>
         <module>feathub-connectors</module>
+        <module>feathub-test-proto</module>
     </modules>
 
     <properties>

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -27,3 +27,8 @@ types-redis~=4.3.21
 types-tzlocal~=4.2
 cryptography
 jupyter
+
+# Requests library introduce breaking change at 2.29. Thus, We have to specify the
+# version, otherwise tests will fail.
+# See https://github.com/docker/docker-py/issues/3113
+requests~=2.28.2

--- a/python/feathub/common/tests/test_type.py
+++ b/python/feathub/common/tests/test_type.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import unittest
+from typing import cast
 
 import numpy as np
 
@@ -42,3 +43,12 @@ class TypesTest(unittest.TestCase):
 
         with self.assertRaises(FeathubTypeException):
             from_numpy_dtype(np.int16)
+
+    def test_multi_level_composite_type(self):
+        key_type = types.VectorType(types.Int64)
+        element_type = types.MapType(key_type, types.Int64)
+        dtype = types.VectorType(element_type)
+
+        self.assertEqual(element_type, dtype.dtype)
+        self.assertEqual(key_type, cast(types.MapType, dtype.dtype).key_dtype)
+        self.assertEqual(types.Int64, cast(types.MapType, dtype.dtype).value_dtype)

--- a/python/feathub/common/types.py
+++ b/python/feathub/common/types.py
@@ -92,6 +92,8 @@ class MapType(DType):
 def from_numpy_dtype(dtype: Type) -> DType:
     if dtype == str:
         return String
+    elif dtype == bytes:
+        return Bytes
     elif dtype == bool:
         return Bool
     elif dtype == np.int32:
@@ -111,6 +113,8 @@ def from_numpy_dtype(dtype: Type) -> DType:
 def to_numpy_dtype(dtype: DType) -> Type:
     if dtype == String:
         return str
+    elif dtype == Bytes:
+        return bytes
     elif dtype == Bool:
         return bool
     elif dtype == Int32:

--- a/python/feathub/feature_tables/feature_table.py
+++ b/python/feathub/feature_tables/feature_table.py
@@ -37,6 +37,7 @@ class FeatureTable(TableDescriptor, ABC):
         timestamp_field: Optional[str] = None,
         timestamp_format: str = "epoch",
         schema: Optional[Schema] = None,
+        data_format_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param name: The name that uniquely identifies this feature table in a registry.
@@ -64,6 +65,7 @@ class FeatureTable(TableDescriptor, ABC):
                        Otherwise, the subclass should overwrite the get_feature method
                        to derive the feature according to the schema of the underlying
                        system.
+        :param data_format_properties: The properties of the data format.
         """
         super().__init__(
             name=name,
@@ -72,6 +74,9 @@ class FeatureTable(TableDescriptor, ABC):
             timestamp_format=timestamp_format,
         )
         self.data_format = data_format
+        self.data_format_properties = (
+            {} if data_format_properties is None else data_format_properties
+        )
         self.system_name = system_name
         self.table_uri = table_uri
         self.schema = schema

--- a/python/feathub/feature_tables/feature_table.py
+++ b/python/feathub/feature_tables/feature_table.py
@@ -31,7 +31,7 @@ class FeatureTable(TableDescriptor, ABC):
         self,
         name: str,
         system_name: str,
-        properties: Dict[str, Any],
+        table_uri: Dict[str, Any],
         data_format: Optional[str] = None,
         keys: Optional[List[str]] = None,
         timestamp_field: Optional[str] = None,
@@ -42,7 +42,7 @@ class FeatureTable(TableDescriptor, ABC):
         :param name: The name that uniquely identifies this feature table in a registry.
         :param system_name: Uniquely identifies the underlying system, e.g. filesystem,
                             kafka, etc.
-        :param properties: It contains the properties specific to the underlying system
+        :param table_uri: It contains the properties specific to the underlying system
                            that are used to uniquely identify the physical table.
         :param data_format: Optional. If it is not None, it specifies the format of the
                             data, e.g. csv, json, parquet, etc. This is typically
@@ -73,7 +73,7 @@ class FeatureTable(TableDescriptor, ABC):
         )
         self.data_format = data_format
         self.system_name = system_name
-        self.properties = properties
+        self.table_uri = table_uri
         self.schema = schema
 
         if schema is not None:

--- a/python/feathub/feature_tables/format_config.py
+++ b/python/feathub/feature_tables/format_config.py
@@ -1,0 +1,94 @@
+#  Copyright 2022 The FeatHub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Dict, Any
+
+from feathub.common.config import BaseConfig, ConfigDef
+from feathub.common.validators import not_none
+
+
+class DataFormat:
+    CSV = "csv"
+    JSON = "json"
+    PROTOBUF = "protobuf"
+
+
+IGNORE_PARSE_ERRORS_CONFIG = "ignore_parse_error"
+IGNORE_PARSE_ERRORS_DOC = (
+    "Skip fields and rows with parse errors instead of failing. Fields are set to "
+    "null in case of errors."
+)
+
+ignore_parse_error_config_def = ConfigDef(
+    name=IGNORE_PARSE_ERRORS_CONFIG,
+    value_type=bool,
+    description=IGNORE_PARSE_ERRORS_DOC,
+    default_value=True,
+)
+
+
+class CsvConfig(BaseConfig):
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(
+            [
+                # TODO: Support more csv config
+                ignore_parse_error_config_def,
+            ]
+        )
+
+
+class JsonConfig(BaseConfig):
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(
+            [
+                # TODO: Support more Json config
+                ignore_parse_error_config_def,
+            ]
+        )
+
+
+PROTOBUF_JAR_PATH_CONFIG = "protobuf.jar_path"
+PROTOBUF_JAR_PATH_DOC = (
+    "The path to the jar that contains the Protobuf generated classes."
+)
+
+PROTOBUF_CLASS_NAME_CONFIG = "protobuf.class_name"
+PROTOBUF_CLASS_NAME_DOC = (
+    "The full name of a Protobuf generated class. The name must match the message name "
+    "in the proto definition file. $ is supported for inner class names, like "
+    "'com.example.OuterClass$MessageClass'"
+)
+
+
+class ProtobufConfig(BaseConfig):
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(
+            [
+                ConfigDef(
+                    name=PROTOBUF_JAR_PATH_CONFIG,
+                    value_type=str,
+                    description=PROTOBUF_JAR_PATH_DOC,
+                    validator=not_none(),
+                ),
+                ConfigDef(
+                    name=PROTOBUF_CLASS_NAME_CONFIG,
+                    value_type=str,
+                    description=PROTOBUF_CLASS_NAME_DOC,
+                    validator=not_none(),
+                ),
+                ignore_parse_error_config_def,
+            ]
+        )

--- a/python/feathub/feature_tables/sinks/black_hole_sink.py
+++ b/python/feathub/feature_tables/sinks/black_hole_sink.py
@@ -24,7 +24,7 @@ class BlackHoleSink(Sink):
     """
 
     def __init__(self) -> None:
-        super().__init__(name="", system_name="blackhole", properties={})
+        super().__init__(name="", system_name="blackhole", table_uri={})
 
     def to_json(self) -> Dict:
         return {"type": "BlackHoleSink"}

--- a/python/feathub/feature_tables/sinks/file_system_sink.py
+++ b/python/feathub/feature_tables/sinks/file_system_sink.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict
+from typing import Dict, Optional, Any
 
 from feathub.feature_tables.sinks.sink import Sink
 
@@ -19,16 +19,23 @@ from feathub.feature_tables.sinks.sink import Sink
 class FileSystemSink(Sink):
     """A Sink which writes data to files."""
 
-    def __init__(self, path: str, data_format: str) -> None:
+    def __init__(
+        self,
+        path: str,
+        data_format: str,
+        data_format_properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """
         :param path: The path to directory of files to write to.
         :param data_format: The format of the data that are written to the file.
+        :param data_format_properties: The properties of the data format.
         """
         super().__init__(
             name="",
             system_name="filesystem",
             table_uri={"path": path},
             data_format=data_format,
+            data_format_properties=data_format_properties,
         )
         self.path = path
 
@@ -37,4 +44,5 @@ class FileSystemSink(Sink):
             "type": "FileSystemSink",
             "path": self.path,
             "data_format": self.data_format,
+            "data_format_properties": self.data_format_properties,
         }

--- a/python/feathub/feature_tables/sinks/file_system_sink.py
+++ b/python/feathub/feature_tables/sinks/file_system_sink.py
@@ -27,7 +27,7 @@ class FileSystemSink(Sink):
         super().__init__(
             name="",
             system_name="filesystem",
-            properties={"path": path},
+            table_uri={"path": path},
             data_format=data_format,
         )
         self.path = path

--- a/python/feathub/feature_tables/sinks/kafka_sink.py
+++ b/python/feathub/feature_tables/sinks/kafka_sink.py
@@ -42,8 +42,7 @@ class KafkaSink(Sink):
         super().__init__(
             name="",
             system_name="kafka",
-            properties={"bootstrap_server": bootstrap_server, "topic": topic},
-            data_format=value_format,
+            table_uri={"bootstrap_server": bootstrap_server, "topic": topic},
         )
         self.bootstrap_server = bootstrap_server
         self.topic = topic

--- a/python/feathub/feature_tables/sinks/kafka_sink.py
+++ b/python/feathub/feature_tables/sinks/kafka_sink.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from feathub.feature_tables.sinks.sink import Sink
 
@@ -24,6 +24,8 @@ class KafkaSink(Sink):
         key_format: Optional[str],
         value_format: str,
         producer_properties: Optional[Dict[str, str]] = None,
+        key_data_format_properties: Optional[Dict[str, Any]] = None,
+        value_data_format_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param bootstrap_server: Comma separated list of Kafka brokers.
@@ -38,6 +40,10 @@ class KafkaSink(Sink):
                              etc.
         :param producer_properties: Optional. If it is not None, it contains the extra
                                     kafka producer properties.
+        :param key_data_format_properties: Optional. The properties of the format for
+                                           Kafka message key.
+        :param value_data_format_properties: Optional. The properties of the format for
+                                             Kafka message value.
         """
         super().__init__(
             name="",
@@ -47,7 +53,13 @@ class KafkaSink(Sink):
         self.bootstrap_server = bootstrap_server
         self.topic = topic
         self.key_format = key_format
+        self.key_format_properties = (
+            {} if key_data_format_properties is None else key_data_format_properties
+        )
         self.value_format = value_format
+        self.value_format_properties = (
+            {} if value_data_format_properties is None else value_data_format_properties
+        )
         self.producer_properties = (
             {} if producer_properties is None else producer_properties
         )
@@ -60,4 +72,6 @@ class KafkaSink(Sink):
             "key_format": self.key_format,
             "value_format": self.value_format,
             "producer_properties": self.producer_properties,
+            "key_data_format_properties": self.key_format_properties,
+            "value_data_format_properties": self.value_format_properties,
         }

--- a/python/feathub/feature_tables/sinks/memory_store_sink.py
+++ b/python/feathub/feature_tables/sinks/memory_store_sink.py
@@ -28,7 +28,7 @@ class MemoryStoreSink(Sink):
         super().__init__(
             name="",
             system_name="memory",
-            properties={"table_name": table_name},
+            table_uri={"table_name": table_name},
         )
         self.table_name = table_name
 

--- a/python/feathub/feature_tables/sinks/mysql_sink.py
+++ b/python/feathub/feature_tables/sinks/mysql_sink.py
@@ -43,7 +43,7 @@ class MySQLSink(Sink):
         super().__init__(
             name="",
             system_name="mysql",
-            properties={
+            table_uri={
                 "host": host,
                 "port": port,
                 "database": database,

--- a/python/feathub/feature_tables/sinks/print_sink.py
+++ b/python/feathub/feature_tables/sinks/print_sink.py
@@ -22,7 +22,7 @@ class PrintSink(Sink):
     """
 
     def __init__(self) -> None:
-        super().__init__(name="", system_name="print", properties={})
+        super().__init__(name="", system_name="print", table_uri={})
 
     def to_json(self) -> Dict:
         return {"type": "PrintSink"}

--- a/python/feathub/feature_tables/sinks/redis_sink.py
+++ b/python/feathub/feature_tables/sinks/redis_sink.py
@@ -40,7 +40,7 @@ class RedisSink(Sink):
         super().__init__(
             name="",
             system_name="redis",
-            properties={
+            table_uri={
                 "namespace": namespace,
                 "host": host,
                 "port": port,

--- a/python/feathub/feature_tables/sinks/sink.py
+++ b/python/feathub/feature_tables/sinks/sink.py
@@ -28,14 +28,14 @@ class Sink(FeatureTable, ABC):
         self,
         name: str,
         system_name: str,
-        properties: Dict[str, Any],
+        table_uri: Dict[str, Any],
         data_format: Optional[str] = None,
     ):
         """
         :param name: The name that uniquely identifies this feature table in a registry.
         :param system_name: Uniquely identifies the underlying system, e.g. filesystem,
                             kafka, etc.
-        :param properties: It contains the properties specific to the underlying system
+        :param table_uri: It contains the properties specific to the underlying system
                            that are used to uniquely identify the physical table.
         :param data_format: Optional. If it is not None, it specifies the format of the
                             data, e.g. csv, json, parquet, etc. This is typically
@@ -45,7 +45,7 @@ class Sink(FeatureTable, ABC):
         super().__init__(
             name=name,
             system_name=system_name,
-            properties=properties,
+            table_uri=table_uri,
             data_format=data_format,
         )
 

--- a/python/feathub/feature_tables/sinks/sink.py
+++ b/python/feathub/feature_tables/sinks/sink.py
@@ -30,6 +30,7 @@ class Sink(FeatureTable, ABC):
         system_name: str,
         table_uri: Dict[str, Any],
         data_format: Optional[str] = None,
+        data_format_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param name: The name that uniquely identifies this feature table in a registry.
@@ -41,12 +42,14 @@ class Sink(FeatureTable, ABC):
                             data, e.g. csv, json, parquet, etc. This is typically
                             used by storage that does not require schema, e.g.
                             filesystem, kafka, etc.
+        :param data_format_properties: The properties of the data format.
         """
         super().__init__(
             name=name,
             system_name=system_name,
             table_uri=table_uri,
             data_format=data_format,
+            data_format_properties=data_format_properties,
         )
 
     def is_bounded(self) -> bool:

--- a/python/feathub/feature_tables/sources/datagen_source.py
+++ b/python/feathub/feature_tables/sources/datagen_source.py
@@ -141,7 +141,7 @@ class DataGenSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="datagen",
-            properties={},
+            table_uri={},
             keys=keys,
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,

--- a/python/feathub/feature_tables/sources/file_system_source.py
+++ b/python/feathub/feature_tables/sources/file_system_source.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import timedelta
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Any
 
 from feathub.feature_tables.feature_table import FeatureTable
 from feathub.table.schema import Schema
@@ -31,6 +31,7 @@ class FileSystemSource(FeatureTable):
         timestamp_field: Optional[str] = None,
         timestamp_format: str = "epoch",
         max_out_of_orderness: timedelta = timedelta(0),
+        data_format_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param name: The name that uniquely identifies this source in a registry.
@@ -51,6 +52,7 @@ class FileSystemSource(FeatureTable):
         :param max_out_of_orderness: The maximum amount of time a record is allowed to
                                      be late. Default is 0 second, meaning the records
                                      should be ordered by `timestamp_field`.
+        :param data_format_properties: The properties of the data format.
         """
         super().__init__(
             name=name,
@@ -63,6 +65,7 @@ class FileSystemSource(FeatureTable):
             schema=schema,
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,
+            data_format_properties=data_format_properties,
         )
         self.path = path
         self.schema = schema
@@ -80,4 +83,5 @@ class FileSystemSource(FeatureTable):
             "timestamp_format": self.timestamp_format,
             "max_out_of_orderness_ms": self.max_out_of_orderness
             / timedelta(milliseconds=1),
+            "data_format_properties": self.data_format_properties,
         }

--- a/python/feathub/feature_tables/sources/file_system_source.py
+++ b/python/feathub/feature_tables/sources/file_system_source.py
@@ -55,7 +55,7 @@ class FileSystemSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="filesystem",
-            properties={
+            table_uri={
                 "path": path,
             },
             data_format=data_format,

--- a/python/feathub/feature_tables/sources/kafka_source.py
+++ b/python/feathub/feature_tables/sources/kafka_source.py
@@ -95,8 +95,7 @@ class KafkaSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="kafka",
-            properties={"bootstrap_server": bootstrap_server, "topic": topic},
-            data_format=value_format,
+            table_uri={"bootstrap_server": bootstrap_server, "topic": topic},
             keys=keys,
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,

--- a/python/feathub/feature_tables/sources/kafka_source.py
+++ b/python/feathub/feature_tables/sources/kafka_source.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from copy import deepcopy
 from datetime import timedelta, datetime
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Any
 
 from feathub.common.exceptions import FeathubException
 from feathub.feature_tables.feature_table import FeatureTable
@@ -42,6 +42,8 @@ class KafkaSource(FeatureTable):
         startup_datetime: Optional[datetime] = None,
         partition_discovery_interval: timedelta = timedelta(minutes=5),
         is_bounded: bool = False,
+        key_data_format_properties: Optional[Dict[str, Any]] = None,
+        value_data_format_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param name: The name that uniquely identifies this source in a registry.
@@ -91,6 +93,10 @@ class KafkaSource(FeatureTable):
         :param is_bounded: Whether the KafkaSource should be bounded. If the KafkaSource
                            is bounded, it stops at the latest offsets of the partitions
                            when the KafkaSource starts to run.
+        :param key_data_format_properties: Optional. The properties of the format for
+                                           Kafka message key.
+        :param value_data_format_properties: Optional. The properties of the format for
+                                             Kafka message value.
         """
         super().__init__(
             name=name,
@@ -104,7 +110,13 @@ class KafkaSource(FeatureTable):
         self.bootstrap_server = bootstrap_server
         self.topic = topic
         self.key_format = key_format
+        self.key_data_format_properties = (
+            {} if key_data_format_properties is None else key_data_format_properties
+        )
         self.value_format = value_format
+        self.value_data_format_properties = (
+            {} if value_data_format_properties is None else value_data_format_properties
+        )
         self.consumer_group = consumer_group
         self.consumer_properties = (
             {} if consumer_properties is None else consumer_properties
@@ -153,4 +165,6 @@ class KafkaSource(FeatureTable):
             "partition_discovery_interval_ms": self.partition_discovery_interval
             / timedelta(milliseconds=1),
             "is_bounded": self.is_bounded(),
+            "key_data_format_properties": self.key_data_format_properties,
+            "value_data_format_properties": self.value_data_format_properties,
         }

--- a/python/feathub/feature_tables/sources/memory_store_source.py
+++ b/python/feathub/feature_tables/sources/memory_store_source.py
@@ -39,7 +39,7 @@ class MemoryStoreSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="memory",
-            properties={"table_name": table_name},
+            table_uri={"table_name": table_name},
             keys=keys,
             timestamp_field=None,
             timestamp_format="epoch",

--- a/python/feathub/feature_tables/sources/mysql_source.py
+++ b/python/feathub/feature_tables/sources/mysql_source.py
@@ -64,7 +64,7 @@ class MySQLSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="mysql",
-            properties={
+            table_uri={
                 "host": host,
                 "port": port,
                 "database": database,

--- a/python/feathub/feature_tables/sources/redis_source.py
+++ b/python/feathub/feature_tables/sources/redis_source.py
@@ -56,7 +56,7 @@ class RedisSource(FeatureTable):
         super().__init__(
             name=name,
             system_name="redis",
-            properties={
+            table_uri={
                 "host": host,
                 "port": port,
                 "username": username,

--- a/python/feathub/feature_tables/tests/test_feature_table.py
+++ b/python/feathub/feature_tables/tests/test_feature_table.py
@@ -31,7 +31,7 @@ class MockFeatureTable(FeatureTable):
         super().__init__(
             name=name,
             system_name="mock",
-            properties={},
+            table_uri={},
             schema=schema,
             keys=keys,
             timestamp_field=timestamp_field,

--- a/python/feathub/feature_tables/tests/test_file_system_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_file_system_source_sink.py
@@ -14,10 +14,28 @@
 import tempfile
 import unittest
 from abc import ABC
+from typing import Dict, Any, Optional
 
-from feathub.common.types import Int64
+import numpy as np
+import pandas as pd
+
+from feathub.common.types import (
+    Int64,
+    String,
+    Int32,
+    Bool,
+    VectorType,
+)
+from feathub.feature_tables.format_config import (
+    PROTOBUF_JAR_PATH_CONFIG,
+    PROTOBUF_CLASS_NAME_CONFIG,
+    IGNORE_PARSE_ERRORS_CONFIG,
+)
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.feature_tables.tests.utils import get_protobuf_jar_path
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature import Feature
 from feathub.table.schema import Schema
 from feathub.tests.feathub_it_test_base import FeathubITTestBase
 
@@ -42,10 +60,114 @@ class FileSystemSourceSinkITTest(ABC, FeathubITTestBase):
         sink_path = tempfile.NamedTemporaryFile(dir=self.temp_dir, suffix=".json").name
         self._test_file_system_source_sink(sink_path, "json")
 
-    def _test_file_system_source_sink(self, path: str, data_format: str):
+    def test_local_file_system_protobuf_source_sink(self):
+        sink_path = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir, suffix=".protobuf"
+        ).name
+        self._test_file_system_source_sink(
+            sink_path,
+            "protobuf",
+            {
+                PROTOBUF_JAR_PATH_CONFIG: get_protobuf_jar_path(),
+                PROTOBUF_CLASS_NAME_CONFIG: "org.feathub.proto.FileSystemTestMessage",
+            },
+        )
+
+    def test_protobuf_all_types(self):
+        df = pd.DataFrame(
+            [["abc", 1, True, [1, 2]]],
+            columns=["string_v", "int64_v", "bool_v", "vector_v"],
+        )
+        source = self.create_file_source(
+            df,
+            data_format="json",
+            schema=Schema.new_builder()
+            .column("string_v", String)
+            .column("int64_v", Int64)
+            .column("bool_v", Bool)
+            .column("vector_v", VectorType(Int32))
+            .build(),
+            timestamp_field=None,
+        )
+
+        features = DerivedFeatureView(
+            name="features",
+            source=source,
+            features=[
+                Feature("string_v", transform="string_v"),
+                Feature("bytes_v", transform="CAST(string_v AS BYTES)"),
+                Feature("int32_v", transform="CAST(int64_v AS INTEGER)"),
+                Feature("int64_v", transform="int64_v"),
+                Feature("float32_v", transform="CAST(int64_v AS FLOAT)"),
+                Feature("float64_v", transform="CAST(int64_v AS DOUBLE)"),
+                Feature("bool_v", transform="bool_v"),
+                Feature("vector_v", transform="vector_v"),
+            ],
+            keep_source_fields=False,
+        )
+
+        path = tempfile.NamedTemporaryFile(dir=self.temp_dir, suffix=".protobuf").name
+        sink = FileSystemSink(
+            path,
+            "protobuf",
+            {
+                PROTOBUF_JAR_PATH_CONFIG: get_protobuf_jar_path(),
+                PROTOBUF_CLASS_NAME_CONFIG: "org.feathub.proto.AllTypesTest",
+            },
+        )
+
+        table = self.client.get_features(features)
+        table.execute_insert(sink, allow_overwrite=True)
+
+        source = FileSystemSource(
+            name=self.generate_random_name("source"),
+            path=path,
+            data_format="protobuf",
+            schema=table.get_schema(),
+            data_format_properties={
+                PROTOBUF_JAR_PATH_CONFIG: get_protobuf_jar_path(),
+                PROTOBUF_CLASS_NAME_CONFIG: "org.feathub.proto.AllTypesTest",
+                IGNORE_PARSE_ERRORS_CONFIG: False,
+            },
+        )
+
+        df = self.client.get_features(source).to_pandas()
+        expected_result = pd.DataFrame(
+            [["abc", b"abc", 1, 1, 1.0, 1.0, True, [1, 2]]],
+            columns=[
+                "string_v",
+                "bytes_v",
+                "int32_v",
+                "int64_v",
+                "float32_v",
+                "float64_v",
+                "bool_v",
+                "vector_v",
+            ],
+        ).astype(
+            {
+                "string_v": str,
+                "bytes_v": bytes,
+                "int32_v": np.int32,
+                "int64_v": np.int64,
+                "float32_v": np.float32,
+                "float64_v": np.float64,
+                "bool_v": bool,
+                "vector_v": object,
+            }
+        )
+
+        self.assertTrue(expected_result.equals(df))
+
+    def _test_file_system_source_sink(
+        self,
+        path: str,
+        data_format: str,
+        data_format_properties: Optional[Dict[str, Any]] = None,
+    ):
         source = self.create_file_source(self.input_data)
 
-        sink = FileSystemSink(path, data_format)
+        sink = FileSystemSink(path, data_format, data_format_properties)
 
         self.client.materialize_features(
             features=source,
@@ -58,6 +180,7 @@ class FileSystemSourceSinkITTest(ABC, FeathubITTestBase):
             path=path,
             data_format=data_format,
             schema=source.schema,
+            data_format_properties=data_format_properties,
         )
 
         df = self.client.get_features(source).to_pandas()

--- a/python/feathub/feature_tables/tests/test_kafka_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_kafka_source_sink.py
@@ -14,14 +14,20 @@
 import unittest
 from abc import ABC
 from datetime import datetime
+from typing import Tuple, Dict, Any, Optional
 
 import pandas as pd
 from testcontainers.kafka import KafkaContainer
 
 from feathub.common import types
 from feathub.common.types import Int64
+from feathub.feature_tables.format_config import (
+    PROTOBUF_JAR_PATH_CONFIG,
+    PROTOBUF_CLASS_NAME_CONFIG,
+)
 from feathub.feature_tables.sinks.kafka_sink import KafkaSink
 from feathub.feature_tables.sources.kafka_source import KafkaSource
+from feathub.feature_tables.tests.utils import get_protobuf_jar_path
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.table.schema import Schema
 from feathub.tests.feathub_it_test_base import FeathubITTestBase
@@ -65,7 +71,24 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         super().tearDownClass()
         cls.kafka_container.stop()
 
-    def test_kafka_source_sink(self):
+    def test_kafka_source_sink_json(self):
+        self._test_kafka_source_sink("json")
+
+    def test_kafka_source_sink_csv(self):
+        self._test_kafka_source_sink("csv")
+
+    def test_kafka_source_sink_protobuf(self):
+        self._test_kafka_source_sink(
+            "protobuf",
+            {
+                PROTOBUF_JAR_PATH_CONFIG: get_protobuf_jar_path(),
+                PROTOBUF_CLASS_NAME_CONFIG: "org.feathub.proto.KafkaTestMessage",
+            },
+        )
+
+    def _test_kafka_source_sink(
+        self, data_format: str, data_format_properties: Optional[Dict[str, Any]] = None
+    ):
         input_data = pd.DataFrame(
             [
                 [1, 1, datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")],
@@ -74,7 +97,6 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
             ],
             columns=["id", "val", "ts"],
         )
-
         schema = (
             Schema.new_builder()
             .column("id", types.Int64)
@@ -82,16 +104,32 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
             .column("ts", types.String)
             .build()
         )
-
-        topic_name, start_time = self._produce_data_to_kafka(input_data, schema)
-
+        topic_name, start_time = self._produce_data_to_kafka(
+            input_data, schema, data_format, data_format_properties
+        )
         # Consume data with kafka source
+        result_df = self.consume_data_from_kafka(
+            schema, start_time, topic_name, data_format, data_format_properties
+        )
+        expected_result_df = (
+            input_data.copy().sort_values(by=["id"]).reset_index(drop=True)
+        )
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def consume_data_from_kafka(
+        self,
+        schema: Schema,
+        start_time: datetime,
+        topic_name: str,
+        data_format: str,
+        data_format_properties: Dict[str, Any] = None,
+    ) -> pd.DataFrame:
         source = KafkaSource(
             "kafka_source",
             bootstrap_server=self.kafka_container.get_bootstrap_server(),
             topic=topic_name,
-            key_format="json",
-            value_format="json",
+            key_format=data_format,
+            value_format=data_format,
             schema=schema,
             consumer_group="test-group",
             keys=["id"],
@@ -99,19 +137,16 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
             startup_mode="timestamp",
             startup_datetime=start_time,
+            key_data_format_properties=data_format_properties,
+            value_data_format_properties=data_format_properties,
         )
-
         result_df = (
             self.client.get_features(source)
             .to_pandas(True)
             .sort_values(by=["id"])
             .reset_index(drop=True)
         )
-
-        expected_result_df = (
-            input_data.copy().sort_values(by=["id"]).reset_index(drop=True)
-        )
-        self.assertTrue(expected_result_df.equals(result_df))
+        return result_df
 
     def test_bounded_kafka_source(self):
         input_data = pd.DataFrame(
@@ -131,7 +166,7 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
             .build()
         )
 
-        topic_name, start_time = self._produce_data_to_kafka(input_data, schema)
+        topic_name, start_time = self._produce_data_to_kafka(input_data, schema, "json")
 
         # Consume data with kafka source
         source = KafkaSource(
@@ -166,7 +201,13 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         )
         self.assertTrue(expected_result_df.equals(result_df))
 
-    def _produce_data_to_kafka(self, input_data: pd.DataFrame, schema: Schema):
+    def _produce_data_to_kafka(
+        self,
+        input_data: pd.DataFrame,
+        schema: Schema,
+        data_format: str,
+        data_format_properties: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, datetime]:
         source = self.create_file_source(
             input_data,
             keys=["id"],
@@ -180,8 +221,10 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         sink = KafkaSink(
             bootstrap_server=self.kafka_container.get_bootstrap_server(),
             topic=topic_name,
-            key_format="json",
-            value_format="json",
+            key_format=data_format,
+            value_format=data_format,
+            key_data_format_properties=data_format_properties,
+            value_data_format_properties=data_format_properties,
         )
 
         start_time = datetime.now()

--- a/python/feathub/feature_tables/tests/utils.py
+++ b/python/feathub/feature_tables/tests/utils.py
@@ -1,0 +1,31 @@
+#  Copyright 2022 The FeatHub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import glob
+import os
+
+from feathub.common.exceptions import FeathubException
+
+
+def get_protobuf_jar_path():
+    current_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+    feathub_root = os.path.abspath(current_dir + "/../../../../")
+    jar_paths = glob.glob(
+        feathub_root + "/java/feathub-test-proto/target/feathub-test-proto-*.jar"
+    )
+    if len(jar_paths) == 0:
+        raise FeathubException(
+            "Cannot found the feathub-test-proto jar. Please run `mvn clean "
+            "package -f ./java` before running pytest."
+        )
+    return jar_paths[0]

--- a/python/feathub/feature_views/on_demand_feature_view.py
+++ b/python/feathub/feature_views/on_demand_feature_view.py
@@ -44,7 +44,7 @@ class OnDemandFeatureView(FeatureView):
             super().__init__(
                 name="_ONLINE_REQUEST",
                 system_name="online_request",
-                properties={},
+                table_uri={},
                 keys=None,
                 timestamp_field=None,
                 timestamp_format="epoch",

--- a/python/feathub/processors/flink/flink_table.py
+++ b/python/feathub/processors/flink/flink_table.py
@@ -142,7 +142,10 @@ class FlinkTable(Table):
                 )
             feature = feature.get_bounded_view()
 
-        return flink_table_to_pandas(self._get_flink_table(feature))
+        with self.flink_processor.flink_table_builder.class_loader:
+            return flink_table_to_pandas(
+                self._get_flink_table(feature),
+            )
 
     def execute_insert(
         self,

--- a/python/feathub/processors/flink/table_builder/file_system_utils.py
+++ b/python/feathub/processors/flink/table_builder/file_system_utils.py
@@ -20,9 +20,14 @@ from pyflink.table import (
 )
 
 from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.format_config import DataFormat
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
 from feathub.processors.flink.flink_types_utils import to_flink_schema
+from feathub.processors.flink.table_builder.format_utils import (
+    load_format,
+    get_flink_format_config,
+)
 from feathub.processors.flink.table_builder.source_sink_utils_common import (
     get_schema_from_table,
     define_watermark,
@@ -58,26 +63,38 @@ def get_table_from_file_source(
         .schema(flink_schema)
     )
 
-    if file_source.data_format == "csv":
-        # Set ignore-parse-errors to set null in case of csv parse error
-        descriptor_builder.option("csv.ignore-parse-errors", "true")
+    load_format(t_env, file_source.data_format, file_source.data_format_properties)
+    flink_format_config = get_flink_format_config(
+        file_source.data_format, file_source.data_format_properties
+    )
+    for k, v in flink_format_config.items():
+        descriptor_builder.option(k, v)
 
     return t_env.from_descriptor(descriptor_builder.build())
 
 
-def insert_into_file_sink(table: NativeFlinkTable, sink: FileSystemSink) -> TableResult:
+def insert_into_file_sink(
+    t_env: StreamTableEnvironment, table: NativeFlinkTable, sink: FileSystemSink
+) -> TableResult:
     path = sink.path
-
     # TODO: Remove this check after FLINK-28513 is resolved.
-    if sink.data_format == "csv" and path.startswith("s3://"):
+    if sink.data_format == DataFormat.CSV and path.startswith("s3://"):
         raise FeathubException(
             "Cannot sink files in CSV format to s3 due to FLINK-28513."
         )
 
-    return table.execute_insert(
+    descriptor_builder = (
         NativeFlinkTableDescriptor.for_connector("filesystem")
         .schema(get_schema_from_table(table))
         .format(sink.data_format)
         .option("path", path)
-        .build()
     )
+
+    load_format(t_env, sink.data_format, sink.data_format_properties)
+    flink_format_config = get_flink_format_config(
+        sink.data_format, sink.data_format_properties
+    )
+    for k, v in flink_format_config.items():
+        descriptor_builder.option(k, v)
+
+    return table.execute_insert(descriptor_builder.build())

--- a/python/feathub/processors/flink/table_builder/format_utils.py
+++ b/python/feathub/processors/flink/table_builder/format_utils.py
@@ -1,0 +1,84 @@
+#  Copyright 2022 The FeatHub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import glob
+import os
+from typing import Dict, Any
+
+from pyflink.table import StreamTableEnvironment
+
+from feathub.common.config import BaseConfig
+from feathub.common.exceptions import FeathubException
+from feathub.feature_tables.format_config import (
+    ProtobufConfig,
+    PROTOBUF_JAR_PATH_CONFIG,
+    PROTOBUF_CLASS_NAME_CONFIG,
+    IGNORE_PARSE_ERRORS_CONFIG,
+    JsonConfig,
+    CsvConfig,
+    DataFormat,
+)
+from feathub.processors.flink.flink_jar_utils import find_jar_lib, add_jar_to_t_env
+
+
+def load_format(
+    t_env: StreamTableEnvironment,
+    data_format: str,
+    data_format_properties: Dict[str, Any],
+) -> None:
+    if data_format == DataFormat.JSON or data_format == DataFormat.CSV:
+        return
+    elif data_format == DataFormat.PROTOBUF:
+        config = ProtobufConfig(data_format_properties)
+        protobuf_jar_path = config.get(PROTOBUF_JAR_PATH_CONFIG)
+        _load_protobuf_format_jar(t_env, protobuf_jar_path)
+        return
+
+    raise FeathubException(f"Unsupported format {data_format}.")
+
+
+def get_flink_format_config(
+    data_format: str, data_format_properties: Dict[str, Any]
+) -> Dict[str, str]:
+    if data_format == DataFormat.JSON:
+        config: BaseConfig = JsonConfig(data_format_properties)
+        return {"json.ignore-parse-errors": str(config.get(IGNORE_PARSE_ERRORS_CONFIG))}
+    elif data_format == DataFormat.CSV:
+        config = CsvConfig(data_format_properties)
+        return {"csv.ignore-parse-errors": str(config.get(IGNORE_PARSE_ERRORS_CONFIG))}
+    elif data_format == DataFormat.PROTOBUF:
+        config = ProtobufConfig(data_format_properties)
+        return {
+            "protobuf.message-class-name": config.get(PROTOBUF_CLASS_NAME_CONFIG),
+            "protobuf.ignore-parse-errors": str(config.get(IGNORE_PARSE_ERRORS_CONFIG)),
+        }
+
+    raise FeathubException(f"Unsupported format {data_format}.")
+
+
+def _load_protobuf_format_jar(
+    t_env: StreamTableEnvironment, protobuf_jar_path: str
+) -> None:
+    avro_jar_path = _get_jar_path("flink-sql-protobuf-*.jar")
+    add_jar_to_t_env(t_env, avro_jar_path, protobuf_jar_path)
+
+
+def _get_jar_path(jar_files_pattern: str) -> str:
+    lib_dir = find_jar_lib()
+    jars = glob.glob(os.path.join(lib_dir, jar_files_pattern))
+    if len(jars) < 1:
+        raise FeathubException(
+            f"Can not find the jar at {lib_dir} with pattern {jar_files_pattern}."
+        )
+    return jars[0]

--- a/python/feathub/processors/flink/table_builder/source_sink_utils.py
+++ b/python/feathub/processors/flink/table_builder/source_sink_utils.py
@@ -82,7 +82,7 @@ def insert_into_sink(
     Insert the flink table to the given sink.
     """
     if isinstance(sink, FileSystemSink):
-        return insert_into_file_sink(features_table, sink)
+        return insert_into_file_sink(t_env, features_table, sink)
     elif isinstance(sink, KafkaSink):
         return insert_into_kafka_sink(t_env, features_table, sink, features_desc.keys)
     elif isinstance(sink, PrintSink):

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -338,6 +338,7 @@ class FlinkProcessorTest(unittest.TestCase):
         )
         mock_table: Table = Mock(spec=Table)
         mock_table_builder = Mock(spec=FlinkTableBuilder)
+        mock_table_builder.class_loader = get_flink_context_class_loader()
         mock_table_builder.build.return_value = mock_table
         processor.flink_table_builder = mock_table_builder
         source = FileSystemSource(

--- a/python/feathub/processors/flink/table_builder/tests/test_kafka_source_sink.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_kafka_source_sink.py
@@ -116,6 +116,8 @@ class KafkaSourceSinkTest(unittest.TestCase):
                 "key.format": "json",
                 "key.fields": "id1;id2",
                 "value.fields-include": "EXCEPT_KEY",
+                "key.json.ignore-parse-errors": "True",
+                "value.json.ignore-parse-errors": "True",
             }
             self.assertEquals(
                 expected_options, dict(flink_table_descriptor.get_options())
@@ -148,6 +150,8 @@ class KafkaSourceSinkTest(unittest.TestCase):
                 "key.format": "json",
                 "key.fields": "id1;id2",
                 "value.fields-include": "EXCEPT_KEY",
+                "key.json.ignore-parse-errors": "True",
+                "value.json.ignore-parse-errors": "True",
             }
             self.assertEquals(
                 expected_options, dict(flink_table_descriptor.get_options())
@@ -179,6 +183,8 @@ class KafkaSourceSinkTest(unittest.TestCase):
                 "key.format": "json",
                 "key.fields": "id",
                 "value.fields-include": "EXCEPT_KEY",
+                "key.json.ignore-parse-errors": "True",
+                "value.json.ignore-parse-errors": "True",
             }
             self.assertEquals(
                 expected_options, dict(flink_table_descriptor.get_options())

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -132,3 +132,10 @@ class LocalProcessorITTest(
     # TODO: Enable this test after local processor support datagen source.
     def test_bounded_left_table_join_unbounded_right_table(self):
         pass
+
+    # TODO: Support protobuf format for LocalProcessor FileSystem connector.
+    def test_local_file_system_protobuf_source_sink(self):
+        pass
+
+    def test_protobuf_all_types(self):
+        pass

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -146,3 +146,10 @@ class SparkProcessorITTest(
 
     def test_over_window_transform_count_with_limit(self):
         pass
+
+    # TODO: Support protobuf format for SparkProcessor FileSystem connector.
+    def test_local_file_system_protobuf_source_sink(self):
+        pass
+
+    def test_protobuf_all_types(self):
+        pass


### PR DESCRIPTION
## What is the purpose of the change

This PR update FlinkProcessor to support protobuf format for FileSystem and Kafka source/sink.

## Brief change log

- Update FeatureTable to allow setting configuration for the data format.
- Update FlinkProcessor FileSystem/Kakfa source/sink support protobuf format.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs