### PR TITLE
Support partially updating hash/map in RedisSink

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisConfigs.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisConfigs.java
@@ -66,6 +66,14 @@ public class RedisConfigs {
                             "A comma-separated list of field names in the input table containing "
                                     + "the key values used to derive Redis keys. Used in lookup source.");
 
+    public static final ConfigOption<Boolean> ENABLE_HASH_PARTIAL_UPDATE =
+            ConfigOptions.key("enableHashPartialUpdate")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, map-typed data (or hash in Redis) would be partially updated "
+                                    + "instead of completely overridden by new data.");
+
     /** Supported Redis deployment modes. */
     public enum RedisMode {
         STANDALONE,

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisDynamicTableFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisDynamicTableFactory.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.DB_NUM;
+import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.ENABLE_HASH_PARTIAL_UPDATE;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.HOST;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.KEY_FIELDS;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.PASSWORD;
@@ -79,6 +80,7 @@ public class RedisDynamicTableFactory
         options.add(USERNAME);
         options.add(PASSWORD);
         options.add(KEY_FIELDS);
+        options.add(ENABLE_HASH_PARTIAL_UPDATE);
         return options;
     }
 }

--- a/python/feathub/feature_tables/sinks/redis_sink.py
+++ b/python/feathub/feature_tables/sinks/redis_sink.py
@@ -33,6 +33,7 @@ class RedisSink(Sink):
         db_num: int = 0,
         namespace: str = "default",
         key_expr: str = 'CONCAT_WS(":", __NAMESPACE__, __KEYS__, __FEATURE_NAME__)',
+        enable_hash_partial_update: bool = False,
     ):
         """
         :param host: The host of the Redis instance to connect.
@@ -60,6 +61,9 @@ class RedisSink(Sink):
                          If not explicitly specified, the key would be a combination of
                          the namespace, all key field values, and the name of the
                          feature.
+        :param enable_hash_partial_update: If true, map-typed data (or hash in Redis)
+                                           would be partially updated instead of
+                                           completely overridden by new data.
         """
         super().__init__(
             name="",
@@ -79,6 +83,7 @@ class RedisSink(Sink):
         self.password = password
         self.db_num = db_num
         self.key_expr = key_expr
+        self.enable_hash_partial_update = enable_hash_partial_update
 
         if NAMESPACE_KEYWORD not in key_expr:
             raise FeathubException(
@@ -102,6 +107,7 @@ class RedisSink(Sink):
             "password": self.password,
             "db_num": self.db_num,
             "key_expr": self.key_expr,
+            "enable_hash_partial_update": self.enable_hash_partial_update,
         }
 
     @classmethod
@@ -115,4 +121,5 @@ class RedisSink(Sink):
             password=json_dict["password"],
             db_num=json_dict["db_num"],
             key_expr=json_dict["key_expr"],
+            enable_hash_partial_update=json_dict["enable_hash_partial_update"],
         )

--- a/python/feathub/processors/flink/table_builder/redis_utils.py
+++ b/python/feathub/processors/flink/table_builder/redis_utils.py
@@ -196,6 +196,7 @@ def add_redis_sink_to_statement_set(
         .option("host", sink.host)
         .option("port", str(sink.port))
         .option("dbNum", str(sink.db_num))
+        .option("enableHashPartialUpdate", str(sink.enable_hash_partial_update))
     )
 
     if sink.username is not None:

--- a/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_redis_source_sink.py
@@ -67,6 +67,7 @@ class RedisSourceSinkTest(unittest.TestCase):
                 "port": "6379",
                 "password": "123456",
                 "dbNum": "3",
+                "enableHashPartialUpdate": "False",
             }
             self.assertEquals(
                 expected_options, dict(flink_table_descriptor.get_options())


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for merging map-typed data when writing data to Redis through RedisSink.

## Brief change log

- Add merge_map configuration to RedisSink.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? python docs