### PR TITLE
Support Redis key expr without feature name

### DIFF
--- a/python/feathub/feature_tables/sinks/redis_sink.py
+++ b/python/feathub/feature_tables/sinks/redis_sink.py
@@ -19,7 +19,6 @@ from feathub.feature_tables.sinks.sink import Sink
 from feathub.feature_tables.sources.redis_source import (
     RedisMode,
     NAMESPACE_KEYWORD,
-    FEATURE_NAME_KEYWORD,
 )
 
 
@@ -81,11 +80,10 @@ class RedisSink(Sink):
         self.db_num = db_num
         self.key_expr = key_expr
 
-        if NAMESPACE_KEYWORD not in key_expr or FEATURE_NAME_KEYWORD not in key_expr:
+        if NAMESPACE_KEYWORD not in key_expr:
             raise FeathubException(
-                f"key_expr {key_expr} should contain {NAMESPACE_KEYWORD} and "
-                f"{FEATURE_NAME_KEYWORD} in order to guarantee the uniqueness of "
-                f"feature keys in Redis."
+                f"key_expr {key_expr} should contain {NAMESPACE_KEYWORD} in order "
+                f"to guarantee the uniqueness of feature keys in Redis."
             )
 
         if mode == RedisMode.CLUSTER and db_num != 0:

--- a/python/feathub/feature_tables/sources/redis_source.py
+++ b/python/feathub/feature_tables/sources/redis_source.py
@@ -114,12 +114,20 @@ class RedisSource(FeatureTable):
         self.namespace = namespace
         self.key_expr = key_expr
 
-        if NAMESPACE_KEYWORD not in key_expr or FEATURE_NAME_KEYWORD not in key_expr:
+        if NAMESPACE_KEYWORD not in key_expr:
             raise FeathubException(
-                f"key_expr {key_expr} should contain {NAMESPACE_KEYWORD} and "
-                f"{FEATURE_NAME_KEYWORD} in order to guarantee the uniqueness of "
-                f"feature keys in Redis."
+                f"key_expr {key_expr} should contain {NAMESPACE_KEYWORD} in order "
+                f"to guarantee the uniqueness of feature keys in Redis."
             )
+
+        if FEATURE_NAME_KEYWORD not in key_expr:
+            feature_names = [x for x in schema.field_names if x not in keys]
+            if len(feature_names) > 1:
+                raise FeathubException(
+                    "In order to guarantee the uniqueness of feature keys in Redis, "
+                    f"key_expr {key_expr} should contain {FEATURE_NAME_KEYWORD},"
+                    f" or the input table should contain only one feature field."
+                )
 
         if KEYS_KEYWORD not in key_expr and any(key not in key_expr for key in keys):
             raise FeathubException(

--- a/python/feathub/processors/flink/table_builder/redis_utils.py
+++ b/python/feathub/processors/flink/table_builder/redis_utils.py
@@ -170,6 +170,13 @@ def add_redis_sink_to_statement_set(
         if x.name not in features_desc.keys
     ]
 
+    if FEATURE_NAME_KEYWORD not in sink.key_expr and len(feature_names) > 1:
+        raise FeathubException(
+            "In order to guarantee the uniqueness of feature keys in Redis, "
+            f"key_expr {sink.key_expr} should contain {FEATURE_NAME_KEYWORD},"
+            f" or the input table should contain only one feature field."
+        )
+
     features_table, _ = append_physical_key_columns_per_feature(
         features_table,
         sink.key_expr,


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support that when specifying `key_expr` when creating `RedisSource` or `RedisSink`, users do not have to include `__FEATURE_NAME__` keyword in it when there is only one feature field in the table.

## Brief change log

- Update `RedisSource`/`RedisSink`'s validation process on `key_expr`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable