### PR TITLE
[hotfix] Update RedisSink write and flush logic

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClient.java
@@ -18,8 +18,10 @@ package com.alibaba.feathub.flink.connectors.redis.sink;
 
 import org.apache.flink.configuration.ReadableConfig;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.DB_NUM;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.HOST;
@@ -37,6 +39,18 @@ public interface JedisClient {
     void rpush(String key, String... string);
 
     void set(String key, String value);
+
+    void lpush(String key, String... string);
+
+    void lpop(String key, int count);
+
+    void rpop(String key, int count);
+
+    List<String> lrange(String key, int start, int stop);
+
+    Set<String> hkeys(String key);
+
+    void hdel(String key, String... field);
 
     void flush();
 

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClusterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisClusterClient.java
@@ -19,15 +19,21 @@ package com.alibaba.feathub.flink.connectors.redis.sink;
 import redis.clients.jedis.ClusterPipeline;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A subclass of {@link JedisClient} that connects to a Redis cluster. Used for Redis Cluster mode.
  */
 public class JedisClusterClient implements JedisClient {
     private final ClusterPipeline pipeline;
+
+    private final UnifiedJedis jedis;
 
     public JedisClusterClient(String host, int port, String username, String password) {
         this.pipeline =
@@ -37,6 +43,10 @@ public class JedisClusterClient implements JedisClient {
                                 .user(username)
                                 .password(password)
                                 .build());
+
+        this.jedis =
+                new JedisCluster(
+                        Collections.singleton(new HostAndPort(host, port)), username, password);
     }
 
     @Override
@@ -60,6 +70,36 @@ public class JedisClusterClient implements JedisClient {
     }
 
     @Override
+    public void lpush(String key, String... string) {
+        pipeline.lpush(key, string);
+    }
+
+    @Override
+    public void lpop(String key, int count) {
+        pipeline.lpop(key, count);
+    }
+
+    @Override
+    public void rpop(String key, int count) {
+        pipeline.rpop(key, count);
+    }
+
+    @Override
+    public List<String> lrange(String key, int start, int stop) {
+        return jedis.lrange(key, start, stop);
+    }
+
+    @Override
+    public Set<String> hkeys(String key) {
+        return jedis.hkeys(key);
+    }
+
+    @Override
+    public void hdel(String key, String... field) {
+        pipeline.hdel(key, field);
+    }
+
+    @Override
     public void flush() {
         pipeline.sync();
     }
@@ -67,5 +107,6 @@ public class JedisClusterClient implements JedisClient {
     @Override
     public void close() {
         pipeline.close();
+        jedis.close();
     }
 }

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisMasterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/JedisMasterClient.java
@@ -18,10 +18,15 @@ package com.alibaba.feathub.flink.connectors.redis.sink;
 
 import org.apache.flink.util.StringUtils;
 
+import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A subclass of {@link JedisClient} that connects to a Redis master instance. Used for Redis
@@ -30,7 +35,9 @@ import java.util.Map;
 public class JedisMasterClient implements JedisClient {
     private final Jedis jedis;
 
-    private final Pipeline pipeline;
+    private final CommandObjects commandObjects;
+
+    private final List<CommandObject<?>> commands;
 
     public JedisMasterClient(String host, int port, String username, String password, int dbNum) {
         jedis = new Jedis(host, port);
@@ -40,37 +47,73 @@ public class JedisMasterClient implements JedisClient {
             jedis.auth(password);
         }
         jedis.select(dbNum);
-        pipeline = jedis.pipelined();
+        commandObjects = new CommandObjects();
+        commands = new ArrayList<>();
     }
 
     @Override
     public void del(String key) {
-        pipeline.del(key);
+        commands.add(commandObjects.del(key));
     }
 
     @Override
     public void hmset(String key, Map<String, String> hash) {
-        pipeline.hmset(key, hash);
+        commands.add(commandObjects.hmset(key, hash));
     }
 
     @Override
     public void rpush(String key, String... string) {
-        pipeline.rpush(key, string);
+        commands.add(commandObjects.rpush(key, string));
     }
 
     @Override
     public void set(String key, String value) {
-        pipeline.set(key, value);
+        commands.add(commandObjects.set(key, value));
+    }
+
+    @Override
+    public void lpush(String key, String... string) {
+        commands.add(commandObjects.lpush(key, string));
+    }
+
+    @Override
+    public void lpop(String key, int count) {
+        commands.add(commandObjects.lpop(key, count));
+    }
+
+    @Override
+    public void rpop(String key, int count) {
+        commands.add(commandObjects.rpop(key, count));
+    }
+
+    @Override
+    public List<String> lrange(String key, int start, int stop) {
+        return jedis.lrange(key, start, stop);
+    }
+
+    @Override
+    public Set<String> hkeys(String key) {
+        return jedis.hkeys(key);
+    }
+
+    @Override
+    public void hdel(String key, String... field) {
+        commands.add(commandObjects.hdel(key, field));
     }
 
     @Override
     public void flush() {
+        Pipeline pipeline = jedis.pipelined();
+        for (CommandObject<?> command : commands) {
+            pipeline.appendCommand(command);
+        }
         pipeline.sync();
+        pipeline.close();
+        commands.clear();
     }
 
     @Override
     public void close() {
-        pipeline.close();
         jedis.close();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

In the current implementation, Redis sink uses pipeline to cache write requests which are flushed per checkpoint and when the cache is full. Such behavior has caused that in some use cases, some features might be deleted, and rewritten after dozens of seconds.

This pull request fixes this behavior by changing the behavior when the sink function writes out list and map data.

## Brief change log

- Compares lists and maps to be written out to Redis with existing values and only update the changed part.
- Flushes out data for every record.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable