### PR TITLE
Optimize RedisSource map lookup behavior

### DIFF
--- a/docs/content/concepts/expression-language.md
+++ b/docs/content/concepts/expression-language.md
@@ -52,6 +52,12 @@ Comparison functions take numeric values as inputs and outputs a boolean value.
 | bool1 OR bool2  | Returns TRUE if bool1 is TRUE or bool2 is TRUE. |
 | bool1 AND bool2 | Returns TRUE if bool1 and bool2 are both TRUE.  |
 
+## Collection Functions
+
+| Function          | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| map ‘[’ value ‘]’ | Returns the value specified by key value in map.             |
+
 ## Type Conversion Functions
 
 | Function             | Description                                                                               |

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/ConversionUtils.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/ConversionUtils.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * Redis-supported data types and backwards.
  */
 public class ConversionUtils {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static String toString(RowData data, int index, DataType dataType)
             throws JsonProcessingException {

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisClient.java
@@ -38,6 +38,8 @@ public interface JedisClient {
 
     void hmset(String key, Map<String, String> hash);
 
+    List<String> hmget(String key, String... fields);
+
     void rpush(String key, String... string);
 
     String get(String key);

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisClusterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisClusterClient.java
@@ -65,6 +65,11 @@ public class JedisClusterClient implements JedisClient {
     }
 
     @Override
+    public List<String> hmget(String key, String... fields) {
+        return jedis.hmget(key, fields);
+    }
+
+    @Override
     public void rpush(String key, String... string) {
         pipeline.rpush(key, string);
     }

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisMasterClient.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/JedisMasterClient.java
@@ -67,6 +67,11 @@ public class JedisMasterClient implements JedisClient {
     }
 
     @Override
+    public List<String> hmget(String key, String... fields) {
+        return jedis.hmget(key, fields);
+    }
+
+    @Override
     public void rpush(String key, String... string) {
         commands.add(commandObjects.rpush(key, string));
     }

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisConfigs.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisConfigs.java
@@ -74,6 +74,17 @@ public class RedisConfigs {
                             "If true, map-typed data (or hash in Redis) would be partially updated "
                                     + "instead of completely overridden by new data.");
 
+    public static final ConfigOption<String> HASH_FIELDS =
+            ConfigOptions.key("hashFields")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A json string representing a Map<String, List<String>> containing the Redis"
+                                    + "hash that needs to be acquired when looking up map values. Keys of the "
+                                    + "map represents the map-typed column names, and the value to each key is a list"
+                                    + "containing the hashes needs to be acquired. If a map-typed column does not "
+                                    + "appear in the map, all hashes corresponding to the map would be acquired.");
+
     /** Supported Redis deployment modes. */
     public enum RedisMode {
         STANDALONE,

--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisDynamicTableFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/RedisDynamicTableFactory.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.DB_NUM;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.ENABLE_HASH_PARTIAL_UPDATE;
+import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.HASH_FIELDS;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.HOST;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.KEY_FIELDS;
 import static com.alibaba.feathub.flink.connectors.redis.RedisConfigs.PASSWORD;
@@ -81,6 +82,7 @@ public class RedisDynamicTableFactory
         options.add(PASSWORD);
         options.add(KEY_FIELDS);
         options.add(ENABLE_HASH_PARTIAL_UPDATE);
+        options.add(HASH_FIELDS);
         return options;
     }
 }

--- a/python/feathub/dsl/abstract_ast_evaluator.py
+++ b/python/feathub/dsl/abstract_ast_evaluator.py
@@ -31,6 +31,7 @@ from feathub.dsl.ast import (
     IsOp,
     NullNode,
     CaseOp,
+    BracketOp,
 )
 
 
@@ -74,6 +75,8 @@ class AbstractAstEvaluator(ABC):
             return self.eval_null_node(ast, variables)
         if isinstance(ast, CaseOp):
             return self.eval_case_op(ast, variables)
+        if isinstance(ast, BracketOp):
+            return self.eval_bracket_op(ast, variables)
 
         raise FeathubExpressionException(f"Unknown AST node {type(ast)}.")
 
@@ -127,4 +130,8 @@ class AbstractAstEvaluator(ABC):
 
     @abc.abstractmethod
     def eval_case_op(self, ast: CaseOp, variables: Optional[Dict]) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def eval_bracket_op(self, ast: BracketOp, variables: Optional[Dict]) -> Any:
         pass

--- a/python/feathub/dsl/expr_lexer_rules.py
+++ b/python/feathub/dsl/expr_lexer_rules.py
@@ -19,6 +19,10 @@ from ply.lex import TOKEN
 from feathub.common.exceptions import FeathubExpressionException
 
 
+VARIABLE_NAME_REGEX = r"[a-zA-Z_][a-zA-Z0-9_]*"
+ID_REGEX = rf"{VARIABLE_NAME_REGEX}|`{VARIABLE_NAME_REGEX}`"
+
+
 class ExprLexerRules:
     literals = ["+", "-", "*", "/"]
 
@@ -58,6 +62,8 @@ class ExprLexerRules:
     tokens = [
         "LPAREN",
         "RPAREN",
+        "LBRACKET",
+        "RBRACKET",
         "LT",
         "LE",
         "GT",
@@ -74,6 +80,8 @@ class ExprLexerRules:
     # Regular expression rules for simple tokens
     t_LPAREN = r"\("
     t_RPAREN = r"\)"
+    t_LBRACKET = r"\["
+    t_RBRACKET = r"\]"
     t_LT = r"<"
     t_LE = r"<="
     t_GT = r">"
@@ -96,7 +104,7 @@ class ExprLexerRules:
         t.value = int(t.value)
         return t
 
-    @TOKEN(r"[a-zA-Z_][a-zA-Z0-9_]*|`[a-zA-Z_][a-zA-Z0-9_]*`")
+    @TOKEN(ID_REGEX)
     def t_ID(self, t: lex.LexToken) -> lex.LexToken:
 
         # Do not check the reserved keywords map if the id is surrounded by backticks

--- a/python/feathub/dsl/expr_parser.py
+++ b/python/feathub/dsl/expr_parser.py
@@ -33,6 +33,7 @@ from feathub.dsl.ast import (
     CaseOp,
     IsOp,
     NullNode,
+    BracketOp,
 )
 from feathub.dsl.expr_lexer_rules import ExprLexerRules
 
@@ -114,8 +115,14 @@ class ExprParser:
         p[0] = ValueNode(p[1])
 
     def p_expression_function_call(self, p: yacc.YaccProduction) -> None:
-        """expression : ID LPAREN arglist RPAREN"""
-        p[0] = FuncCallOp(p[1], p[3])
+        """
+        expression : ID LPAREN arglist RPAREN
+                   | ID LPAREN RPAREN
+        """
+        if len(p) == 5:
+            p[0] = FuncCallOp(p[1], p[3])
+        else:
+            p[0] = FuncCallOp(p[1], ArgListNode([]))
 
     def p_expression_arglist(self, p: yacc.YaccProduction) -> None:
         """
@@ -187,6 +194,12 @@ class ExprParser:
             p[0] = CaseOp.new_builder().case(p[2], p[4])
         else:
             p[0] = p[1].case(p[3], p[5])
+
+    def p_expression_bracket_op(self, p: yacc.YaccProduction) -> None:
+        """
+        expression : expression LBRACKET expression RBRACKET
+        """
+        p[0] = BracketOp(p[1], p[3])
 
     def p_error(self, p: yacc.YaccProduction) -> None:  # noqa
         if p:

--- a/python/feathub/dsl/expr_utils.py
+++ b/python/feathub/dsl/expr_utils.py
@@ -11,14 +11,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Set
+
+import re
+from typing import Set, cast, Any, Tuple
 
 from ply import lex
 
+from feathub.dsl.ast import BracketOp, VariableNode, ValueNode
 from feathub.dsl.built_in_func import BUILTIN_FUNC_DEF_MAP
-from feathub.dsl.expr_lexer_rules import ExprLexerRules
+from feathub.dsl.expr_lexer_rules import ExprLexerRules, ID_REGEX, VARIABLE_NAME_REGEX
+from feathub.dsl.expr_parser import ExprParser
 
 lexer = lex.lex(module=ExprLexerRules())
+_parser = ExprParser()
 
 
 def get_variables(feathub_expr: str) -> Set[str]:
@@ -34,3 +39,50 @@ def get_variables(feathub_expr: str) -> Set[str]:
         if tok.type == "ID" and tok.value not in BUILTIN_FUNC_DEF_MAP:
             variables.add(tok.value)
     return variables
+
+
+def is_id(expr: str) -> bool:
+    """
+    Returns whether the feature expression is a single ID.
+    """
+    match_result = re.match(ID_REGEX, expr)
+    return match_result is not None and match_result.end() == len(expr)
+
+
+def get_var_name(expr: str) -> str:
+    """
+    Returns the variable name from the feature expression of the
+    expression is a single ID.
+    """
+    match_result = re.match(VARIABLE_NAME_REGEX, expr)
+    # TODO: Modify configurations to align the format requirement between
+    #  black and flake8 about whitespaces between functions and colons.
+    start_index = match_result.start()
+    end_index = match_result.end()
+    return expr[start_index:end_index]
+
+
+def is_static_map_lookup_op(expr: str) -> bool:
+    """
+    Returns whether the feature expression represents a static lookup
+    operation on a map-typed variable. "Static" means the lookup key
+    is a literal instead of a variable.
+    """
+    ast = _parser.parse(expr)
+    return (
+        isinstance(ast, BracketOp)
+        and isinstance(ast.left_child, VariableNode)
+        and isinstance(ast.right_child, ValueNode)
+    )
+
+
+def get_static_map_lookup_variable_and_key(expr: str) -> Tuple[str, Any]:
+    """
+    Get the map-typed variable name and the static lookup key if the
+    expression is a static map lookup operation.
+    """
+    ast = _parser.parse(expr)
+    return (
+        cast(VariableNode, cast(BracketOp, ast).left_child).var_name,
+        cast(ValueNode, cast(BracketOp, ast).right_child).value,
+    )

--- a/python/feathub/dsl/tests/test_expr_parser.py
+++ b/python/feathub/dsl/tests/test_expr_parser.py
@@ -23,6 +23,7 @@ from feathub.dsl.ast import (
     NullNode,
     CaseOp,
     CompareOp,
+    BracketOp,
 )
 from feathub.dsl.expr_parser import ExprParser
 
@@ -93,6 +94,18 @@ class ExprParserTest(unittest.TestCase):
                 ],
                 results=[ValueNode(value=1)],
                 default=NullNode(),
+            ),
+            "a['key1']": BracketOp(
+                left_child=VariableNode(var_name="a"),
+                right_child=ValueNode(value="key1"),
+            ),
+            "a[0]": BracketOp(
+                left_child=VariableNode(var_name="a"),
+                right_child=ValueNode(value=0),
+            ),
+            "a[b]": BracketOp(
+                left_child=VariableNode(var_name="a"),
+                right_child=VariableNode(var_name="b"),
             ),
         }
 

--- a/python/feathub/feature_views/feature.py
+++ b/python/feathub/feature_views/feature.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Union, Optional, Dict, Sequence
+from typing import Union, Optional, Dict, Sequence, Collection
 import json
 
 from feathub.common.exceptions import FeathubException
@@ -25,6 +25,17 @@ from feathub.feature_views.transforms.sliding_window_transform import (
 from feathub.feature_views.transforms.transformation import Transformation
 from feathub.feature_views.transforms.over_window_transform import OverWindowTransform
 from feathub.feature_views.transforms.expression_transform import ExpressionTransform
+
+
+def get_default_feature_name(disallowed_names: Collection[str]) -> str:
+    """
+    Returns a default name for a feature. Values in the disallowed_names would
+    not be returned.
+    """
+    index = 0
+    while f"_{index}" in disallowed_names:
+        index += 1
+    return f"_{index}"
 
 
 class Feature:

--- a/python/feathub/feature_views/feature_view.py
+++ b/python/feathub/feature_views/feature_view.py
@@ -51,11 +51,7 @@ class FeatureView(TableDescriptor, ABC):
         :param source: The source dataset used to derive this feature view. If it is a
                        string, it should refer to the name of a table descriptor in the
                        registry.
-        :param features: A list of features to be joined onto this feature view.
-                         If a feature is a string, it should be either in the format
-                         {table_name}.{feature_name}, which refers to a feature in the
-                         table with the given name, or in the format {feature_name},
-                         which refers to a feature in the source table.
+        :param features: A list of features to be computed in this feature view.
         :param keep_source_fields: True iff all fields in the source table should be
                                    included in this table. The feature in the source
                                    will be overwritten by the feature in this feature

--- a/python/feathub/feature_views/on_demand_feature_view.py
+++ b/python/feathub/feature_views/on_demand_feature_view.py
@@ -64,11 +64,13 @@ class OnDemandFeatureView(FeatureView):
     ):
         """
         :param name: The unique identifier of this feature view in the registry.
-        :param features: A list of features to be joined onto this feature view.
-                         If a feature is a string, it should be either in the format
-                         {table_name}.{feature_name}, which refers to a feature in the
-                         table with the given name, or in the format {feature_name},
-                         which refers to a feature in the source table.
+        :param features: A list of features to be computed in this feature view. If a
+                         feature is a string, it should be in either of the following
+                         formats:
+                         1. {feature_name}, which refers to a feature in the table with
+                            the given name
+                         2. {table_name}.{feature_name}, which refers to a feature in
+                            the source table
         :param request_schema: The schema of the request expected by the
                                OnDemandFeatureView.
         :param keep_source_fields: True iff all fields in the source table should be

--- a/python/feathub/feature_views/tests/test_sliding_feature_view.py
+++ b/python/feathub/feature_views/tests/test_sliding_feature_view.py
@@ -91,7 +91,7 @@ class SlidingFeatureViewTest(unittest.TestCase):
         feature_1 = Feature(
             name="feature_1",
             dtype=types.Float32,
-            transform=JoinTransform(table_name="t1", feature_name="f1"),
+            transform=JoinTransform(table_name="t1", expr="f1"),
         )
 
         with self.assertRaises(FeathubException):

--- a/python/feathub/feature_views/transforms/join_transform.py
+++ b/python/feathub/feature_views/transforms/join_transform.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Dict
 
-from feathub.common.utils import append_metadata_to_json
+from feathub.common.utils import append_metadata_to_json, deprecated_alias
 from feathub.feature_views.transforms.transformation import Transformation
 
 
@@ -22,29 +22,35 @@ class JoinTransform(Transformation):
     Derives feature values by joining parent table with a feature from another table.
     """
 
+    @deprecated_alias(feature_name="expr")
     def __init__(
         self,
         table_name: str,
-        feature_name: str,
+        expr: str,
     ):
         """
         :param table_name: The name of a Source or FeatureView table.
-        :param feature_name: The feature name.
+        :param expr: The feature expr. it should be in either of the following
+                     formats:
+                     1. {feature_name}, which refers to a feature in the host table
+                     2. {map_feature_name}[{literal_key_value}], which refers to a
+                        static lookup of a map feature in the host table with the
+                        given name
         """
         super().__init__()
         self.table_name = table_name
-        self.feature_name = feature_name
+        self.expr = expr
 
     @append_metadata_to_json
     def to_json(self) -> Dict:
         return {
             "table_name": self.table_name,
-            "feature_name": self.feature_name,
+            "expr": self.expr,
         }
 
     @classmethod
     def from_json(cls, json_dict: Dict) -> "JoinTransform":
         return JoinTransform(
             table_name=json_dict["table_name"],
-            feature_name=json_dict["feature_name"],
+            expr=json_dict["expr"],
         )

--- a/python/feathub/feature_views/transforms/tests/test_join_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_join_transform.py
@@ -16,7 +16,7 @@ from abc import ABC
 import pandas as pd
 
 from feathub.common.exceptions import FeathubException
-from feathub.common.types import Int64, String, Float64
+from feathub.common.types import Int64, String, Float64, MapType
 from feathub.feature_tables.sources.datagen_source import DataGenSource
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
@@ -370,3 +370,58 @@ class JoinTransformITTest(ABC, FeathubITTestBase):
         message_key_words = {"join", "timestamp", "field"}
         for word in message_key_words:
             self.assertIn(word, cm.exception.args[0].lower())
+
+    def test_join_transform_with_map_lookup(self):
+        df_1 = self.input_data.copy()
+        source = self.create_file_source(df_1)
+
+        df_2 = pd.DataFrame(
+            [
+                ["Alex", {"Alex": 100.0}, "2022-01-01,09:01:00"],
+                ["Emma", {"Emma": 400.0}, "2022-01-01,09:02:00"],
+                ["Alex", {"Alex": 200.0}, "2022-01-02,07:03:00"],
+                ["Emma", {"Emma": 300.0}, "2022-01-02,09:04:00"],
+                ["Jack", {"Jack": 500.0}, "2022-01-03,09:05:00"],
+                ["Alex", {"Alex": 450.0}, "2022-01-03,09:06:00"],
+            ],
+            columns=["name", "avg_cost_map", "time"],
+        )
+        source_2 = self.create_file_source(
+            df_2,
+            schema=Schema(
+                ["name", "avg_cost_map", "time"],
+                [String, MapType(String, Float64), String],
+            ),
+            timestamp_format="%Y-%m-%d,%H:%M:%S",
+            keys=["name"],
+            data_format="json",
+        )
+        feature_view = DerivedFeatureView(
+            name="feature_view",
+            source=source,
+            features=[
+                "cost",
+                "distance",
+                f"{source_2.name}.avg_cost_map['Alex']",
+            ],
+            keep_source_fields=False,
+        )
+
+        [_, built_feature_view] = self.client.build_features([source_2, feature_view])
+
+        expected_result_df = df_1[["name", "time", "cost", "distance"]]
+        expected_result_df["_0"] = pd.Series([None, None, 200.0, None, None, 200.0])
+        expected_result_df = expected_result_df.sort_values(
+            by=["name", "time"]
+        ).reset_index(drop=True)
+
+        result_df = (
+            self.client.get_features(feature_descriptor=built_feature_view)
+            .to_pandas()
+            .sort_values(by=["name", "time"])
+            .reset_index(drop=True)
+        )
+
+        self.assertIsNone(source.keys)
+        self.assertListEqual(["name"], built_feature_view.keys)
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_sliding_window_transform.py
@@ -1544,7 +1544,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                         [200.0, 200.0],
                         2,
                     ],
-                    ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), [], 0],
+                    ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
                 ],
                 columns=[
                     "name",
@@ -1601,7 +1601,7 @@ class SlidingWindowTransformITTest(ABC, FeathubITTestBase):
                         [200.0, 200.0],
                         2,
                     ],
-                    ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), [], 0],
+                    ["Alex", to_epoch_millis("2022-01-01 09:04:59.999"), None, 0],
                 ],
                 columns=[
                     "name",

--- a/python/feathub/processors/flink/ast_evaluator/flink_ast_evaluator.py
+++ b/python/feathub/processors/flink/ast_evaluator/flink_ast_evaluator.py
@@ -28,6 +28,7 @@ from feathub.dsl.ast import (
     IsOp,
     NullNode,
     CaseOp,
+    BracketOp,
 )
 from feathub.processors.flink.ast_evaluator.functions import evaluate_function
 
@@ -103,3 +104,8 @@ class FlinkAstEvaluator(AbstractAstEvaluator):
             eval_result = eval_result + f"ELSE {default} "
         eval_result = eval_result + "END"
         return eval_result
+
+    def eval_bracket_op(self, ast: BracketOp, variables: Optional[Dict]) -> Any:
+        left_val = self.eval(ast.left_child, variables)
+        right_val = self.eval(ast.right_child, variables)
+        return f"{left_val}[{right_val}]"

--- a/python/feathub/processors/flink/flink_processor.py
+++ b/python/feathub/processors/flink/flink_processor.py
@@ -300,7 +300,7 @@ class FlinkProcessor(Processor):
         if isinstance(features, str):
             features = self.registry.get_features(name=features)
         elif isinstance(features, FeatureView) and features.is_unresolved():
-            features = self.registry.get_features(name=features.name)
+            features = self.registry.build_features([features])[0]
 
         return features
 

--- a/python/feathub/processors/flink/table_builder/aggregation_utils.py
+++ b/python/feathub/processors/flink/table_builder/aggregation_utils.py
@@ -96,10 +96,10 @@ def get_default_value_and_type(
                 f"Unsupported DataType of AggFunc COUNT or SUM: "
                 f"{type(agg_descriptor.field_data_type)}"
             )
-    elif agg_descriptor.agg_func == AggFunc.COLLECT_LIST:
-        default_value = []
-        default_type = DataTypes.ARRAY(agg_descriptor.field_data_type)
     else:
+        # TODO: Change the default value of collection-typed agg functions
+        #  (COLLECT_LIST, VALUE_COUNTS, etc) to empty collection after
+        #  FLINK-32494 is resolved
         default_value = None
     return (
         default_value,

--- a/python/feathub/processors/flink/table_builder/join_utils.py
+++ b/python/feathub/processors/flink/table_builder/join_utils.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from datetime import timedelta
-from typing import List, Dict, Tuple, Any, Sequence, Optional
+from typing import List, Dict, Tuple, Any, Sequence, Optional, cast
 
 from pyflink.table import (
     Table as NativeFlinkTable,
@@ -21,10 +21,17 @@ from pyflink.table import (
 )
 from pyflink.table.types import DataType
 
+from feathub.dsl.expr_utils import (
+    is_id,
+    get_var_name,
+    get_static_map_lookup_variable_and_key,
+)
+from feathub.feature_views.feature import Feature
 from feathub.feature_views.sliding_feature_view import (
     SlidingFeatureView,
     ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
 )
+from feathub.feature_views.transforms.join_transform import JoinTransform
 from feathub.feature_views.transforms.sliding_window_transform import (
     SlidingWindowTransform,
 )
@@ -53,13 +60,13 @@ class JoinFieldDescriptor:
 
     def __init__(
         self,
-        field_name: str,
+        field_expr: str,
         field_data_type: Optional[DataType] = None,
         valid_time_interval: Optional[timedelta] = None,
         default_value: Optional[Any] = None,
     ):
         """
-        :param field_name: The name of the field to join.
+        :param field_expr: The expression of the field to join.
         :param field_data_type: Optional. If it is not None, the field is cast to the
                                 given type. Otherwise, use its original type.
         :param valid_time_interval: Optional. If it is not None, it specifies the valid
@@ -71,31 +78,40 @@ class JoinFieldDescriptor:
                                     to the `default_value`.
         :param default_value: The default value of the field when the value is expired.
         """
-        self.field_name = field_name
+        self.field_expr = field_expr
         self.field_data_type = field_data_type
         self.valid_time_interval = valid_time_interval
         self.default_value = default_value
 
     @staticmethod
-    def from_table_descriptor_and_field_name(
-        table_descriptor: TableDescriptor, field_name: str
+    def from_table_descriptor_and_feature(
+        table_descriptor: TableDescriptor, feature: Feature
     ) -> "JoinFieldDescriptor":
-        feature = table_descriptor.get_feature(field_name)
-        transform = feature.transform
+        join_expr = cast(JoinTransform, feature.transform).expr
+        if is_id(join_expr):
+            field_name = get_var_name(join_expr)
+        else:
+            field_name, _ = get_static_map_lookup_variable_and_key(join_expr)
+        transform = table_descriptor.get_feature(field_name).transform
 
         if (
             not isinstance(table_descriptor, SlidingFeatureView)
             or not isinstance(transform, SlidingWindowTransform)
             or table_descriptor.config.get(ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG)
         ):
-            return JoinFieldDescriptor(field_name, to_flink_type(feature.dtype))
+            return JoinFieldDescriptor(join_expr, to_flink_type(feature.dtype))
 
-        default_value, _ = get_default_value_and_type(
-            agg_descriptor=AggregationFieldDescriptor.from_feature(feature)
-        )
+        if is_id(join_expr):
+            default_value, _ = get_default_value_and_type(
+                agg_descriptor=AggregationFieldDescriptor.from_feature(
+                    table_descriptor.get_feature(field_name)
+                )
+            )
+        else:
+            default_value = None
 
         return JoinFieldDescriptor(
-            feature.name,
+            join_expr,
             to_flink_type(feature.dtype),
             transform.step_size,
             default_value,
@@ -108,7 +124,7 @@ class JoinFieldDescriptor:
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, self.__class__)
-            and self.field_name == other.field_name
+            and self.field_expr == other.field_expr
             and self.valid_time_interval == other.valid_time_interval
             and self.default_value == other.default_value
             and self.field_data_type == other.field_data_type
@@ -117,7 +133,7 @@ class JoinFieldDescriptor:
     def __hash__(self) -> int:
         return hash(
             (
-                self.field_name,
+                self.field_expr,
                 self.valid_time_interval,
                 self.default_value,
                 self.field_data_type,

--- a/python/feathub/processors/local/aggregation_utils.py
+++ b/python/feathub/processors/local/aggregation_utils.py
@@ -27,7 +27,7 @@ def _value_counts(inputs: Sequence[Any]) -> Any:
 
 def _collect_list(inputs: Sequence[Any]) -> Any:
     if len(inputs) <= 0:
-        return []
+        return None
     return list(inputs)
 
 

--- a/python/feathub/processors/local/ast_evaluator/local_ast_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_ast_evaluator.py
@@ -32,6 +32,7 @@ from feathub.dsl.ast import (
     IsOp,
     NullNode,
     CaseOp,
+    BracketOp,
 )
 from feathub.processors.local.ast_evaluator.local_func_evaluator import (
     LocalFuncEvaluator,
@@ -190,3 +191,8 @@ class LocalAstEvaluator(AbstractAstEvaluator):
             return self.eval(ast.default, variables)
 
         return None
+
+    def eval_bracket_op(self, ast: BracketOp, variables: Optional[Dict]) -> Any:
+        left_value = self.eval(ast.left_child, variables)
+        right_value = self.eval(ast.right_child, variables)
+        return left_value[right_value] if right_value in left_value else None

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -141,3 +141,6 @@ class LocalProcessorITTest(
 
     def test_protobuf_all_types(self):
         pass
+
+    def test_join_transform_with_map_lookup(self):
+        pass

--- a/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
@@ -28,6 +28,7 @@ from feathub.dsl.ast import (
     IsOp,
     NullNode,
     CaseOp,
+    BracketOp,
 )
 from feathub.processors.spark.ast_evaluator.functions import evaluate_function
 
@@ -103,3 +104,8 @@ class SparkAstEvaluator(AbstractAstEvaluator):
             eval_result = eval_result + f"ELSE {default} "
         eval_result = eval_result + "END"
         return eval_result
+
+    def eval_bracket_op(self, ast: BracketOp, variables: Optional[Dict]) -> Any:
+        left_val = self.eval(ast.left_child, variables)
+        right_val = self.eval(ast.right_child, variables)
+        return f"{left_val}[{right_val}]"

--- a/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
+++ b/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
@@ -16,6 +16,7 @@ from typing import Dict, Tuple, List, Sequence, Union, Optional
 
 import pandas as pd
 
+from feathub.dsl.expr_utils import is_id
 from feathub.feature_views.transforms.join_transform import JoinTransform
 from pyspark.sql import DataFrame as NativeSparkDataFrame, functions
 from pyspark.sql import SparkSession
@@ -269,6 +270,11 @@ class SparkDataFrameBuilder:
                     )
 
                 join_transform = feature.transform
+                if not is_id(join_transform.expr):
+                    raise FeathubException(
+                        "It is not supported to use Feathub expression in JoinTransform"
+                        " for spark processor."
+                    )
                 right_table_descriptor = descriptors_by_names[join_transform.table_name]
                 if right_table_descriptor.timestamp_field is None:
                     raise FeathubException(
@@ -289,9 +295,9 @@ class SparkDataFrameBuilder:
                 ] = JoinFieldDescriptor.from_field_name(EVENT_TIME_ATTRIBUTE_NAME)
 
                 join_field_descriptors[
-                    join_transform.feature_name
+                    join_transform.expr
                 ] = JoinFieldDescriptor.from_table_descriptor_and_field_name(
-                    right_table_descriptor, join_transform.feature_name
+                    right_table_descriptor, join_transform.expr
                 )
             else:
                 raise RuntimeError(

--- a/python/feathub/processors/spark/spark_processor.py
+++ b/python/feathub/processors/spark/spark_processor.py
@@ -159,7 +159,7 @@ class SparkProcessor(Processor):
         if isinstance(features, str):
             features = self._registry.get_features(name=features)
         elif isinstance(features, FeatureView) and features.is_unresolved():
-            features = self._registry.get_features(name=features.name)
+            features = self._registry.build_features([features])[0]
 
         return features
 

--- a/python/feathub/processors/spark/tests/test_spark_processor.py
+++ b/python/feathub/processors/spark/tests/test_spark_processor.py
@@ -158,3 +158,6 @@ class SparkProcessorITTest(
 
     def test_protobuf_all_types(self):
         pass
+
+    def test_join_transform_with_map_lookup(self):
+        pass

--- a/python/feathub/registries/tests/test_registry.py
+++ b/python/feathub/registries/tests/test_registry.py
@@ -134,7 +134,7 @@ class RegistryTestBase(ABC, unittest.TestCase):
             self.fail("RuntimeError should be raised.")
         except RuntimeError as err:
             self.assertTrue(
-                "Table 'feature_view' is not found in the cache or registry" in str(err)
+                "Table 'source' is not found in the cache or registry" in str(err)
             )
 
         # build_features() should fail because 'source' is not built or registered.


### PR DESCRIPTION
## What is the purpose of the change

This pull request mainly adds an optimization to Redis source so that when only certain keys of a map-typed feature would be used during a lookup join, the Redis source need not get the whole map value from Redis.

## Brief change log

- Support getItem operation in Feathub expression
- Support assigning default field names for features
- Support using getItem expression in JoinTransform
- Modify COLLECT_LIST's default value, changing from `[]` to `None` due to FLINK-32494.
- Optimize RedisSource in lookup joins under conditions described above.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable