### PR TITLE
Add support for MySqlRegistry

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -16,6 +16,8 @@ applications.
 - [Engines](engines/_index.md)
 	- [Apache Flink](engines/flink.md)
 	- [Apache Spark](engines/spark.md)
+- [Registries](registries/_index.md)
+  - [MySQL](registries/mysql.md)
 - [Connectors](connectors/_index.md)
   - [Overview](connectors/overview.md) 
   - [Formats](connectors/formats/_index.md)

--- a/docs/content/connectors/hive.md
+++ b/docs/content/connectors/hive.md
@@ -36,7 +36,7 @@ hive_sink = HiveSink(
 )
 
 feathub_client.materialize_features(
-    features=feature_view,
+    feature_descriptor=feature_view,
     sink=sink,
     allow_overwrite=True,
 ).wait(30000)

--- a/docs/content/connectors/kafka.md
+++ b/docs/content/connectors/kafka.md
@@ -28,7 +28,7 @@ sink = KafkaSink(
 )
 
 feathub_client.materialize_features(
-    features=feature_view,
+    feature_descriptor=feature_view,
     sink=sink,
     allow_overwrite=True,
 ).wait(30000)

--- a/docs/content/connectors/mysql.md
+++ b/docs/content/connectors/mysql.md
@@ -32,7 +32,7 @@ sink = MySQLSink(
 )
 
 feathub_client.materialize_features(
-    features=feature_view,
+    feature_descriptor=feature_view,
     sink=sink,
     allow_overwrite=True,
 ).wait(30000)

--- a/docs/content/connectors/redis.md
+++ b/docs/content/connectors/redis.md
@@ -33,7 +33,7 @@ sink = RedisSink(
 )
 
 feathub_client.materialize_features(
-    features=feature_view,
+    feature_descriptor=feature_view,
     sink=sink,
     allow_overwrite=True,
 ).wait(30000)

--- a/docs/content/registries/_index.md
+++ b/docs/content/registries/_index.md
@@ -1,0 +1,3 @@
+# Registries
+
+- [MySQL](mysql.md)

--- a/docs/content/registries/mysql.md
+++ b/docs/content/registries/mysql.md
@@ -1,0 +1,52 @@
+# MySQL
+
+The MySqlRegistry supports persisting all registered TableDescriptors into a
+MySQL database table. The following describes the configurations required to set
+up a MySqlRegistry instance.
+
+<!-- TODO: document the schema of the mysql table and the behavior when the feature descriptor is updated. -->
+
+## Configurations
+
+| Key      | Required | Default | Type    | Description                                                  |
+| -------- | -------- | ------- | ------- | ------------------------------------------------------------ |
+| database | Required | -       | String  | The name of the MySQL database to hold the Feathub registry. |
+| table    | Required | -       | String  | The name of the MySQL table to hold the Feathub registry.    |
+| host     | Required | -       | String  | IP address or hostname of the MySQL server.                  |
+| port     | Optional | 3306    | Integer | The port of the MySQL server.                                |
+| username | Optional | (None)  | String  | Name of the user to connect to the MySQL server.             |
+| password | Optional | (None)  | String  | The password of the user.                                    |
+
+## Examples
+
+Here is an example that creates a FeathubClient that persists TableDescriptors
+to MySQL.
+
+```python
+client = FeathubClient(
+    {
+        "processor": {
+            "type": "local",
+        },
+        "online_store": {
+            "types": ["memory"],
+            "memory": {},
+        },
+        "registry": {
+            "type": "mysql",
+            "mysql": {
+                "database": "default",
+                "table": "feathub_registry_features",
+                "host": "127.0.0.1",
+                "port": 3306,
+                "username": "admin",
+                "password": "123456",
+            },
+        },
+        "feature_service": {
+            "type": "local",
+            "local": {},
+        },
+    }
+)
+```

--- a/docs/examples/feature_embedding.ipynb
+++ b/docs/examples/feature_embedding.ipynb
@@ -307,7 +307,7 @@
     "sink = MemoryStoreSink(table_name=\"table_name_1\")\n",
     "\n",
     "job = client.materialize_features(\n",
-    "    features=feature_view,\n",
+    "    feature_descriptor=feature_view,\n",
     "    sink=sink,\n",
     "    allow_overwrite=True,\n",
     ")\n",

--- a/docs/examples/fraud_detection.ipynb
+++ b/docs/examples/fraud_detection.ipynb
@@ -1257,7 +1257,7 @@
     "sink = MemoryStoreSink(table_name=\"table_name_1\")\n",
     "\n",
     "job = client.materialize_features(\n",
-    "    features=online_feature_view,\n",
+    "    feature_descriptor=online_feature_view,\n",
     "    sink=sink,\n",
     "    allow_overwrite=True,\n",
     ")\n",

--- a/docs/examples/nyc_taxi.ipynb
+++ b/docs/examples/nyc_taxi.ipynb
@@ -115,6 +115,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "80213d9d",
    "metadata": {},
@@ -152,6 +153,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a673465d",
    "metadata": {},
@@ -189,6 +191,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1461c1eb",
    "metadata": {},
@@ -242,6 +245,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "da8a141b",
    "metadata": {},
@@ -327,10 +331,11 @@
     "    keep_source_fields=True,\n",
     ")\n",
     "\n",
-    "_ = client.build_features(features_list=[feature_view_1, feature_view_2])"
+    "_ = client.build_features(feature_descriptors=[feature_view_1, feature_view_2])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "27479e79",
    "metadata": {},
@@ -349,6 +354,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c3571381",
    "metadata": {},
@@ -405,6 +411,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b61a0eee",
    "metadata": {},
@@ -428,7 +435,7 @@
     "client.build_features([selected_features])\n",
     "\n",
     "job = client.materialize_features(\n",
-    "    features=selected_features,\n",
+    "    feature_descriptor=selected_features,\n",
     "    sink=sink,\n",
     "    start_datetime=datetime(2020, 1, 1),\n",
     "    end_datetime=datetime(2020, 5, 20),\n",
@@ -438,6 +445,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bf75973a",
    "metadata": {},

--- a/python/feathub/examples/nyc_taxi.py
+++ b/python/feathub/examples/nyc_taxi.py
@@ -83,7 +83,7 @@ def run_nyc_taxi_example(client: FeathubClient) -> None:
     client.build_features([selected_features])
 
     job = client.materialize_features(
-        features=selected_features,
+        feature_descriptor=selected_features,
         sink=sink,
         start_datetime=datetime(2020, 1, 1),
         end_datetime=datetime(2020, 5, 20),
@@ -229,7 +229,7 @@ def build_features(client: FeathubClient) -> FeatureView:
         keep_source_fields=True,
     )
 
-    client.build_features(features_list=[feature_view_1, feature_view_2])
+    client.build_features(feature_descriptors=[feature_view_1, feature_view_2])
 
     return feature_view_2
 

--- a/python/feathub/feature_service/tests/test_feature_service.py
+++ b/python/feathub/feature_service/tests/test_feature_service.py
@@ -111,7 +111,7 @@ class FeatureServiceTest(unittest.TestCase):
         file_source = self._create_file_source(input_data, keys=keys)
 
         self.processor.materialize_features(
-            features=file_source,
+            feature_descriptor=file_source,
             sink=online_store_sink,
             allow_overwrite=True,
         ).wait()

--- a/python/feathub/feature_tables/sources/memory_store_source.py
+++ b/python/feathub/feature_tables/sources/memory_store_source.py
@@ -48,7 +48,10 @@ class MemoryStoreSource(FeatureTable):
         self.table_name = table_name
 
     def build(
-        self, registry: "Registry", props: Optional[Dict] = None
+        self,
+        registry: "Registry",
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> TableDescriptor:
         built_table = MemoryStoreSource(
             name=self.name, keys=self.keys, table_name=self.table_name

--- a/python/feathub/feature_tables/tests/test_black_hole_sink.py
+++ b/python/feathub/feature_tables/tests/test_black_hole_sink.py
@@ -24,7 +24,5 @@ class BlackHoleSinkITTest(ABC, FeathubITTestBase):
         sink = BlackHoleSink()
 
         self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source, sink=sink, allow_overwrite=True
         ).wait()

--- a/python/feathub/feature_tables/tests/test_datagen_source.py
+++ b/python/feathub/feature_tables/tests/test_datagen_source.py
@@ -93,7 +93,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
@@ -111,7 +111,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
@@ -129,7 +129,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
@@ -147,7 +147,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["val"] >= 0).all() and (df["val"] <= 100).all())
@@ -186,7 +186,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             ),
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
 
@@ -203,7 +203,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             timestamp_format="%Y-%m-%d %H:%M:%S",
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(1000, df.shape[0])
         self.assertTrue((df["ts"].max() - df["ts"].min()) <= timedelta(seconds=1))
@@ -221,7 +221,7 @@ class DataGenSourceITTest(ABC, FeathubITTestBase):
             ),
         )
 
-        df = self.client.get_features(features=source).to_pandas()
+        df = self.client.get_features(feature_descriptor=source).to_pandas()
 
         self.assertEquals(10, df.shape[0])
         self.assertTrue((df["string_value"].str.len() == 101).all())

--- a/python/feathub/feature_tables/tests/test_file_system_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_file_system_source_sink.py
@@ -170,9 +170,7 @@ class FileSystemSourceSinkITTest(ABC, FeathubITTestBase):
         sink = FileSystemSink(path, data_format, data_format_props)
 
         self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source, sink=sink, allow_overwrite=True
         ).wait()
 
         source = FileSystemSource(

--- a/python/feathub/feature_tables/tests/test_kafka_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_kafka_source_sink.py
@@ -230,9 +230,7 @@ class KafkaSourceSinkITTest(ABC, FeathubITTestBase):
         start_time = datetime.now()
 
         self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source, sink=sink, allow_overwrite=True
         ).wait()
 
         return topic_name, start_time

--- a/python/feathub/feature_tables/tests/test_print_sink.py
+++ b/python/feathub/feature_tables/tests/test_print_sink.py
@@ -24,9 +24,7 @@ class PrintSinkITTest(ABC, FeathubITTestBase):
         sink = PrintSink()
 
         self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source, sink=sink, allow_overwrite=True
         ).wait()
 
     def test_print_sink_execute_insert(self):

--- a/python/feathub/feature_tables/tests/test_redis_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_redis_source_sink.py
@@ -131,9 +131,7 @@ def _test_redis_sink(
     )
 
     self.client.materialize_features(
-        features=source,
-        sink=sink,
-        allow_overwrite=True,
+        feature_descriptor=source, sink=sink, allow_overwrite=True
     ).wait(30000)
 
     if not isinstance(redis_client, RedisCluster):

--- a/python/feathub/feature_views/on_demand_feature_view.py
+++ b/python/feathub/feature_views/on_demand_feature_view.py
@@ -100,7 +100,10 @@ class OnDemandFeatureView(FeatureView):
                 )
 
     def build(
-        self, registry: Registry, props: Optional[Dict] = None
+        self,
+        registry: "Registry",
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> TableDescriptor:
         """
         Gets a copy of self as a resolved table descriptor.
@@ -115,7 +118,9 @@ class OnDemandFeatureView(FeatureView):
                 join_table_name = parts[0]
                 join_feature_name = parts[1]
 
-                table_desc = registry.get_features(name=join_table_name)
+                table_desc = registry.get_features(
+                    name=join_table_name, force_update=force_update
+                )
 
                 if (
                     isinstance(table_desc, MemoryStoreSource)

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -220,7 +220,10 @@ class SlidingFeatureView(FeatureView):
         return list(OrderedDict.fromkeys(output_fields))
 
     def build(
-        self, registry: Registry, props: Optional[Dict] = None
+        self,
+        registry: "Registry",
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> TableDescriptor:
         """
         Gets a copy of self as a resolved table descriptor.
@@ -232,11 +235,13 @@ class SlidingFeatureView(FeatureView):
         The source table descriptor will be cached in the registry.
         """
         if isinstance(self.source, str):
-            source = registry.get_features(name=self.source)
+            source = registry.get_features(name=self.source, force_update=force_update)
         else:
-            source = registry.build_features(features_list=[self.source], props=props)[
-                0
-            ]
+            source = registry.build_features(
+                feature_descriptors=[self.source],
+                force_update=force_update,
+                props=props,
+            )[0]
 
         features = []
         for feature in self.features:

--- a/python/feathub/feature_views/sql_feature_view.py
+++ b/python/feathub/feature_views/sql_feature_view.py
@@ -86,7 +86,10 @@ class SqlFeatureView(FeatureView):
         self._is_bounded = is_bounded
 
     def build(
-        self, registry: Registry, props: Optional[Dict] = None
+        self,
+        registry: "Registry",
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> TableDescriptor:
         return SqlFeatureView(
             name=self.name,

--- a/python/feathub/feature_views/tests/test_derived_feature_view.py
+++ b/python/feathub/feature_views/tests/test_derived_feature_view.py
@@ -285,7 +285,7 @@ class DerivedFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["timestamp"])
             .reset_index(drop=True)

--- a/python/feathub/feature_views/tests/test_sliding_feature_view.py
+++ b/python/feathub/feature_views/tests/test_sliding_feature_view.py
@@ -517,7 +517,7 @@ class SlidingFeatureViewITTest(ABC, FeathubITTestBase):
         )
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["window_time"])
             .reset_index(drop=True)

--- a/python/feathub/feature_views/transforms/tests/test_join_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_join_transform.py
@@ -103,7 +103,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=built_feature_view_3)
+            self.client.get_features(feature_descriptor=built_feature_view_3)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -205,7 +205,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=built_feature_view_2)
+            self.client.get_features(feature_descriptor=built_feature_view_2)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -317,7 +317,7 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            client.get_features(features=built_feature_view_3)
+            client.get_features(feature_descriptor=built_feature_view_3)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)

--- a/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_over_window_transform.py
@@ -87,7 +87,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         )
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -148,7 +148,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -250,7 +250,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -305,7 +305,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -347,7 +347,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -401,7 +401,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["lower_name", "time"])
             .reset_index(drop=True)
@@ -543,7 +543,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             ],
         )
 
-        table = self.client.get_features(features=features)
+        table = self.client.get_features(feature_descriptor=features)
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )
@@ -873,7 +873,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -955,7 +955,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
         ).reset_index(drop=True)
 
         result_df = (
-            self.client.get_features(features=built_feature_view_2)
+            self.client.get_features(feature_descriptor=built_feature_view_2)
             .to_pandas()
             .sort_values(by=["name", "time"])
             .reset_index(drop=True)
@@ -1089,7 +1089,7 @@ class OverWindowTransformITTest(ABC, FeathubITTestBase):
             ],
         )
 
-        table = self.client.get_features(features=features)
+        table = self.client.get_features(feature_descriptor=features)
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )

--- a/python/feathub/feature_views/transforms/tests/test_python_udf_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_python_udf_transform.py
@@ -54,7 +54,7 @@ class PythonUDFTransformITTest(ABC, FeathubITTestBase):
             by=["name", "time"]
         ).reset_index(drop=True)
 
-        table = self.client.get_features(features=feature_view)
+        table = self.client.get_features(feature_descriptor=feature_view)
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )
@@ -93,7 +93,7 @@ class PythonUDFTransformITTest(ABC, FeathubITTestBase):
             by=["name", "time"]
         ).reset_index(drop=True)
 
-        table = self.client.get_features(features=feature_view)
+        table = self.client.get_features(feature_descriptor=feature_view)
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )
@@ -135,7 +135,7 @@ class PythonUDFTransformITTest(ABC, FeathubITTestBase):
             by=["name", "time"]
         ).reset_index(drop=True)
 
-        table = self.client.get_features(features=feature_view)
+        table = self.client.get_features(feature_descriptor=feature_view)
         result_df = (
             table.to_pandas().sort_values(by=["name", "time"]).reset_index(drop=True)
         )

--- a/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
@@ -128,7 +128,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             )
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["window_time"])
                 .reset_index(drop=True)
@@ -225,7 +225,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             ).reset_index(drop=True)
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["name", "window_time"])
                 .reset_index(drop=True)
@@ -329,7 +329,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             ).reset_index(drop=True)
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["name_name", "window_time"])
                 .reset_index(drop=True)
@@ -723,7 +723,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             ).reset_index(drop=True)
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["name", "window_time"])
                 .reset_index(drop=True)
@@ -1128,7 +1128,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             ).reset_index(drop=True)
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["name", "window_time"])
                 .reset_index(drop=True)
@@ -1249,7 +1249,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             ).reset_index(drop=True)
 
             result_df = (
-                self.client.get_features(features=built_joined_feature)
+                self.client.get_features(feature_descriptor=built_joined_feature)
                 .to_pandas()
                 .sort_values(by=["name", "time"])
                 .reset_index(drop=True)
@@ -2259,7 +2259,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
             )
 
             result_df = (
-                self.client.get_features(features=features)
+                self.client.get_features(feature_descriptor=features)
                 .to_pandas()
                 .sort_values(by=["name", "window_time"])
                 .reset_index(drop=True)
@@ -2458,7 +2458,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
         )
 
         result_df = (
-            client.get_features(features=features)
+            client.get_features(feature_descriptor=features)
             .to_pandas()
             .sort_values(by=["name", "window_time"])
             .reset_index(drop=True)

--- a/python/feathub/processors/flink/flink_processor.py
+++ b/python/feathub/processors/flink/flink_processor.py
@@ -177,16 +177,16 @@ class FlinkProcessor(Processor):
 
     def get_table(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         keys: Union[pd.DataFrame, TableDescriptor, None] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,
     ) -> FlinkTable:
-        features = self._resolve_table_descriptor(features)
+        feature_descriptor = self._resolve_table_descriptor(feature_descriptor)
 
         return FlinkTable(
             flink_processor=self,
-            feature=features,
+            feature=feature_descriptor,
             keys=keys,
             start_datetime=start_datetime,
             end_datetime=end_datetime,
@@ -194,7 +194,7 @@ class FlinkProcessor(Processor):
 
     def materialize_features(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         sink: FeatureTable,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
@@ -204,18 +204,18 @@ class FlinkProcessor(Processor):
         if ttl is not None or not allow_overwrite:
             raise RuntimeError("Unsupported operation.")
 
-        features = self._resolve_table_descriptor(features)
+        feature_descriptor = self._resolve_table_descriptor(feature_descriptor)
 
         # Get the tables to join in order to compute the feature if we are using a local
         # registry.
         join_tables = (
-            self._get_join_tables(features)
+            self._get_join_tables(feature_descriptor)
             if self.registry.registry_type == LocalRegistry.REGISTRY_TYPE
             else {}
         )
 
         return self.flink_job_submitter.submit(
-            features=features,
+            features=feature_descriptor,
             keys=None,
             start_datetime=start_datetime,
             end_datetime=end_datetime,

--- a/python/feathub/processors/flink/flink_table.py
+++ b/python/feathub/processors/flink/flink_table.py
@@ -154,7 +154,7 @@ class FlinkTable(Table):
         allow_overwrite: bool = False,
     ) -> ProcessorJob:
         return self.flink_processor.materialize_features(
-            features=self.feature,
+            feature_descriptor=self.feature,
             sink=sink,
             ttl=ttl,
             start_datetime=self.start_datetime,

--- a/python/feathub/processors/flink/job_submitter/flink_application_cluster_job_entry.py
+++ b/python/feathub/processors/flink/job_submitter/flink_application_cluster_job_entry.py
@@ -57,7 +57,7 @@ def run_job(feathub_job_descriptor_path: str) -> None:
     registry = Registry.instantiate(props=props)
 
     for _, join_table in feathub_job_descriptor.local_registry_tables.items():
-        registry.register_features(features=join_table, override=True)
+        registry.register_features(feature_descriptors=[join_table], force_update=True)
 
     flink_table_builder = FlinkTableBuilder(
         t_env=t_env,

--- a/python/feathub/processors/flink/table_builder/flink_table_builder.py
+++ b/python/feathub/processors/flink/table_builder/flink_table_builder.py
@@ -627,7 +627,9 @@ class FlinkTableBuilder:
         if isinstance(self.registry, LocalRegistry):
             return set(x for x in cast(LocalRegistry, self.registry).tables.keys())
 
-        raise FeathubException(f"Unsupported Registry type {type(self.registry)}.")
+        # Non-local registries do not support scanning all registered tables. Make sure
+        # that all needed features have been properly configures through other paths.
+        return set()
 
     @staticmethod
     def _apply_filter_if_any(

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -473,7 +473,7 @@ class FlinkProcessorITTest(
             FeathubException, "Cannot sink files in CSV format to s3"
         ):
             self.client.materialize_features(
-                features=source, sink=sink, allow_overwrite=True
+                feature_descriptor=source, sink=sink, allow_overwrite=True
             )
 
     def test_random_field_max_past(self):

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_sql_feature_view.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_sql_feature_view.py
@@ -83,7 +83,7 @@ class FlinkSqlFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .reset_index(drop=True)
         )
@@ -127,7 +127,7 @@ class FlinkSqlFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features, keys=keys)
+            self.client.get_features(feature_descriptor=features, keys=keys)
             .to_pandas()
             .sort_values(by=["name", "cost"])
             .reset_index(drop=True)
@@ -167,7 +167,7 @@ class FlinkSqlFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .reset_index(drop=True)
         )
@@ -226,7 +226,7 @@ class FlinkSqlFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .reset_index(drop=True)
         )
@@ -277,7 +277,7 @@ class FlinkSqlFeatureViewITTest(ABC, FeathubITTestBase):
         self.client.build_features([features])
 
         result_df = (
-            self.client.get_features(features=features)
+            self.client.get_features(feature_descriptor=features)
             .to_pandas()
             .reset_index(drop=True)
         )

--- a/python/feathub/processors/processor.py
+++ b/python/feathub/processors/processor.py
@@ -43,7 +43,7 @@ class Processor(ABC):
     @abstractmethod
     def get_table(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         keys: Union[pd.DataFrame, TableDescriptor, None] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,
@@ -51,9 +51,9 @@ class Processor(ABC):
         """
         Returns a table of features according to the specified criteria.
 
-        :param features: Describes the features to be included in the table. If it is a
-                         string, it refers to the name of a table descriptor in the
-                         entity registry.
+        :param feature_descriptor: Describes the features to be included in the table.
+                                   If it is a string, it refers to the name of a table
+                                   descriptor in the entity registry.
         :param keys: Optional. If it is TableDescriptor or DataFrame, it should be
                      transformed into a table of keys. If it is not None, the output
                      table should only include rows whose key fields match at least one
@@ -76,7 +76,7 @@ class Processor(ABC):
     @abstractmethod
     def materialize_features(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         sink: FeatureTable,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
@@ -87,9 +87,9 @@ class Processor(ABC):
         Starts a job to write a table of features into the given sink according to the
         specified criteria.
 
-        :param features: Describes the table of features to be inserted in the sink. If
-                         it is a string, it refers to the name of a table descriptor in
-                         the entity registry.
+        :param feature_descriptor: Describes the table of features to be inserted in the
+                                   sink. If it is a string, it refers to the name of a
+                                   table descriptor in the entity registry.
         :param sink: Describes the location to write the features.
         :param ttl: Optional. If it is not None, the features data should be purged from
                     the sink after the specified period of time.

--- a/python/feathub/processors/spark/spark_processor.py
+++ b/python/feathub/processors/spark/spark_processor.py
@@ -96,15 +96,15 @@ class SparkProcessor(Processor):
 
     def get_table(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         keys: Union[pd.DataFrame, TableDescriptor, None] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,
     ) -> SparkTable:
-        features = self._resolve_table_descriptor(features)
+        feature_descriptor = self._resolve_table_descriptor(feature_descriptor)
 
         return SparkTable(
-            feature=features,
+            feature=feature_descriptor,
             spark_processor=self,
             keys=keys,
             start_datetime=start_datetime,
@@ -113,7 +113,7 @@ class SparkProcessor(Processor):
 
     def materialize_features(
         self,
-        features: Union[str, TableDescriptor],
+        feature_descriptor: Union[str, TableDescriptor],
         sink: FeatureTable,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
@@ -125,7 +125,7 @@ class SparkProcessor(Processor):
                 "Spark processor does not support inserting features with ttl."
             )
 
-        resolved_features = self._resolve_table_descriptor(features)
+        resolved_features = self._resolve_table_descriptor(feature_descriptor)
 
         dataframe = self.get_spark_dataframe(
             feature=resolved_features,

--- a/python/feathub/processors/spark/spark_table.py
+++ b/python/feathub/processors/spark/spark_table.py
@@ -112,7 +112,7 @@ class SparkTable(Table):
         allow_overwrite: bool = False,
     ) -> SparkJob:
         return self._spark_processor.materialize_features(
-            features=self._feature,
+            feature_descriptor=self._feature,
             sink=sink,
             ttl=ttl,
             allow_overwrite=allow_overwrite,

--- a/python/feathub/registries/mysql_registry.py
+++ b/python/feathub/registries/mysql_registry.py
@@ -1,0 +1,291 @@
+# Copyright 2022 The FeatHub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from datetime import datetime
+from hashlib import sha256
+from typing import List, Optional, Dict, Any, Tuple
+
+import mysql.connector
+
+from feathub.common.config import ConfigDef
+from feathub.common.exceptions import FeathubException
+from feathub.common.utils import from_json
+from feathub.registries.registry import Registry
+from feathub.registries.registry_config import REGISTRY_PREFIX, RegistryConfig
+from feathub.table.table_descriptor import TableDescriptor
+
+MYSQL_REGISTRY_PREFIX = REGISTRY_PREFIX + "mysql."
+
+DATABASE_CONFIG = MYSQL_REGISTRY_PREFIX + "database"
+DATABASE_DOC = "The name of the MySQL database to hold the Feathub registry."
+
+TABLE_CONFIG = MYSQL_REGISTRY_PREFIX + "table"
+TABLE_DOC = "The name of the MySQL table to hold the Feathub registry."
+
+HOST_CONFIG = MYSQL_REGISTRY_PREFIX + "host"
+HOST_DOC = "IP address or hostname of the MySQL server."
+
+PORT_CONFIG = MYSQL_REGISTRY_PREFIX + "port"
+PORT_DOC = "The port of the MySQL server."
+
+USERNAME_CONFIG = MYSQL_REGISTRY_PREFIX + "username"
+USERNAME_DOC = "Name of the user to connect to the MySQL server."
+
+PASSWORD_CONFIG = MYSQL_REGISTRY_PREFIX + "password"
+PASSWORD_DOC = "The password of the user."
+
+
+# TODO: validate and throw exception if a required config's value is NONE.
+mysql_registry_config_defs: List[ConfigDef] = [
+    ConfigDef(
+        name=DATABASE_CONFIG,
+        value_type=str,
+        description=DATABASE_DOC,
+        default_value=None,
+    ),
+    ConfigDef(
+        name=TABLE_CONFIG,
+        value_type=str,
+        description=TABLE_DOC,
+        default_value=None,
+    ),
+    ConfigDef(
+        name=HOST_CONFIG,
+        value_type=str,
+        description=HOST_DOC,
+        default_value=None,
+    ),
+    ConfigDef(
+        name=PORT_CONFIG,
+        value_type=int,
+        description=PORT_DOC,
+        default_value=3306,
+    ),
+    ConfigDef(
+        name=USERNAME_CONFIG,
+        value_type=str,
+        description=USERNAME_DOC,
+        default_value=None,
+    ),
+    ConfigDef(
+        name=PASSWORD_CONFIG,
+        value_type=str,
+        description=PASSWORD_DOC,
+        default_value=None,
+    ),
+]
+
+
+class MySqlRegistryConfig(RegistryConfig):
+    def __init__(self, props: Dict[str, Any]) -> None:
+        super().__init__(props)
+        self.update_config_values(mysql_registry_config_defs)
+
+
+def _get_digest(original_descriptor: str, resolved_descriptor: str) -> str:
+    return sha256(
+        (original_descriptor + resolved_descriptor).encode("utf-8")
+    ).hexdigest()
+
+
+class MySqlRegistry(Registry):
+    """
+    A registry that stores entities in a MySQL database.
+    """
+
+    def __init__(
+        self,
+        props: Dict,
+    ):
+        super().__init__("mysql", props)
+        mysql_registry_config = MySqlRegistryConfig(props)
+        self.database = mysql_registry_config.get(DATABASE_CONFIG)
+        self.table = mysql_registry_config.get(TABLE_CONFIG)
+        self.host = mysql_registry_config.get(HOST_CONFIG)
+        self.port = mysql_registry_config.get(PORT_CONFIG)
+        self.username = mysql_registry_config.get(USERNAME_CONFIG)
+        self.password = mysql_registry_config.get(PASSWORD_CONFIG)
+
+        # dict that acts as a local cache for built and registered descriptors.
+        # each value in the dict is a tuple of
+        # - original descriptor.
+        # - resolved descriptor.
+        # - UTC timestamp when the descriptor is resolved.
+        self.tables: Dict[str, Tuple[TableDescriptor, TableDescriptor, datetime]] = {}
+
+        self.conn = mysql.connector.connect(
+            host=self.host,
+            port=self.port,
+            user=self.username,
+            password=self.password,
+            database=self.database,
+        )
+        self.cursor = self.conn.cursor()
+
+        self.cursor.execute(
+            f"""
+                CREATE TABLE IF NOT EXISTS `{self.table}`(
+                   `name` VARCHAR(64) NOT NULL,
+                   `timestamp` TIMESTAMP NOT NULL,
+                   `digest` VARCHAR(64) NOT NULL,
+                   `original_descriptor` TEXT NOT NULL,
+                   `resolved_descriptor` TEXT NOT NULL,
+                   PRIMARY KEY ( `name`, `timestamp` )
+                );
+            """
+        )
+
+    def build_features(
+        self,
+        feature_descriptors: List[TableDescriptor],
+        force_update: bool = False,
+        props: Optional[Dict] = None,
+    ) -> List[TableDescriptor]:
+        result = []
+        for table in feature_descriptors:
+            if table.name == "":
+                raise FeathubException(
+                    "Cannot build a TableDescriptor with empty name."
+                )
+
+            # TODO: add document about the limitations on the length of feature
+            #  table names.
+            if len(table.name) > 64:
+                raise FeathubException(
+                    "Cannot build or register a descriptor with a name longer"
+                    "than 64 characters."
+                )
+
+            self.tables[table.name] = (
+                table,
+                table.build(self, force_update=force_update, props=props),
+                datetime.utcnow(),
+            )
+            result.append(self.tables[table.name][1])
+
+        return result
+
+    def register_features(
+        self, feature_descriptors: List[TableDescriptor], force_update: bool = False
+    ) -> List[bool]:
+        self.build_features(feature_descriptors, force_update=force_update)
+
+        results = []
+        for descriptor in feature_descriptors:
+            existing_descriptor = self._get_descriptor_from_mysql(descriptor.name)
+
+            original_descriptor = json.dumps(
+                self.tables[descriptor.name][0].to_json(), sort_keys=True
+            )
+            resolved_descriptor = json.dumps(
+                self.tables[descriptor.name][1].to_json(), sort_keys=True
+            )
+            digest = _get_digest(original_descriptor, resolved_descriptor)
+
+            if existing_descriptor is not None and (
+                existing_descriptor[1] == digest
+                or existing_descriptor[0] >= self.tables[descriptor.name][2]
+            ):
+                results.append(False)
+                continue
+
+            original_descriptor = original_descriptor.replace('"', '\\"')
+            resolved_descriptor = resolved_descriptor.replace('"', '\\"')
+            timestamp = self.tables[descriptor.name][2].strftime("%Y-%m-%d %H:%M:%S %z")
+            self.cursor.execute(
+                f"""
+                    INSERT INTO {self.table} (
+                       `name`,
+                       `timestamp`,
+                       `digest`,
+                       `original_descriptor`,
+                       `resolved_descriptor`
+                    ) VALUES (
+                        "{descriptor.name}",
+                        "{timestamp}",
+                        "{digest}",
+                        "{original_descriptor}",
+                        "{resolved_descriptor}"
+                    );
+                """
+            )
+            results.append(True)
+        return results
+
+    def get_features(
+        self, name: str, force_update: bool = False, is_resolved: bool = True
+    ) -> TableDescriptor:
+        if force_update:
+            self._get_descriptor_from_mysql(name)
+
+        if name not in self.tables:
+            raise RuntimeError(
+                f"Table '{name}' is not found in the cache or registry. "
+                "Please invoke build_features(..) for this table."
+            )
+
+        return self.tables[name][1 if is_resolved else 0]  # type: ignore
+
+    def delete_features(self, name: str) -> bool:
+        if self._get_descriptor_from_mysql(name) is None and name not in self.tables:
+            return False
+
+        self.cursor.execute(
+            f"""
+                DELETE FROM {self.table}
+                WHERE `name` = "{name}";
+            """
+        )
+        self.tables.pop(name)
+        return True
+
+    def _get_descriptor_from_mysql(
+        self, name: str
+    ) -> Optional[Tuple[datetime, str, TableDescriptor, TableDescriptor]]:
+        self.cursor.execute(
+            f"""
+                SELECT
+                    `timestamp`,
+                    `digest`,
+                    `original_descriptor`,
+                    `resolved_descriptor`
+                FROM {self.table}
+                WHERE `name` = "{name}"
+                ORDER BY `timestamp` DESC
+                LIMIT 1;
+            """
+        )
+        results: List[Tuple] = self.cursor.fetchall()
+        if len(results) == 0:
+            return None
+
+        timestamp, digest, original_descriptor, resolved_descriptor = results[0]
+        if _get_digest(original_descriptor, resolved_descriptor) != digest:
+            raise FeathubException(
+                f"Acquired features' json string cannot match the digest. "
+                f"Data might be broken. Json string: {resolved_descriptor}, "
+                f"digest: {digest}"
+            )
+
+        original_descriptor = from_json(json.loads(original_descriptor))
+        resolved_descriptor = from_json(json.loads(resolved_descriptor))
+
+        if name not in self.tables or self.tables[name][2] < timestamp:
+            self.tables[name] = (original_descriptor, resolved_descriptor, timestamp)
+
+        return timestamp, digest, original_descriptor, resolved_descriptor
+
+    def __del__(self) -> None:
+        self.cursor.close()
+        self.conn.close()

--- a/python/feathub/registries/registry.py
+++ b/python/feathub/registries/registry.py
@@ -38,9 +38,14 @@ class Registry(ABC):
         self._registry_type = registry_type
         self._config = config
 
+    # TODO: move :param props: to other place to avoid job-specific global
+    #  properties affecting feature descriptors saved in Registry.
     @abstractmethod
     def build_features(
-        self, features_list: List[TableDescriptor], props: Optional[Dict] = None
+        self,
+        feature_descriptors: List[TableDescriptor],
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> List[TableDescriptor]:
         """
         For each table descriptor in the given list, resolve this descriptor by
@@ -50,11 +55,14 @@ class Registry(ABC):
         referred by a TableDescriptor with the given global properties if it is not
         configured already.
 
-        And caches the resolved descriptors and well as their dependent table
+        And caches the resolved descriptors as well as their dependent table
         descriptors in memory so that they can be used when building other table
         descriptors.
 
-        :param features_list: A list of table descriptors.
+        :param feature_descriptors: A list of table descriptors.
+        :param force_update: If True, the feature descriptor would be directly searched
+                             in registry. If False, the feature descriptor would be
+                             searched in local cache first.
         :param props: Optional. If it is not None, it is the global properties that are
                       used to configure the given table descriptors.
         :return: A list of resolved descriptors corresponding to the input descriptors.
@@ -63,26 +71,37 @@ class Registry(ABC):
 
     @abstractmethod
     def register_features(
-        self, features: TableDescriptor, override: bool = True
-    ) -> bool:
+        self, feature_descriptors: List[TableDescriptor], force_update: bool = False
+    ) -> List[bool]:
         """
-        Registers the given table descriptor in the registry. Each descriptor is
+        Registers the given table descriptor in the registry after building and
+        caching them in memory as described in build_features. Each descriptor is
         uniquely identified by its name in the registry.
 
-        :param features: A table descriptor to be registered.
-        :param override: Indicates whether the registration can overwrite existing
-                         descriptor or not.
-        :return: True iff registration is successful.
+        :param feature_descriptors: A table descriptor to be registered.
+        :param force_update: If True, the feature descriptor would be directly searched
+                             in registry. If False, the feature descriptor would be
+                             searched in local cache first.
+        :return: A list of bool values denoting whether the registration for each
+                 descriptor is successful.
         """
         pass
 
     @abstractmethod
-    def get_features(self, name: str) -> TableDescriptor:
+    def get_features(
+        self, name: str, force_update: bool = False, is_resolved: bool = True
+    ) -> TableDescriptor:
         """
         Returns the table descriptor previously registered with the given name. Raises
         RuntimeError if there is no such table in the registry.
 
         :param name: The name of the table descriptor to search for.
+        :param force_update: If True, the feature descriptor would be directly searched
+                             in registry. If False, the feature descriptor would be
+                             searched in local cache first.
+        :param is_resolved: If False, the original feature descriptor would be returned.
+                            If True, the descriptor that had been resolved would be
+                            returned.
         :return: A table descriptor with the given name.
         """
         pass
@@ -110,6 +129,10 @@ class Registry(ABC):
             from feathub.registries.local_registry import LocalRegistry
 
             return LocalRegistry(props=props)
+        elif registry_type == RegistryType.MYSQL:
+            from feathub.registries.mysql_registry import MySqlRegistry
+
+            return MySqlRegistry(props=props)
 
         raise RuntimeError(f"Failed to instantiate registry with props={props}.")
 

--- a/python/feathub/registries/registry_config.py
+++ b/python/feathub/registries/registry_config.py
@@ -21,6 +21,7 @@ from feathub.common.validators import in_list
 
 class RegistryType(Enum):
     LOCAL = "local"
+    MYSQL = "mysql"
 
 
 REGISTRY_PREFIX = "registry."

--- a/python/feathub/registries/tests/test_local_registry.py
+++ b/python/feathub/registries/tests/test_local_registry.py
@@ -12,116 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import tempfile
-import shutil
-
-import numpy as np
-import pandas as pd
-
-from feathub.common import types
-from feathub.common.types import from_numpy_dtype
-from feathub.processors.local.local_processor import LocalProcessor
-from feathub.registries.local_registry import LocalRegistry
-from feathub.feature_tables.sources.file_system_source import FileSystemSource
-from feathub.feature_views.feature import Feature
-from feathub.feature_views.derived_feature_view import DerivedFeatureView
-from feathub.table.schema import Schema
+from feathub.feathub_client import FeathubClient
+from feathub.registries.tests.test_registry import RegistryTestBase
 
 
-class LocalRegistryTest(unittest.TestCase):
-    def setUp(self):
-        self.registry = LocalRegistry(props={})
-        self.processor = LocalProcessor(props={}, registry=self.registry)
-        self.temp_dir = tempfile.mkdtemp()
-        self.input_data = pd.DataFrame(
-            [
-                ["Alex", 100, 100, "2022-01-01 08:01:00"],
-                ["Emma", 400, 250, "2022-01-01 08:02:00"],
-                ["Alex", 300, 200, "2022-01-02 08:03:00"],
-                ["Emma", 200, 250, "2022-01-02 08:04:00"],
-                ["Jack", 500, 500, "2022-01-03 08:05:00"],
-                ["Alex", 600, 800, "2022-01-03 08:06:00"],
-            ],
-            columns=["name", "cost", "distance", "time"],
+class LocalRegistryTest(RegistryTestBase):
+    __test__ = True
+
+    def _get_client(self) -> FeathubClient:
+        return FeathubClient(
+            {
+                "processor": {
+                    "type": "local",
+                },
+                "online_store": {
+                    "types": ["memory"],
+                    "memory": {},
+                },
+                "registry": {
+                    "type": "local",
+                    "local": {
+                        "namespace": "default",
+                    },
+                },
+                "feature_service": {
+                    "type": "local",
+                    "local": {},
+                },
+            }
         )
-
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    def _create_file_source(self, df: pd.DataFrame) -> FileSystemSource:
-        path = tempfile.NamedTemporaryFile(dir=self.temp_dir, suffix=".csv").name
-        schema = Schema(
-            field_names=df.keys().tolist(),
-            field_types=[from_numpy_dtype(dtype) for dtype in df.dtypes],
-        )
-        df.to_csv(path, index=False, header=False)
-
-        return FileSystemSource(
-            name="source",
-            path=path,
-            data_format="csv",
-            schema=schema,
-            timestamp_field="time",
-            timestamp_format="%Y-%m-%d %H:%M:%S",
-        )
-
-    def test_get_features(self):
-        df = self.input_data.copy()
-        source = self._create_file_source(df)
-        try:
-            self.registry.get_features(source.name)
-            self.fail("RuntimeError should be raised.")
-        except RuntimeError as err:
-            self.assertTrue(
-                "Table 'source' is not found in the cache or registry" in str(err)
-            )
-
-        self.registry.build_features([source])
-        fetched_source = self.registry.get_features(source.name)
-        self.assertEqual(source, fetched_source)
-
-    def test_build_features(self):
-        df = self.input_data.copy()
-        source = self._create_file_source(df)
-
-        f_cost_per_mile = Feature(
-            name="cost_per_mile",
-            dtype=types.Float32,
-            transform="cost / distance + 10",
-        )
-        features = DerivedFeatureView(
-            name="feature_view",
-            source="source",
-            features=[
-                f_cost_per_mile,
-            ],
-            keep_source_fields=True,
-        )
-
-        # get_table() should fail because 'source' is not built or registered.
-        try:
-            self.processor.get_table(features=features).to_pandas()
-            self.fail("RuntimeError should be raised.")
-        except RuntimeError as err:
-            self.assertTrue(
-                "Table 'feature_view' is not found in the cache or registry" in str(err)
-            )
-
-        # build_features() should fail because 'source' is not built or registered.
-        try:
-            self.registry.build_features([features])
-            self.fail("RuntimeError should be raised.")
-        except RuntimeError as err:
-            self.assertTrue(
-                "Table 'source' is not found in the cache or registry" in str(err)
-            )
-
-        self.registry.build_features([source, features])
-        result_df = self.processor.get_table(features=features).to_pandas()
-
-        expected_result_df = df
-        expected_result_df["cost_per_mile"] = expected_result_df.apply(
-            lambda row: row["cost"] / row["distance"] + 10, axis=1
-        ).astype(np.float32)
-        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/registries/tests/test_mysql_registry.py
+++ b/python/feathub/registries/tests/test_mysql_registry.py
@@ -1,0 +1,73 @@
+# Copyright 2022 The FeatHub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+
+from testcontainers.mysql import MySqlContainer
+
+from feathub.feathub_client import FeathubClient
+from feathub.registries.tests.test_registry import RegistryTestBase
+
+
+class MySqlRegistryTest(RegistryTestBase):
+    __test__ = True
+
+    mysql_container = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mysql_container = MySqlContainer(image="mysql:8.0")
+        cls.mysql_container.start()
+        cls.client = FeathubClient(
+            {
+                "processor": {
+                    "type": "local",
+                },
+                "online_store": {
+                    "types": ["memory"],
+                    "memory": {},
+                },
+                "registry": {
+                    "type": "mysql",
+                    "mysql": {
+                        "database": cls.mysql_container.MYSQL_DATABASE,
+                        "table": "feathub_registry_features",
+                        "host": cls.mysql_container.get_container_host_ip(),
+                        "port": int(
+                            cls.mysql_container.get_exposed_port(
+                                cls.mysql_container.port_to_expose
+                            )
+                        ),
+                        "username": cls.mysql_container.MYSQL_USER,
+                        "password": cls.mysql_container.MYSQL_PASSWORD,
+                    },
+                },
+                "feature_service": {
+                    "type": "local",
+                    "local": {},
+                },
+            }
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.mysql_container.stop()
+        cls.mysql_container = None
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        registry: Any = self.client.registry
+        registry.cursor.execute("DELETE FROM feathub_registry_features;")
+
+    def _get_client(self) -> FeathubClient:
+        return self.client

--- a/python/feathub/registries/tests/test_registry.py
+++ b/python/feathub/registries/tests/test_registry.py
@@ -11,12 +11,26 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import shutil
+import tempfile
 import unittest
+from abc import ABC, abstractmethod
 from typing import cast
 
+import numpy as np
+import pandas as pd
+
+from feathub.common import types
 from feathub.common.config import flatten_dict
+from feathub.common.types import from_numpy_dtype
+from feathub.feathub_client import FeathubClient
+from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature import Feature
 from feathub.registries.local_registry import LocalRegistry
 from feathub.registries.registry import Registry
+from feathub.table.schema import Schema
+from feathub.table.table_descriptor import TableDescriptor
 
 
 class RegistryTest(unittest.TestCase):
@@ -32,3 +46,153 @@ class RegistryTest(unittest.TestCase):
         registry = Registry.instantiate(props=config)
         self.assertIsInstance(registry, LocalRegistry)
         self.assertEqual("my-namespace", cast(LocalRegistry, registry).namespace)
+
+
+class RegistryTestBase(ABC, unittest.TestCase):
+
+    # By setting this attribute to false, it prevents pytest from discovering
+    # this class as a test when searching up from its child classes.
+    __test__ = False
+
+    def setUp(self) -> None:
+        self.client = self._get_client()
+        self.registry = self.client.registry
+        self.processor = self.client.processor
+        self.temp_dir = tempfile.mkdtemp()
+        self.input_data = pd.DataFrame(
+            [
+                ["Alex", 100, 100, "2022-01-01 08:01:00"],
+                ["Emma", 400, 250, "2022-01-01 08:02:00"],
+                ["Alex", 300, 200, "2022-01-02 08:03:00"],
+                ["Emma", 200, 250, "2022-01-02 08:04:00"],
+                ["Jack", 500, 500, "2022-01-03 08:05:00"],
+                ["Alex", 600, 800, "2022-01-03 08:06:00"],
+            ],
+            columns=["name", "cost", "distance", "time"],
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @abstractmethod
+    def _get_client(self) -> FeathubClient:
+        pass
+
+    def _create_file_source(self, df: pd.DataFrame) -> FileSystemSource:
+        path = tempfile.NamedTemporaryFile(dir=self.temp_dir, suffix=".csv").name
+        schema = Schema(
+            field_names=df.keys().tolist(),
+            field_types=[from_numpy_dtype(dtype) for dtype in df.dtypes],
+        )
+        df.to_csv(path, index=False, header=False)
+
+        return FileSystemSource(
+            name="source",
+            path=path,
+            data_format="csv",
+            schema=schema,
+            timestamp_field="time",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+    def test_get_features(self):
+        df = self.input_data.copy()
+        source = self._create_file_source(df)
+        try:
+            self.registry.get_features(source.name)
+            self.fail("RuntimeError should be raised.")
+        except RuntimeError as err:
+            self.assertTrue(
+                "Table 'source' is not found in the cache or registry" in str(err)
+            )
+
+        self.registry.register_features([source])
+        fetched_source = self.registry.get_features(source.name, force_update=True)
+        self.assertEqual(source, fetched_source)
+
+    def test_build_features(self):
+        df = self.input_data.copy()
+        source = self._create_file_source(df)
+
+        f_cost_per_mile = Feature(
+            name="cost_per_mile",
+            dtype=types.Float32,
+            transform="cost / distance + 10",
+        )
+        features = DerivedFeatureView(
+            name="feature_view",
+            source="source",
+            features=[
+                f_cost_per_mile,
+            ],
+            keep_source_fields=True,
+        )
+
+        # get_table() should fail because 'source' is not built or registered.
+        try:
+            self.processor.get_table(feature_descriptor=features).to_pandas()
+            self.fail("RuntimeError should be raised.")
+        except RuntimeError as err:
+            self.assertTrue(
+                "Table 'feature_view' is not found in the cache or registry" in str(err)
+            )
+
+        # build_features() should fail because 'source' is not built or registered.
+        try:
+            self.registry.build_features([features])
+            self.fail("RuntimeError should be raised.")
+        except RuntimeError as err:
+            self.assertTrue(
+                "Table 'source' is not found in the cache or registry" in str(err)
+            )
+
+        self.registry.build_features([source, features])
+        result_df = self.processor.get_table(feature_descriptor=features).to_pandas()
+
+        expected_result_df = df
+        expected_result_df["cost_per_mile"] = expected_result_df.apply(
+            lambda row: row["cost"] / row["distance"] + 10, axis=1
+        ).astype(np.float32)
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_delete_features(self):
+        df = self.input_data.copy()
+        source: TableDescriptor = self._create_file_source(df)
+
+        f_cost_per_mile = Feature(
+            name="cost_per_mile",
+            dtype=types.Float32,
+            transform="cost / distance + 10",
+        )
+        features: TableDescriptor = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                f_cost_per_mile,
+            ],
+            keep_source_fields=True,
+        )
+
+        source, features = self.registry.build_features([source, features])
+        fetched_source = self.registry.get_features(source.name)
+        self.assertEqual(source, fetched_source)
+
+        self.assertTrue(self.registry.delete_features(source.name))
+        self.assertFalse(self.registry.delete_features(source.name))
+        try:
+            self.registry.get_features(source.name)
+            self.fail("RuntimeError should be raised.")
+        except RuntimeError as err:
+            self.assertTrue(
+                "Table 'source' is not found in the cache or registry" in str(err)
+            )
+
+        # A resolved feature should still be able to work after its dependency
+        # has been deleted.
+        result_df = self.processor.get_table(feature_descriptor=features).to_pandas()
+
+        expected_result_df = df
+        expected_result_df["cost_per_mile"] = expected_result_df.apply(
+            lambda row: row["cost"] / row["distance"] + 10, axis=1
+        ).astype(np.float32)
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -74,7 +74,10 @@ class TableDescriptor(Entity):
         self.timestamp_format = timestamp_format
 
     def build(
-        self, registry: "Registry", props: Optional[Dict] = None
+        self,
+        registry: "Registry",
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> TableDescriptor:
         """
         Gets a copy of self after recursively replacing the dependent table and feature
@@ -86,10 +89,15 @@ class TableDescriptor(Entity):
         so that they can be used when building other table descriptors.
 
         :param registry: The entity registry to retrieve table description by name.
+        :param force_update: If True, the feature descriptor would be directly searched
+                             in registry. If False, the feature descriptor would be
+                             searched in local cache first.
         :param props: Optional. If it is not None, it is the global properties that are
                       used to configure the given table descriptors.
         :return: A resolved table descriptor.
         """
+
+        # TODO: return a COPY of self instead of the existing Python object.
         return self
 
     def get_feature(self, feature_name: str) -> Feature:

--- a/python/feathub/tests/feathub_it_test_base.py
+++ b/python/feathub/tests/feathub_it_test_base.py
@@ -59,19 +59,28 @@ class RegistryWithJsonCheck(Registry):
         self.registry = registry
 
     def build_features(
-        self, features_list: List[TableDescriptor], props: Optional[Dict] = None
+        self,
+        feature_descriptors: List[TableDescriptor],
+        force_update: bool = False,
+        props: Optional[Dict] = None,
     ) -> List[TableDescriptor]:
-        features_list = [self._save_and_reload_through_json(x) for x in features_list]
-        return self.registry.build_features(features_list, props)
+        feature_descriptors = [
+            self._save_and_reload_through_json(x) for x in feature_descriptors
+        ]
+        return self.registry.build_features(feature_descriptors, force_update, props)
 
     def register_features(
-        self, features: TableDescriptor, override: bool = True
-    ) -> bool:
-        features = self._save_and_reload_through_json(features)
-        return self.registry.register_features(features, override)
+        self, feature_descriptors: List[TableDescriptor], force_update: bool = False
+    ) -> List[bool]:
+        feature_descriptors = [
+            self._save_and_reload_through_json(x) for x in feature_descriptors
+        ]
+        return self.registry.register_features(feature_descriptors, force_update)
 
-    def get_features(self, name: str) -> TableDescriptor:
-        return self.registry.get_features(name)
+    def get_features(
+        self, name: str, force_update: bool = False, is_resolved: bool = True
+    ) -> TableDescriptor:
+        return self.registry.get_features(name, force_update, is_resolved)
 
     def delete_features(self, name: str) -> bool:
         return self.delete_features(name)

--- a/python/feathub/tests/test_get_features.py
+++ b/python/feathub/tests/test_get_features.py
@@ -30,7 +30,7 @@ def _to_timestamp(datetime_str):
 class GetFeaturesITTest(ABC, FeathubITTestBase):
     def test_get_table_from_file_source(self):
         source = self.create_file_source(self.input_data.copy())
-        table = self.client.get_features(features=source)
+        table = self.client.get_features(feature_descriptor=source)
         df = table.to_pandas()
         self.assertTrue(self.input_data.equals(df))
 
@@ -45,7 +45,7 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
             columns=["name"],
         )
         result_df = (
-            self.client.get_features(features=source, keys=keys)
+            self.client.get_features(feature_descriptor=source, keys=keys)
             .to_pandas()
             .sort_values(by=["name", "cost", "distance", "time"])
             .reset_index(drop=True)
@@ -78,7 +78,7 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
             columns=["name", "cost"],
         )
         result_df = (
-            self.client.get_features(features=source, keys=keys)
+            self.client.get_features(feature_descriptor=source, keys=keys)
             .to_pandas()
             .sort_values(by=["name", "cost", "distance", "time"])
             .reset_index(drop=True)
@@ -110,7 +110,7 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
         )
 
         with self.assertRaises(FeathubException):
-            self.client.get_features(features=source, keys=keys).to_pandas()
+            self.client.get_features(feature_descriptor=source, keys=keys).to_pandas()
 
     def test_get_table_with_start_datetime(self):
         df = self.input_data.copy()
@@ -118,7 +118,9 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
         start_datetime = _to_timestamp("2022-01-02 08:03:00")
 
         result_df = (
-            self.client.get_features(features=source, start_datetime=start_datetime)
+            self.client.get_features(
+                feature_descriptor=source, start_datetime=start_datetime
+            )
             .to_pandas()
             .sort_values(by=["name", "cost", "distance", "time"])
             .reset_index(drop=True)
@@ -144,7 +146,9 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
         end_datetime = _to_timestamp("2022-01-02 08:03:00")
 
         result_df = (
-            self.client.get_features(features=source, end_datetime=end_datetime)
+            self.client.get_features(
+                feature_descriptor=source, end_datetime=end_datetime
+            )
             .to_pandas()
             .sort_values(by=["name", "cost", "distance", "time"])
             .reset_index(drop=True)
@@ -170,12 +174,12 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
 
         with self.assertRaises(FeathubException):
             self.client.get_features(
-                features=source, end_datetime=_datetime
+                feature_descriptor=source, end_datetime=_datetime
             ).to_pandas()
 
         with self.assertRaises(FeathubException):
             self.client.get_features(
-                features=source, start_datetime=_datetime
+                feature_descriptor=source, start_datetime=_datetime
             ).to_pandas()
 
     def test_get_table_with_unsupported_feature_view(self):
@@ -220,3 +224,9 @@ class GetFeaturesITTest(ABC, FeathubITTestBase):
             lambda row: row["cost"] / row["distance"] + 5, axis=1
         )
         self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_deprecated_parameter(self):
+        source = self.create_file_source(self.input_data.copy())
+        table = self.client.get_features(features=source)
+        df = table.to_pandas()
+        self.assertTrue(self.input_data.equals(df))

--- a/python/feathub/tests/test_online_features.py
+++ b/python/feathub/tests/test_online_features.py
@@ -31,9 +31,7 @@ class OnlineFeaturesITTest(ABC, FeathubITTestBase):
 
         source_1 = self.create_file_source(self.input_data, keys=["name"])
         self.client.materialize_features(
-            features=source_1,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source_1, sink=sink, allow_overwrite=True
         ).wait()
 
         # Inserts data with different schema to the same table.
@@ -55,9 +53,7 @@ class OnlineFeaturesITTest(ABC, FeathubITTestBase):
 
         try:
             self.client.materialize_features(
-                features=source_2,
-                sink=sink,
-                allow_overwrite=True,
+                feature_descriptor=source_2, sink=sink, allow_overwrite=True
             ).wait()
             self.fail("RuntimeError should be raised.")
         except RuntimeError as err:
@@ -174,9 +170,7 @@ class OnlineFeaturesITTest(ABC, FeathubITTestBase):
 
         source = self.create_file_source(input_data, keys=["name"])
         self.client.materialize_features(
-            features=source,
-            sink=sink,
-            allow_overwrite=True,
+            feature_descriptor=source, sink=sink, allow_overwrite=True
         ).wait()
 
         return MemoryOnlineStore.get_instance().get(


### PR DESCRIPTION
## What is the purpose of the change

This pull request mainly adds MySqlRegistry so that Feathub feature metadata can be persisted remotely and synced across a distributed environment.

## Brief change log

- Adds MySqlRegistry.
- Adds from_json() method to TableDescriptor and relevant classes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs