### PR TITLE
Support custom key in Redis connector

### DIFF
--- a/docs/content/concepts/expression-language.md
+++ b/docs/content/concepts/expression-language.md
@@ -106,6 +106,19 @@ Arguments:
 
 `LOWER(str)` - Returns `str` with all characters changed to lowercase.
 
+### CONCAT
+
+`CONCAT(string1, string2,… )` - Returns a string that concatenates string1,
+string2, ….E.g., CONCAT(‘AA’, ‘BB’, ‘CC’) returns “AABBCC”. Non-string
+parameters would first be cast to string before concatenation.
+
+### CONCAT_WS
+
+`CONCAT_WS(string1, string2, string3,…)` - Returns a string that concatenates
+string2, string3, … with a separator string1. The separator is added between the
+strings to be concatenated. Non-string parameters would first be cast to string
+before concatenation.
+
 ## Temporal Functions
 
 ### UNIX_TIMESTAMP

--- a/docs/content/connectors/redis.md
+++ b/docs/content/connectors/redis.md
@@ -5,6 +5,8 @@ FeatHub provides `RedisSource` to read data from a Redis database and
 should be deployed in standalone, master-slave, or cluster mode. Currently,
 `RedisSource` can only be used as an online store source.
 
+<!-- TODO: Add document describing the structure of data saved to Redis. -->
+
 ## Supported Processors and Usages
 
 - Flink: Lookup<sup>1</sup>, Streaming Upsert
@@ -21,7 +23,10 @@ Here are the examples of using `RedisSource` and `RedisSink`:
  materialized must have keys.
 
 ```python
-feature_view = DerivedFeatureView(...)
+feature_view = DerivedFeatureView(
+    keys=["user_id", "item_id"],
+    ...
+)
 
 sink = RedisSink(
     host="host",
@@ -29,7 +34,9 @@ sink = RedisSink(
     username="username",
     password="password",
     db_num=0,
-    namespace="namespace",
+    key_expr='CONCAT_WS(":", __NAMESPACE__, __KEYS__, __FEATURE_NAME__)',
+    # key_expr can also be configured as follows, and the effect is the same.
+    # key_expr='CONCAT_WS(":", __NAMESPACE__, user_id, item_id, __FEATURE_NAME__)',
 )
 
 feathub_client.materialize_features(
@@ -53,10 +60,13 @@ feature_table_schema = (
 source = RedisSource(
     name="feature_table",
     schema=feature_table_schema,
-    keys=["id"],
+    keys=["user_id", "item_id"],
     host="host",
     port=6379,
     timestamp_field="ts",
+    key_expr='CONCAT_WS(":", __NAMESPACE__, __KEYS__, __FEATURE_NAME__)',
+    # key_expr can also be configured as follows, and the effect is the same.
+    # key_expr='CONCAT_WS(":", __NAMESPACE__, user_id, item_id, __FEATURE_NAME__)',
 )
 
 on_demand_feature_view = OnDemandFeatureView(

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisDynamicTableSinkFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisDynamicTableSinkFactory.java
@@ -26,8 +26,6 @@ import java.util.Set;
 
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.DB_NUM;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.HOST;
-import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.KEY_FIELDS;
-import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.NAMESPACE;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PASSWORD;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.PORT;
 import static com.alibaba.feathub.flink.connectors.redis.sink.RedisSinkConfigs.REDIS_MODE;
@@ -55,8 +53,6 @@ public class RedisDynamicTableSinkFactory implements DynamicTableSinkFactory {
         options.add(HOST);
         options.add(PORT);
         options.add(DB_NUM);
-        options.add(NAMESPACE);
-        options.add(KEY_FIELDS);
         return options;
     }
 

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkConfigs.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkConfigs.java
@@ -58,25 +58,6 @@ public class RedisSinkConfigs {
                     .withDescription(
                             "The No. of the Redis database to connect. Not supported in cluster mode.");
 
-    static final ConfigOption<String> NAMESPACE =
-            ConfigOptions.key("namespace")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "A string that identifies a namespace for Redis keys. "
-                                    + "Input tables with different namespaces can save "
-                                    + "records with the same key into Redis without "
-                                    + "overwriting each other.");
-
-    static final ConfigOption<String> KEY_FIELDS =
-            ConfigOptions.key("keyFields")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "A comma-separated list of the key field names in the input table. "
-                                    + "Values in this field would be concatenated with the "
-                                    + "namespace and used as keys in Redis storage");
-
     enum RedisMode {
         STANDALONE,
         MASTER_SLAVE,

--- a/python/feathub/dsl/built_in_func.py
+++ b/python/feathub/dsl/built_in_func.py
@@ -50,6 +50,12 @@ BUILTIN_FUNCS = [
         name="LOWER", result_type_strategy=lambda input_types: String
     ),
     BuiltInFuncDefinition(
+        name="CONCAT", result_type_strategy=lambda input_types: String
+    ),
+    BuiltInFuncDefinition(
+        name="CONCAT_WS", result_type_strategy=lambda input_types: String
+    ),
+    BuiltInFuncDefinition(
         name="UNIX_TIMESTAMP", result_type_strategy=lambda input_types: Int64
     ),
     BuiltInFuncDefinition(

--- a/python/feathub/dsl/tests/test_ast_type_derive.py
+++ b/python/feathub/dsl/tests/test_ast_type_derive.py
@@ -118,6 +118,12 @@ class AstTypeDeriverTest(unittest.TestCase):
         ast = self.expr_parser.parse("LOWER('ABC')")
         self.assertEqual(String, ast.eval_dtype({}))
 
+        ast = self.expr_parser.parse("CONCAT('AA', 'BB')")
+        self.assertEqual(String, ast.eval_dtype({}))
+
+        ast = self.expr_parser.parse("CONCAT_WS(';', 'AA', 'BB')")
+        self.assertEqual(String, ast.eval_dtype({}))
+
         ast = self.expr_parser.parse("UNIX_TIMESTAMP('2022-01-01 00:00:00')")
         self.assertEqual(Int64, ast.eval_dtype({}))
 

--- a/python/feathub/feature_tables/tests/test_redis_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_redis_source_sink.py
@@ -24,6 +24,7 @@ from testcontainers.core.waiting_utils import wait_container_is_ready
 from testcontainers.redis import RedisContainer
 
 from feathub.common import types
+from feathub.common.exceptions import FeathubException
 from feathub.feature_tables.sinks.redis_sink import RedisSink
 from feathub.table.schema import Schema
 from feathub.tests.feathub_it_test_base import FeathubITTestBase
@@ -222,8 +223,6 @@ def _test_redis_sink_update_entry(
         initial_data_containing_result_data,
         initial_date_contained_by_result_data,
     ]:
-        redis_client.delete(*redis_client.keys("*"))
-
         input_data = pd.DataFrame(
             [initial_data, result_data],
             columns=["id", "val", "map", "list"],
@@ -260,6 +259,68 @@ def _test_redis_sink_update_entry(
     redis_client.close()
 
 
+def _test_redis_sink_custom_key(
+    self: FeathubITTestBase,
+    host: str,
+    port: int,
+    mode: str,
+    redis_client: Union[Redis, RedisCluster],
+):
+    # TODO: Fix the bug that in flink processor when column "val"
+    #  contains None, all values in this column are saved as None
+    #  to Redis.
+    input_data = pd.DataFrame(
+        [
+            [1, 1, [1.0, 2.0]],
+            [2, 2, [2.0, 3.0]],
+            [3, 3, [3.0, 4.0]],
+        ],
+        columns=["id", "val", "list"],
+    )
+
+    schema = (
+        Schema.new_builder()
+        .column("id", types.Int64)
+        .column("val", types.Int32)
+        .column("list", types.Float64Vector)
+        .build()
+    )
+
+    source = self.create_file_source(
+        input_data,
+        keys=["id"],
+        schema=schema,
+        timestamp_field=None,
+        data_format="json",
+    )
+
+    sink = RedisSink(
+        mode=mode,
+        host=host,
+        port=port,
+        key_expr="CONCAT(__NAMESPACE__, CAST(id AS STRING), __FEATURE_NAME__)",
+    )
+
+    self.client.materialize_features(
+        feature_descriptor=source, sink=sink, allow_overwrite=True
+    ).wait(30000)
+
+    if not isinstance(redis_client, RedisCluster):
+        # Cluster client do not scan all nodes in the KEYS command
+        self.assertEquals(len(redis_client.keys("*")), input_data.shape[0] * 2)
+
+    for i in range(input_data.shape[0]):
+        self.assertEquals(
+            redis_client.get(f"default{i+1}val"), f"{i+1}".encode("utf-8")
+        )
+        self.assertEquals(
+            redis_client.lrange(f"default{i+1}list", 0, -1),
+            [str(i + 1.0).encode("utf-8"), str(i + 2.0).encode("utf-8")],
+        )
+
+    redis_client.close()
+
+
 class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
     redis_container: RedisContainer
 
@@ -273,6 +334,14 @@ class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
     def tearDownClass(cls) -> None:
         super().tearDownClass()
         cls.redis_container.stop()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        redis_client = self.redis_container.get_client()
+        existing_keys = redis_client.keys("*")
+        if len(existing_keys) > 0:
+            redis_client.delete(*existing_keys)
+        redis_client.close()
 
     def test_redis_sink_standalone_mode(self):
         _test_redis_sink(
@@ -300,6 +369,38 @@ class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
             self.redis_container.get_client(),
         )
 
+    def test_redis_sink_custom_key_standalone_mode(self):
+        _test_redis_sink_custom_key(
+            self,
+            "127.0.0.1",
+            int(
+                self.redis_container.get_exposed_port(
+                    self.redis_container.port_to_expose
+                )
+            ),
+            "standalone",
+            self.redis_container.get_client(),
+        )
+
+    def test_illegal_key_expr(self):
+        try:
+            RedisSink(
+                namespace="test_namespace",
+                host="127.0.0.1",
+                port=6379,
+                password="123456",
+                db_num=3,
+                key_expr="__FEATURE_NAME__",
+            )
+            self.fail("FeathubException should be raised.")
+        except FeathubException as err:
+            self.assertEqual(
+                str(err),
+                "key_expr __FEATURE_NAME__ should contain __NAMESPACE__ and "
+                "__FEATURE_NAME__ in order to guarantee the uniqueness of "
+                "feature keys in Redis.",
+            )
+
 
 class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
     redis_cluster_container: RedisClusterContainer
@@ -315,6 +416,14 @@ class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
         super().tearDownClass()
         cls.redis_cluster_container.stop()
 
+    def tearDown(self) -> None:
+        super().tearDown()
+        redis_client = self.redis_cluster_container.get_client()
+        existing_keys = redis_client.keys("*")
+        if len(existing_keys) > 0:
+            redis_client.delete(*existing_keys)
+        redis_client.close()
+
     def test_redis_sink_cluster_mode(self):
         _test_redis_sink(
             self,
@@ -326,6 +435,15 @@ class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
 
     def test_redis_sink_update_entry_cluster_mode(self):
         _test_redis_sink_update_entry(
+            self,
+            "127.0.0.1",
+            7000,
+            "cluster",
+            self.redis_cluster_container.get_client(),
+        )
+
+    def test_redis_sink_custom_key_cluster_mode(self):
+        _test_redis_sink_custom_key(
             self,
             "127.0.0.1",
             7000,

--- a/python/feathub/feature_views/transforms/tests/test_expression_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_expression_transform.py
@@ -205,6 +205,76 @@ class ExpressionTransformITTest(ABC, FeathubITTestBase):
 
         self.assertTrue(expected_result_df.equals(result_df))
 
+    def test_concat(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        name_distance = Feature(
+            name="name_distance",
+            transform='CONCAT(name, "_", distance)',
+        )
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                name_distance,
+            ],
+            keep_source_fields=True,
+        )
+
+        result_df = (
+            self.client.get_features(features)
+            .to_pandas()
+            .sort_values(by=["time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = self.input_data.copy()
+        expected_result_df["name_distance"] = expected_result_df.apply(
+            lambda row: str(row["name"]) + "_" + str(row["distance"]),
+            axis=1,
+        )
+        expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(
+            drop=True
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_concat_ws(self):
+        source = self.create_file_source(self.input_data.copy())
+
+        name_distance = Feature(
+            name="name_distance",
+            transform='CONCAT_WS("_", name, distance)',
+        )
+
+        features = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                name_distance,
+            ],
+            keep_source_fields=True,
+        )
+
+        result_df = (
+            self.client.get_features(features)
+            .to_pandas()
+            .sort_values(by=["time"])
+            .reset_index(drop=True)
+        )
+
+        expected_result_df = self.input_data.copy()
+        expected_result_df["name_distance"] = expected_result_df.apply(
+            lambda row: str(row["name"]) + "_" + str(row["distance"]),
+            axis=1,
+        )
+        expected_result_df = expected_result_df.sort_values(by=["time"]).reset_index(
+            drop=True
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))
+
     def test_case(self):
         upper_name = Feature(
             name="upper_name",

--- a/python/feathub/online_stores/online_store_client.py
+++ b/python/feathub/online_stores/online_store_client.py
@@ -71,6 +71,7 @@ class OnlineStoreClient(ABC):
                 namespace=source.namespace,
                 keys=source.keys,
                 timestamp_field=source.timestamp_field,
+                key_expr=source.key_expr,
             )
 
         if isinstance(source, MySQLSource):

--- a/python/feathub/processors/flink/ast_evaluator/functions.py
+++ b/python/feathub/processors/flink/ast_evaluator/functions.py
@@ -26,6 +26,13 @@ _functions_with_equal_signature = {"LOWER", "JSON_STRING"}
 def evaluate_function(func_name: str, args: List[Any]) -> str:
     if func_name in _functions_with_equal_signature:
         return f"{func_name}({', '.join(args)})"
+    elif func_name in {"CONCAT", "CONCAT_WS"}:
+        tmp_args = args.copy()
+        for i in range(len(tmp_args)):
+            if i == 0 and func_name == "CONCAT_WS":
+                continue
+            tmp_args[i] = f"CAST({tmp_args[i]} AS STRING)"
+        return f"{func_name}({', '.join(tmp_args)})"
     elif func_name == "UNIX_TIMESTAMP":
         if len(args) > 1:
             args[1] = to_java_date_format(args[1])

--- a/python/feathub/processors/flink/table_builder/tests/mock_table_descriptor.py
+++ b/python/feathub/processors/flink/table_builder/tests/mock_table_descriptor.py
@@ -28,6 +28,7 @@ class MockTableDescriptor(TableDescriptor):
         keys: Optional[List[str]] = None,
         timestamp_field: Optional[str] = None,
         timestamp_format: str = "epoch",
+        output_feature_names: Optional[List[str]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -35,9 +36,12 @@ class MockTableDescriptor(TableDescriptor):
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,
         )
+        self.output_feature_names = output_feature_names
 
     def get_output_features(self) -> List[Feature]:
-        raise RuntimeError("Unsupported operation.")
+        if self.output_feature_names is None:
+            raise RuntimeError("Unsupported operation.")
+        return [Feature(x, "") for x in self.output_feature_names]
 
     def is_bounded(self) -> bool:
         raise RuntimeError("Unsupported operation.")

--- a/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
@@ -50,7 +50,9 @@ class RedisSourceSinkTest(unittest.TestCase):
 
         table = t_env.from_elements([(1,)]).alias("id")
         with patch("pyflink.table.table.Table.execute_insert") as execute_insert:
-            descriptor: TableDescriptor = MockTableDescriptor(keys=["id"])
+            descriptor: TableDescriptor = MockTableDescriptor(
+                keys=["id"], output_feature_names=["id", "val"]
+            )
 
             insert_into_sink(t_env, table, descriptor, sink)
             flink_table_descriptor: NativeFlinkTableDescriptor = (
@@ -59,13 +61,11 @@ class RedisSourceSinkTest(unittest.TestCase):
 
             expected_options = {
                 "connector": "redis",
-                "namespace": "test_namespace",
                 "mode": "STANDALONE",
                 "host": "127.0.0.1",
                 "port": "6379",
                 "password": "123456",
                 "dbNum": "3",
-                "keyFields": "id",
             }
             self.assertEquals(
                 expected_options, dict(flink_table_descriptor.get_options())

--- a/python/feathub/processors/flink/tests/test_redis_client.py
+++ b/python/feathub/processors/flink/tests/test_redis_client.py
@@ -251,7 +251,18 @@ class RedisClientTestBase(unittest.TestCase):
         )
 
         descriptor: TableDescriptor = MockTableDescriptor(
-            keys=["id"], timestamp_field="ts", timestamp_format="%Y-%m-%d %H:%M:%S"
+            keys=["id"],
+            timestamp_field="ts",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+            output_feature_names=[
+                "id",
+                "val",
+                "ts",
+                "map",
+                "list",
+                "nested_map",
+                "nested_list",
+            ],
         )
 
         insert_into_sink(t_env, table, descriptor, sink).wait(30000)

--- a/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
@@ -26,6 +26,10 @@ class LocalFuncEvaluator:
     def eval(self, func_name: str, values: Any) -> Any:
         if func_name == "LOWER":
             return values[0].lower()
+        elif func_name == "CONCAT":
+            return "".join([str(x) for x in values])
+        elif func_name == "CONCAT_WS":
+            return values[0].join([str(x) for x in values[1:]])
         elif func_name == "UNIX_TIMESTAMP":
             if values[0] is None:
                 return None

--- a/python/feathub/processors/spark/ast_evaluator/functions.py
+++ b/python/feathub/processors/spark/ast_evaluator/functions.py
@@ -20,7 +20,7 @@ from feathub.common.utils import to_java_date_format
 This set contains the name of the built-in functions whose name
 and argument list is the same between FeatHub and in Spark.
 """
-_functions_with_equal_signature = {"LOWER", "MAP"}
+_functions_with_equal_signature = {"LOWER", "MAP", "CONCAT", "CONCAT_WS"}
 
 
 def evaluate_function(func_name: str, args: List[Any]) -> str:


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for customizing the key of the features to save to redis.

## Brief change log

- Add `CONCAT` function to all processors.
- Add `key_expr` parameter to `RedisSink` and `RedisSource`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs