### PR TITLE
Support cluster mode in Redis connector

### DIFF
--- a/docs/content/connectors/redis.md
+++ b/docs/content/connectors/redis.md
@@ -1,7 +1,8 @@
 # Redis
 
 FeatHub provides `RedisSource` to read data from a Redis database and
-`RedisSink` to materialize feature view to a Redis database. Currently,
+`RedisSink` to materialize feature view to a Redis database. The Redis service
+should be deployed in standalone, master-slave, or cluster mode. Currently,
 `RedisSource` can only be used as an online store source.
 
 ## Supported Processors and Usages

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClient.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The FeatHub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.connectors.redis.sink;
+
+import org.apache.flink.configuration.ReadableConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.DB_NUM;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.HOST;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PASSWORD;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PORT;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.REDIS_MODE;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.USERNAME;
+
+/** A wrapper interface for jedis clients in different deployment modes. */
+public interface JedisClient {
+    long hset(final byte[] key, final Map<byte[], byte[]> hash);
+
+    byte[] scriptLoad(final byte[] script);
+
+    Object evalsha(final byte[] sha1, final List<byte[]> keys, final List<byte[]> args);
+
+    void close();
+
+    static JedisClient create(ReadableConfig config) {
+        String username = config.get(USERNAME);
+        String password = config.get(PASSWORD);
+        String host = config.get(HOST);
+        int port = config.get(PORT);
+        if (Objects.requireNonNull(config.get(REDIS_MODE)) == RedisSinkConfigs.RedisMode.CLUSTER) {
+            return new JedisClusterClient(host, port, username, password);
+        }
+        int dbNum = config.get(DB_NUM);
+        return new JedisMasterClient(host, port, username, password, dbNum);
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClusterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClusterClient.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The FeatHub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.connectors.redis.sink;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.collections.BidiMap;
+import org.apache.commons.collections.bidimap.DualHashBidiMap;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisNoScriptException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A subclass of {@link JedisClient} that connects to a Redis cluster. Used for Redis Cluster mode.
+ */
+public class JedisClusterClient implements JedisClient {
+    private static final byte[] SAMPLE_KEY = "SAMPLE_KEY".getBytes();
+
+    private final JedisCluster cluster;
+
+    private final BidiMap scriptShaMap;
+
+    public JedisClusterClient(String host, int port, String username, String password) {
+        this.cluster =
+                new JedisCluster(
+                        Collections.singleton(new HostAndPort(host, port)), username, password);
+        this.scriptShaMap = new DualHashBidiMap();
+    }
+
+    @Override
+    public long hset(byte[] key, Map<byte[], byte[]> hash) {
+        return this.cluster.hset(key, hash);
+    }
+
+    @Override
+    public byte[] scriptLoad(byte[] script) {
+        if (scriptShaMap.containsValue(script)) {
+            return (byte[]) scriptShaMap.getKey(script);
+        }
+        // Loads the script on an arbitrary cluster node and cache it locally
+        // because Redis does not support loading script on all nodes in one time.
+        byte[] sha = this.cluster.scriptLoad(script, SAMPLE_KEY);
+        scriptShaMap.put(sha, script);
+        return sha;
+    }
+
+    @Override
+    public Object evalsha(byte[] sha1, List<byte[]> keys, List<byte[]> args) {
+        try {
+            return this.cluster.evalsha(sha1, keys, args);
+        } catch (JedisNoScriptException e) {
+            // Load the cached script onto the relevant cluster node dynamically.
+            byte[] script = (byte[]) scriptShaMap.get(sha1);
+            for (byte[] key : keys) {
+                byte[] sha = this.cluster.scriptLoad(script, key);
+                Preconditions.checkState(Arrays.equals(sha1, sha));
+            }
+            return this.cluster.evalsha(sha1, keys, args);
+        }
+    }
+
+    @Override
+    public void close() {
+        this.cluster.close();
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisMasterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisMasterClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The FeatHub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.connectors.redis.sink;
+
+import org.apache.flink.util.StringUtils;
+
+import redis.clients.jedis.Jedis;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A subclass of {@link JedisClient} that connects to a Redis master instance. Used for Redis
+ * Standalone and Master-Slave mode.
+ */
+public class JedisMasterClient implements JedisClient {
+    private final Jedis jedis;
+
+    public JedisMasterClient(String host, int port, String username, String password, int dbNum) {
+        jedis = new Jedis(host, port);
+        if (!StringUtils.isNullOrWhitespaceOnly(username)) {
+            jedis.auth(username, password);
+        } else if (!StringUtils.isNullOrWhitespaceOnly(password)) {
+            jedis.auth(password);
+        }
+        jedis.select(dbNum);
+    }
+
+    @Override
+    public long hset(byte[] key, Map<byte[], byte[]> hash) {
+        return this.jedis.hset(key, hash);
+    }
+
+    @Override
+    public byte[] scriptLoad(byte[] script) {
+        return this.jedis.scriptLoad(script);
+    }
+
+    @Override
+    public Object evalsha(byte[] sha1, List<byte[]> keys, List<byte[]> args) {
+        return this.jedis.evalsha(sha1, keys, args);
+    }
+
+    @Override
+    public void close() {
+        jedis.close();
+    }
+}

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisDynamicTableSinkFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisDynamicTableSinkFactory.java
@@ -30,6 +30,7 @@ import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.K
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.NAMESPACE;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PASSWORD;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PORT;
+import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.REDIS_MODE;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.TIMESTAMP_FIELD;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.USERNAME;
 
@@ -63,6 +64,7 @@ public class RedisDynamicTableSinkFactory implements DynamicTableSinkFactory {
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(REDIS_MODE);
         options.add(USERNAME);
         options.add(PASSWORD);
         options.add(TIMESTAMP_FIELD);

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkConfigs.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkConfigs.java
@@ -21,6 +21,11 @@ import org.apache.flink.configuration.ConfigOptions;
 
 /** Configurations used by Redis sink. */
 public class RedisSinkConfigs {
+    static final ConfigOption<RedisMode> REDIS_MODE =
+            ConfigOptions.key("mode")
+                    .enumType(RedisMode.class)
+                    .defaultValue(RedisMode.STANDALONE)
+                    .withDescription("The deployment mode of the Redis service to connect.");
 
     static final ConfigOption<String> HOST =
             ConfigOptions.key("host")
@@ -50,7 +55,8 @@ public class RedisSinkConfigs {
             ConfigOptions.key("dbNum")
                     .intType()
                     .noDefaultValue()
-                    .withDescription("The No. of the Redis database to connect.");
+                    .withDescription(
+                            "The No. of the Redis database to connect. Not supported in cluster mode.");
 
     static final ConfigOption<String> NAMESPACE =
             ConfigOptions.key("namespace")
@@ -82,4 +88,10 @@ public class RedisSinkConfigs {
                                     + "key and namespace but different timestamp are written out "
                                     + "through this sink, the record with larger timestamp value "
                                     + "will finally be persisted to Redis.");
+
+    enum RedisMode {
+        STANDALONE,
+        MASTER_SLAVE,
+        CLUSTER,
+    }
 }

--- a/java/feathub-dist/pom.xml
+++ b/java/feathub-dist/pom.xml
@@ -64,10 +64,6 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-pool2</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.json</groupId>
                     <artifactId>json</artifactId>
                 </exclusion>

--- a/python/feathub/feature_tables/sinks/redis_sink.py
+++ b/python/feathub/feature_tables/sinks/redis_sink.py
@@ -11,9 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict
+from typing import Dict, Union
 
+from feathub.common.exceptions import FeathubException
 from feathub.feature_tables.sinks.sink import Sink
+from feathub.feature_tables.sources.redis_source import RedisMode
 
 
 class RedisSink(Sink):
@@ -21,6 +23,7 @@ class RedisSink(Sink):
         self,
         host: str,
         port: int = 6379,
+        mode: Union[RedisMode, str] = RedisMode.STANDALONE,
         username: str = None,
         password: str = None,
         db_num: int = 0,
@@ -29,9 +32,11 @@ class RedisSink(Sink):
         """
         :param host: The host of the Redis instance to connect.
         :param port: The port of the Redis instance to connect.
+        :param mode: The deployment mode or the name of the mode of the redis service.
         :param username: The username used by the Redis authorization process.
         :param password: The password used by the Redis authorization process.
-        :param db_num: The No. of the Redis database to connect.
+        :param db_num: The No. of the Redis database to connect. Not supported in
+                       Cluster mode.
         :param namespace: The namespace to persist features in Redis. Feature tables
                           sinking to Redis sinks with different namespaces can save
                           records with the same key into Redis without overwriting
@@ -41,20 +46,24 @@ class RedisSink(Sink):
             name="",
             system_name="redis",
             table_uri={
-                "namespace": namespace,
                 "host": host,
                 "port": port,
-                "username": username,
-                "password": password,
                 "db_num": db_num,
+                "namespace": namespace,
             },
         )
         self.namespace = namespace
         self.host = host
         self.port = port
+        self.mode = mode if isinstance(mode, RedisMode) else RedisMode(mode)
         self.username = username
         self.password = password
         self.db_num = db_num
+
+        if mode == RedisMode.CLUSTER and db_num != 0:
+            raise FeathubException(
+                "Selecting database is not supported in Cluster mode."
+            )
 
     def to_json(self) -> Dict:
         return {
@@ -62,6 +71,7 @@ class RedisSink(Sink):
             "namespace": self.namespace,
             "host": self.host,
             "port": self.port,
+            "mode": self.mode.name,
             "username": self.username,
             "password": self.password,
             "db_num": self.db_num,

--- a/python/feathub/feature_tables/tests/test_redis_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_redis_source_sink.py
@@ -13,8 +13,13 @@
 #  limitations under the License.
 from abc import ABC
 from datetime import datetime
+from typing import Union
 
 import pandas as pd
+import redis
+from redis import RedisCluster, Redis
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
 from testcontainers.redis import RedisContainer
 
 from feathub.common import types
@@ -28,8 +33,110 @@ from feathub.table.schema import Schema
 from feathub.tests.feathub_it_test_base import FeathubITTestBase
 
 
-class RedisSourceSinkITTest(ABC, FeathubITTestBase):
-    redis_container = None
+class RedisClusterContainer(DockerContainer):
+    def __init__(self, image="grokzen/redis-cluster:7.0.10", **kwargs):
+        super(RedisClusterContainer, self).__init__(image, **kwargs)
+        self.with_env("IP", "0.0.0.0")
+        for port in range(7000, 7003):
+            self.with_bind_ports(port, port)
+
+    @wait_container_is_ready(
+        redis.exceptions.ConnectionError,
+        redis.exceptions.RedisClusterException,
+        IndexError,
+    )
+    def _wait_container_ready(self):
+        client = self.get_client()
+        if not client.ping():
+            raise redis.exceptions.ConnectionError("Could not connect to Redis")
+        client.close()
+
+    def get_client(self):
+        return RedisCluster(host="127.0.0.1", port=7000)
+
+    def start(self):
+        super().start()
+        self._wait_container_ready()
+        return self
+
+
+def _test_redis_sink(
+    self: FeathubITTestBase,
+    host: str,
+    port: int,
+    mode: str,
+    redis_client: Union[Redis, RedisCluster],
+):
+    # TODO: Fix the bug that in flink processor when column "val"
+    #  contains None, all values in this column are saved as None
+    #  to Redis.
+    input_data = pd.DataFrame(
+        [
+            [1, 1, datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")],
+            [2, 2, datetime(2022, 1, 1, 0, 0, 1).strftime("%Y-%m-%d %H:%M:%S")],
+            [3, 3, datetime(2022, 1, 1, 0, 0, 2).strftime("%Y-%m-%d %H:%M:%S")],
+        ],
+        columns=["id", "val", "ts"],
+    )
+
+    schema = (
+        Schema.new_builder()
+        .column("id", types.Int64)
+        .column("val", types.Int64)
+        .column("ts", types.String)
+        .build()
+    )
+
+    source = self.create_file_source(
+        input_data,
+        keys=["id"],
+        schema=schema,
+        timestamp_field="ts",
+        timestamp_format="%Y-%m-%d %H:%M:%S",
+    )
+
+    sink = RedisSink(
+        namespace="test_namespace",
+        mode=mode,
+        host=host,
+        port=port,
+    )
+
+    self.client.materialize_features(
+        features=source,
+        sink=sink,
+        allow_overwrite=True,
+    ).wait(30000)
+
+    if not isinstance(redis_client, RedisCluster):
+        # Cluster client do not scan all nodes in the KEYS command
+        self.assertEquals(len(redis_client.keys("*")), input_data.shape[0])
+
+    for i in range(input_data.shape[0]):
+        key = b"test_namespace:" + serialize_object_with_protobuf(
+            input_data["id"][i], Int64
+        )
+
+        self.assertEquals(
+            {
+                int(0).to_bytes(4, byteorder="big"): serialize_object_with_protobuf(
+                    i + 1, Int64
+                ),
+                b"__timestamp__": int(
+                    to_unix_timestamp(
+                        datetime(2022, 1, 1, 0, 0, i),
+                        format="%Y-%m-%d %H:%M:%S",
+                    )
+                ).to_bytes(8, byteorder="big"),
+            },
+            redis_client.hgetall(key.decode("utf-8")),
+        )
+
+    redis_client.close()
+
+
+class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
+    redis_container: RedisContainer
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -42,76 +149,39 @@ class RedisSourceSinkITTest(ABC, FeathubITTestBase):
         super().tearDownClass()
         cls.redis_container.stop()
 
-    def test_redis_sink(self):
-        # TODO: Fix the bug that in flink processor when column "val"
-        #  contains None, all values in this column are saved as None
-        #  to Redis.
-        input_data = pd.DataFrame(
-            [
-                [1, 1, datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")],
-                [2, 2, datetime(2022, 1, 1, 0, 0, 1).strftime("%Y-%m-%d %H:%M:%S")],
-                [3, 3, datetime(2022, 1, 1, 0, 0, 2).strftime("%Y-%m-%d %H:%M:%S")],
-            ],
-            columns=["id", "val", "ts"],
+    def test_redis_sink_standalone_mode(self):
+        _test_redis_sink(
+            self,
+            "127.0.0.1",
+            int(
+                self.redis_container.get_exposed_port(
+                    self.redis_container.port_to_expose
+                )
+            ),
+            "standalone",
+            self.redis_container.get_client(),
         )
 
-        schema = (
-            Schema.new_builder()
-            .column("id", types.Int64)
-            .column("val", types.Int64)
-            .column("ts", types.String)
-            .build()
-        )
 
-        source = self.create_file_source(
-            input_data,
-            keys=["id"],
-            schema=schema,
-            timestamp_field="ts",
-            timestamp_format="%Y-%m-%d %H:%M:%S",
-        )
-
-        host, port, redis_client = self._get_redis_host_port_and_client()
-
-        sink = RedisSink(
-            namespace="test_namespace",
-            host=host,
-            port=port,
-        )
-
-        self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
-        ).wait(30000)
-
-        self.assertEquals(len(redis_client.keys("*")), input_data.shape[0])
-
-        for i in range(input_data.shape[0]):
-            key = b"test_namespace:" + serialize_object_with_protobuf(
-                input_data["id"][i], Int64
-            )
-
-            self.assertEquals(
-                {
-                    int(0).to_bytes(4, byteorder="big"): serialize_object_with_protobuf(
-                        i + 1, Int64
-                    ),
-                    b"__timestamp__": int(
-                        to_unix_timestamp(
-                            datetime(2022, 1, 1, 0, 0, i),
-                            format="%Y-%m-%d %H:%M:%S",
-                        )
-                    ).to_bytes(8, byteorder="big"),
-                },
-                redis_client.hgetall(key.decode("utf-8")),
-            )
+class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
+    redis_cluster_container: RedisClusterContainer
 
     @classmethod
-    def _get_redis_host_port_and_client(cls):
-        host = cls.redis_container.get_container_host_ip()
-        if host == "localhost":
-            host = "127.0.0.1"
-        port = cls.redis_container.get_exposed_port(cls.redis_container.port_to_expose)
-        client = cls.redis_container.get_client()
-        return host, int(port), client
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.redis_cluster_container = RedisClusterContainer()
+        cls.redis_cluster_container.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.redis_cluster_container.stop()
+
+    def test_redis_sink_cluster_mode(self):
+        _test_redis_sink(
+            self,
+            "127.0.0.1",
+            7000,
+            "cluster",
+            self.redis_cluster_container.get_client(),
+        )

--- a/python/feathub/online_stores/online_store_client.py
+++ b/python/feathub/online_stores/online_store_client.py
@@ -64,6 +64,7 @@ class OnlineStoreClient(ABC):
                 schema=source.schema,
                 host=source.host,
                 port=source.port,
+                mode=source.mode,
                 username=source.username,
                 password=source.password,
                 db_num=source.db_num,

--- a/python/feathub/processors/flink/table_builder/redis_utils.py
+++ b/python/feathub/processors/flink/table_builder/redis_utils.py
@@ -63,6 +63,7 @@ def insert_into_redis_sink(
     redis_sink_descriptor_builder = (
         NativeFlinkTableDescriptor.for_connector("redis")
         .schema(get_schema_from_table(features_table))
+        .option("mode", sink.mode.name)
         .option("host", sink.host)
         .option("port", str(sink.port))
         .option("dbNum", str(sink.db_num))
@@ -94,6 +95,7 @@ def _get_redis_connector_jars() -> list:
         "flink-connector-redis-*.jar",
         "jedis-*.jar",
         "gson-*.jar",
+        "commons-pool2-*.jar",
     ]
     jars = []
     for x in jar_patterns:

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -42,7 +42,8 @@ from feathub.feature_tables.tests.test_kafka_source_sink import (
 from feathub.feature_tables.tests.test_mysql_source_sink import MySQLSourceSinkITTest
 from feathub.feature_tables.tests.test_print_sink import PrintSinkITTest
 from feathub.feature_tables.tests.test_redis_source_sink import (
-    RedisSourceSinkITTest,
+    RedisSourceSinkStandaloneModeITTest,
+    RedisSourceSinkClusterModeITTest,
 )
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
@@ -408,7 +409,8 @@ class FlinkProcessorITTest(
     OverWindowTransformITTest,
     PrintSinkITTest,
     PythonUDFTransformITTest,
-    RedisSourceSinkITTest,
+    RedisSourceSinkStandaloneModeITTest,
+    RedisSourceSinkClusterModeITTest,
     SlidingWindowTransformITTest,
     SlidingFeatureViewITTest,
     BlackHoleSinkITTest,

--- a/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
@@ -60,6 +60,7 @@ class RedisSourceSinkTest(unittest.TestCase):
             expected_options = {
                 "connector": "redis",
                 "namespace": "test_namespace",
+                "mode": "STANDALONE",
                 "host": "127.0.0.1",
                 "port": "6379",
                 "password": "123456",


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for redis cluster mode on Feathub's redis connector.

## Brief change log

- Add support to write to and get online feature from a Redis cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs