### PR TITLE
[hotfix] Set up jupyter dependency in e2e CI

### DIFF
--- a/.github/workflows/run-e2e-examples.yaml
+++ b/.github/workflows/run-e2e-examples.yaml
@@ -16,9 +16,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - name: Install Python Setup Tools
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
+          python -m pip install jupyter
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes dependency error when running notebook examples in CI.

The correctness of this PR is verified in https://github.com/yunfengzhou-hub/feathub/actions/runs/4932857493.

## Brief change log

  - Installs jupyter dependency in e2e CI.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable