### PR TITLE
Support keep_timestamp_field in Sinks

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/lookup/RedisLookupFunction.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/lookup/RedisLookupFunction.java
@@ -155,6 +155,9 @@ public class RedisLookupFunction extends LookupFunction {
             DataType valueType = fieldDataTypes[valueFieldIndex];
             if (valueType instanceof CollectionDataType) {
                 List<String> redisData = client.lrange(key, 0, -1);
+                if (redisData.isEmpty()) {
+                    continue;
+                }
                 ArrayData flinkSqlData =
                         ConversionUtils.fromList(redisData, (CollectionDataType) valueType);
                 result.setField(valueFieldIndex, flinkSqlData);
@@ -169,11 +172,17 @@ public class RedisLookupFunction extends LookupFunction {
                         redisData.put(hashFields[valueFieldIndex][j], values.get(j));
                     }
                 }
+                if (redisData.isEmpty()) {
+                    continue;
+                }
                 MapData flinkSqlData =
                         ConversionUtils.fromMap(redisData, (KeyValueDataType) valueType);
                 result.setField(valueFieldIndex, flinkSqlData);
             } else {
                 String redisData = client.get(key);
+                if (redisData == null) {
+                    continue;
+                }
                 Object flinkSqlData = ConversionUtils.fromString(redisData, valueType);
                 result.setField(valueFieldIndex, flinkSqlData);
             }

--- a/python/feathub/feathub_client.py
+++ b/python/feathub/feathub_client.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 from feathub.common.config import flatten_dict
 from feathub.common.utils import deprecated_alias
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.materialization_group import MaterializationGroup
 from feathub.processors.processor import Processor
 from feathub.registries.registry import Registry
@@ -88,7 +88,7 @@ class FeathubClient:
     def materialize_features(
         self,
         feature_descriptor: Union[str, TableDescriptor],
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,

--- a/python/feathub/feature_tables/sinks/file_system_sink.py
+++ b/python/feathub/feature_tables/sinks/file_system_sink.py
@@ -25,11 +25,15 @@ class FileSystemSink(Sink):
         path: str,
         data_format: str,
         data_format_props: Optional[Dict[str, Any]] = None,
+        keep_timestamp_field: bool = True,
     ) -> None:
         """
         :param path: The path to directory of files to write to.
         :param data_format: The format of the data that are written to the file.
         :param data_format_props: The properties of the data format.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
@@ -37,6 +41,7 @@ class FileSystemSink(Sink):
             table_uri={"path": path},
             data_format=data_format,
             data_format_props=data_format_props,
+            keep_timestamp_field=keep_timestamp_field,
         )
         self.path = path
 
@@ -46,6 +51,7 @@ class FileSystemSink(Sink):
             "path": self.path,
             "data_format": self.data_format,
             "data_format_props": self.data_format_props,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
@@ -54,4 +60,5 @@ class FileSystemSink(Sink):
             path=json_dict["path"],
             data_format=json_dict["data_format"],
             data_format_props=json_dict["data_format_props"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sinks/hive_sink.py
+++ b/python/feathub/feature_tables/sinks/hive_sink.py
@@ -31,6 +31,7 @@ class HiveSink(Sink):
         table: str,
         hive_catalog_conf_dir: str,
         processor_specific_props: Optional[Dict[str, str]] = None,
+        keep_timestamp_field: bool = True,
     ):
         """
         :param database: The database to write to.
@@ -44,6 +45,9 @@ class HiveSink(Sink):
         :param processor_specific_props: Extra properties to be passthrough to the
                                          processor. The available configurations are
                                          different for different processors.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
@@ -54,6 +58,7 @@ class HiveSink(Sink):
                 ),
                 "database": database,
             },
+            keep_timestamp_field=keep_timestamp_field,
         )
         self.database = database
         self.table = table
@@ -67,6 +72,7 @@ class HiveSink(Sink):
             "table": self.table,
             "hive_catalog_conf_dir": self.hive_catalog_conf_dir,
             "processor_specific_props": self.processor_specific_props,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
@@ -76,4 +82,5 @@ class HiveSink(Sink):
             table=json_dict["table"],
             hive_catalog_conf_dir=json_dict["hive_catalog_conf_dir"],
             processor_specific_props=json_dict["processor_specific_props"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sinks/kafka_sink.py
+++ b/python/feathub/feature_tables/sinks/kafka_sink.py
@@ -27,6 +27,7 @@ class KafkaSink(Sink):
         producer_props: Optional[Dict[str, str]] = None,
         key_data_format_props: Optional[Dict[str, Any]] = None,
         value_data_format_props: Optional[Dict[str, Any]] = None,
+        keep_timestamp_field: bool = True,
     ):
         """
         :param bootstrap_server: Comma separated list of Kafka brokers.
@@ -45,11 +46,15 @@ class KafkaSink(Sink):
                                            Kafka message key.
         :param value_data_format_props: Optional. The properties of the format for
                                              Kafka message value.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
             system_name="kafka",
             table_uri={"bootstrap_server": bootstrap_server, "topic": topic},
+            keep_timestamp_field=keep_timestamp_field,
         )
         self.bootstrap_server = bootstrap_server
         self.topic = topic
@@ -73,6 +78,7 @@ class KafkaSink(Sink):
             "producer_props": self.producer_props,
             "key_data_format_props": self.key_format_props,
             "value_data_format_props": self.value_format_props,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
@@ -85,4 +91,5 @@ class KafkaSink(Sink):
             producer_props=json_dict["producer_props"],
             key_data_format_props=json_dict["key_data_format_props"],
             value_data_format_props=json_dict["value_data_format_props"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sinks/memory_store_sink.py
+++ b/python/feathub/feature_tables/sinks/memory_store_sink.py
@@ -22,14 +22,22 @@ class MemoryStoreSink(Sink):
     A sink corresponding to a table in an online feature store.
     """
 
-    def __init__(self, table_name: str):
+    def __init__(
+        self,
+        table_name: str,
+        keep_timestamp_field: bool = True,
+    ):
         """
         :param table_name: The name of a table in the feature store.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
             system_name="memory",
             table_uri={"table_name": table_name},
+            keep_timestamp_field=keep_timestamp_field,
         )
         self.table_name = table_name
 
@@ -37,8 +45,12 @@ class MemoryStoreSink(Sink):
     def to_json(self) -> Dict:
         return {
             "table_name": self.table_name,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
     def from_json(cls, json_dict: Dict) -> "MemoryStoreSink":
-        return MemoryStoreSink(table_name=json_dict["table_name"])
+        return MemoryStoreSink(
+            table_name=json_dict["table_name"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
+        )

--- a/python/feathub/feature_tables/sinks/mysql_sink.py
+++ b/python/feathub/feature_tables/sinks/mysql_sink.py
@@ -29,6 +29,7 @@ class MySQLSink(Sink):
         password: str,
         port: int = 3306,
         processor_specific_props: Optional[Dict[str, str]] = None,
+        keep_timestamp_field: bool = True,
     ):
         """
         :param database: Database name to write to.
@@ -40,6 +41,9 @@ class MySQLSink(Sink):
         :param processor_specific_props: Extra properties to be passthrough to the
                                          processor. The available configurations are
                                          different for different processors.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
@@ -50,6 +54,7 @@ class MySQLSink(Sink):
                 "database": database,
                 "table": table,
             },
+            keep_timestamp_field=keep_timestamp_field,
         )
 
         self.host = host
@@ -72,6 +77,7 @@ class MySQLSink(Sink):
             "password": self.password,
             "port": self.port,
             "processor_specific_props": self.processor_specific_props,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
@@ -84,4 +90,5 @@ class MySQLSink(Sink):
             password=json_dict["password"],
             port=json_dict["port"],
             processor_specific_props=json_dict["processor_specific_props"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sinks/redis_sink.py
+++ b/python/feathub/feature_tables/sinks/redis_sink.py
@@ -34,6 +34,7 @@ class RedisSink(Sink):
         namespace: str = "default",
         key_expr: str = 'CONCAT_WS(":", __NAMESPACE__, __KEYS__, __FEATURE_NAME__)',
         enable_hash_partial_update: bool = False,
+        keep_timestamp_field: bool = True,
     ):
         """
         :param host: The host of the Redis instance to connect.
@@ -64,6 +65,9 @@ class RedisSink(Sink):
         :param enable_hash_partial_update: If true, map-typed data (or hash in Redis)
                                            would be partially updated instead of
                                            completely overridden by new data.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name="",
@@ -74,6 +78,7 @@ class RedisSink(Sink):
                 "db_num": db_num,
                 "namespace": namespace,
             },
+            keep_timestamp_field=keep_timestamp_field,
         )
         self.namespace = namespace
         self.host = host
@@ -108,6 +113,7 @@ class RedisSink(Sink):
             "db_num": self.db_num,
             "key_expr": self.key_expr,
             "enable_hash_partial_update": self.enable_hash_partial_update,
+            "keep_timestamp_field": self.keep_timestamp_field,
         }
 
     @classmethod
@@ -122,4 +128,5 @@ class RedisSink(Sink):
             db_num=json_dict["db_num"],
             key_expr=json_dict["key_expr"],
             enable_hash_partial_update=json_dict["enable_hash_partial_update"],
+            keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sinks/sink.py
+++ b/python/feathub/feature_tables/sinks/sink.py
@@ -31,6 +31,7 @@ class Sink(FeatureTable, ABC):
         table_uri: Dict[str, Any],
         data_format: Optional[str] = None,
         data_format_props: Optional[Dict[str, Any]] = None,
+        keep_timestamp_field: bool = True,
     ):
         """
         :param name: The name that uniquely identifies this feature table in a registry.
@@ -43,6 +44,9 @@ class Sink(FeatureTable, ABC):
                             used by storage that does not require schema, e.g.
                             filesystem, kafka, etc.
         :param data_format_props: The properties of the data format.
+        :param keep_timestamp_field: True if the timestamp field of the feature table
+                                     should be persisted to the external system through
+                                     the sink.
         """
         super().__init__(
             name=name,
@@ -51,6 +55,7 @@ class Sink(FeatureTable, ABC):
             data_format=data_format,
             data_format_props=data_format_props,
         )
+        self.keep_timestamp_field = keep_timestamp_field
 
     def is_bounded(self) -> bool:
         raise FeathubException(

--- a/python/feathub/feature_tables/tests/test_redis_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_redis_source_sink.py
@@ -32,6 +32,7 @@ from feathub.feature_tables.sources.redis_source import (
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
 from feathub.feature_views.transforms.join_transform import JoinTransform
+from feathub.feature_views.transforms.python_udf_transform import PythonUdfTransform
 from feathub.online_stores.conversion_utils import to_python_object
 from feathub.table.schema import Schema
 from feathub.tests.feathub_it_test_base import FeathubITTestBase
@@ -81,6 +82,7 @@ def _generate_test_data():
                 1,
                 1,
                 datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S"),
+                datetime(2022, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S"),
                 {"key": True},
                 [1.0, 2.0],
                 {"key": {"key": True}},
@@ -89,6 +91,7 @@ def _generate_test_data():
             [
                 2,
                 2,
+                datetime(2022, 1, 1, 0, 0, 1).strftime("%Y-%m-%d %H:%M:%S"),
                 datetime(2022, 1, 1, 0, 0, 1).strftime("%Y-%m-%d %H:%M:%S"),
                 {"key": False},
                 [2.0, 3.0],
@@ -99,34 +102,50 @@ def _generate_test_data():
                 3,
                 3,
                 datetime(2022, 1, 1, 0, 0, 2).strftime("%Y-%m-%d %H:%M:%S"),
+                datetime(2022, 1, 1, 0, 0, 2).strftime("%Y-%m-%d %H:%M:%S"),
                 {"key": True},
                 [3.0, 4.0],
                 {"key": {"key": True}},
                 {"key": [3.0, 4.0]},
             ],
+            [
+                4,
+                None,
+                datetime(2022, 1, 1, 0, 0, 3).strftime("%Y-%m-%d %H:%M:%S"),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
         ],
-        columns=["id", "val", "ts", "map", "list", "nested_map", "nested_list"],
+        # ts is the table's timestamp field, while ts2 is not.
+        columns=["id", "val", "ts", "ts2", "map", "list", "nested_map", "nested_list"],
     )
 
     redis_data = [
         (b"test_namespace:1:val", b"1"),
         (b"test_namespace:1:ts", b"2022-01-01 00:00:00"),
+        (b"test_namespace:1:ts2", b"2022-01-01 00:00:00"),
         (b"test_namespace:1:map", {b"key": b"true"}),
         (b"test_namespace:1:list", [b"1.0", b"2.0"]),
         (b"test_namespace:1:nested_map", {b"key": b'{"key":"true"}'}),
         (b"test_namespace:1:nested_list", {b"key": b'["1.0","2.0"]'}),
         (b"test_namespace:2:val", b"2"),
         (b"test_namespace:2:ts", b"2022-01-01 00:00:01"),
+        (b"test_namespace:2:ts2", b"2022-01-01 00:00:01"),
         (b"test_namespace:2:map", {b"key": b"false"}),
         (b"test_namespace:2:list", [b"2.0", b"3.0"]),
         (b"test_namespace:2:nested_map", {b"key": b'{"key":"false"}'}),
         (b"test_namespace:2:nested_list", {b"key": b'["2.0","3.0"]'}),
         (b"test_namespace:3:val", b"3"),
         (b"test_namespace:3:ts", b"2022-01-01 00:00:02"),
+        (b"test_namespace:3:ts2", b"2022-01-01 00:00:02"),
         (b"test_namespace:3:map", {b"key": b"true"}),
         (b"test_namespace:3:list", [b"3.0", b"4.0"]),
         (b"test_namespace:3:nested_map", {b"key": b'{"key":"true"}'}),
         (b"test_namespace:3:nested_list", {b"key": b'["3.0","4.0"]'}),
+        (b"test_namespace:4:ts", b"2022-01-01 00:00:03"),
     ]
 
     schema = (
@@ -134,6 +153,7 @@ def _generate_test_data():
         .column("id", types.Int64)
         .column("val", types.Int64)
         .column("ts", types.String)
+        .column("ts2", types.String)
         .column("map", types.MapType(types.String, types.Bool))
         .column("list", types.Float64Vector)
         .column(
@@ -154,9 +174,6 @@ def _test_redis_sink(
     mode: str,
     redis_client: Union[Redis, RedisCluster],
 ):
-    # TODO: Fix the bug that in flink processor when column "val"
-    #  contains None, all values in this column are saved as None
-    #  to Redis.
     dataframe_data, redis_data, schema = _generate_test_data()
 
     source = self.create_file_source(
@@ -181,7 +198,7 @@ def _test_redis_sink(
 
     if not isinstance(redis_client, RedisCluster):
         # Cluster client do not scan all nodes in the KEYS command
-        self.assertEquals(len(redis_client.keys("*")), dataframe_data.shape[0] * 6)
+        self.assertEquals(len(redis_client.keys("*")), len(redis_data))
 
     for data in redis_data:
         feature_name = data[0].decode("utf-8").split(":")[-1]
@@ -351,9 +368,6 @@ def _test_redis_sink_custom_key(
     mode: str,
     redis_client: Union[Redis, RedisCluster],
 ):
-    # TODO: Fix the bug that in flink processor when column "val"
-    #  contains None, all values in this column are saved as None
-    #  to Redis.
     input_data = pd.DataFrame(
         [
             [1, 1, [1.0, 2.0]],
@@ -406,6 +420,62 @@ def _test_redis_sink_custom_key(
     redis_client.close()
 
 
+def _test_redis_sink_not_keep_timestamp(
+    self: FeathubITTestBase,
+    host: str,
+    port: int,
+    mode: str,
+    redis_client: Union[Redis, RedisCluster],
+):
+    dataframe_data, redis_data, schema = _generate_test_data()
+
+    redis_data = [x for x in redis_data if not x[0].endswith(b"ts")]
+
+    source = self.create_file_source(
+        dataframe_data,
+        keys=["id"],
+        schema=schema,
+        timestamp_field="ts",
+        timestamp_format="%Y-%m-%d %H:%M:%S",
+        data_format="json",
+    )
+
+    sink = RedisSink(
+        namespace="test_namespace",
+        mode=mode,
+        host=host,
+        port=port,
+        keep_timestamp_field=False,
+    )
+
+    self.client.materialize_features(
+        feature_descriptor=source, sink=sink, allow_overwrite=True
+    ).wait(30000)
+
+    if not isinstance(redis_client, RedisCluster):
+        # Cluster client do not scan all nodes in the KEYS command
+        self.assertEquals(len(redis_client.keys("*")), len(redis_data))
+
+    for data in redis_data:
+        feature_name = data[0].decode("utf-8").split(":")[-1]
+        field_type = schema.get_field_type(feature_name)
+        keys = data[0].decode("utf-8").split(":")[1]
+
+        if isinstance(field_type, types.VectorType):
+            actual_result: Any = redis_client.lrange(data[0], 0, -1)
+        elif isinstance(field_type, types.MapType):
+            actual_result = redis_client.hgetall(data[0])
+        else:
+            actual_result = redis_client.get(data[0])
+
+        self.assertEquals(
+            dataframe_data[feature_name][int(keys) - 1],
+            to_python_object(actual_result, field_type),
+        )
+
+    redis_client.close()
+
+
 def _test_redis_source_join(
     self: FeathubITTestBase,
     host: str,
@@ -434,7 +504,7 @@ def _test_redis_source_join(
     )
 
     input_data = pd.DataFrame(
-        [[1], [2], [3]],
+        [[1], [2], [3], [4]],
         columns=["id"],
     )
 
@@ -455,6 +525,7 @@ def _test_redis_source_join(
             "id",
             f"{redis_source.name}.val",
             f"{redis_source.name}.ts",
+            f"{redis_source.name}.ts2",
             f"{redis_source.name}.map",
             f"{redis_source.name}.list",
             f"{redis_source.name}.nested_map",
@@ -757,6 +828,96 @@ def _test_redis_source_join_filter_map_key(
     redis_client.close()
 
 
+def _test_python_udf_on_redis_source_join(
+    self: FeathubITTestBase,
+    host: str,
+    port: int,
+    mode: str,
+    redis_client: Union[Redis, RedisCluster],
+):
+    redis_client.set("test_namespace:Alex:ItemA:cost", "100")
+    redis_client.set("test_namespace:Alex:ItemB:cost", "300")
+    redis_client.set("test_namespace:Emma:ItemA:cost", "400")
+    redis_client.set("test_namespace:Emma:ItemB:cost", "250")
+
+    redis_source = RedisSource(
+        name="redis_source",
+        namespace="test_namespace",
+        mode=mode,
+        host=host,
+        port=port,
+        keys=["name", "item"],
+        schema=(
+            Schema.new_builder()
+            .column("name", types.String)
+            .column("item", types.String)
+            .column("cost", types.Int64)
+            .build()
+        ),
+    )
+
+    input_data = pd.DataFrame(
+        [
+            ["Alex", "ItemA", "2022-01-01 08:01:00"],
+            ["Emma", "ItemB", "2022-01-01 08:02:00"],
+            ["Alex", "ItemB", "2022-01-03 08:03:00"],
+        ],
+        columns=["name", "item", "time"],
+    )
+
+    schema = (
+        Schema.new_builder()
+        .column("name", types.String)
+        .column("item", types.String)
+        .column("time", types.String)
+        .build()
+    )
+    source = self.create_file_source(
+        df=input_data,
+        keys=["item", "name"],
+        schema=schema,
+        data_format="csv",
+    )
+
+    feature_view = DerivedFeatureView(
+        name="feature_view",
+        source=source,
+        features=[
+            "name",
+            "item",
+            f"{redis_source.name}.cost",
+            Feature(
+                name="twice_cost",
+                dtype=types.Int64,
+                transform=PythonUdfTransform(lambda row: row["cost"] * 2),
+            ),
+        ],
+        keep_source_fields=False,
+    )
+
+    [_, built_feature_view] = self.client.build_features([redis_source, feature_view])
+
+    result_df = (
+        self.client.get_features(feature_descriptor=built_feature_view)
+        .to_pandas()
+        .sort_values(by=["name"])
+        .reset_index(drop=True)
+    )
+
+    expected_result = pd.DataFrame(
+        [
+            ["2022-01-01 08:01:00", "Alex", "ItemA", 100, 200],
+            ["2022-01-03 08:03:00", "Alex", "ItemB", 300, 600],
+            ["2022-01-01 08:02:00", "Emma", "ItemB", 250, 500],
+        ],
+        columns=["time", "name", "item", "cost", "twice_cost"],
+    )
+
+    self.assertTrue(result_df.equals(expected_result))
+
+    redis_client.close()
+
+
 class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
     redis_container: RedisContainer
 
@@ -820,6 +981,19 @@ class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
 
     def test_redis_sink_custom_key_standalone_mode(self):
         _test_redis_sink_custom_key(
+            self,
+            "127.0.0.1",
+            int(
+                self.redis_container.get_exposed_port(
+                    self.redis_container.port_to_expose
+                )
+            ),
+            "standalone",
+            self.redis_container.get_client(),
+        )
+
+    def test_redis_sink_not_keep_timestamp_standalone_mode(self):
+        _test_redis_sink_not_keep_timestamp(
             self,
             "127.0.0.1",
             int(
@@ -960,6 +1134,19 @@ class RedisSourceSinkStandaloneModeITTest(ABC, FeathubITTestBase):
             self.redis_container.get_client(),
         )
 
+    def test_python_udf_on_redis_source_join_standalone_mode(self):
+        _test_python_udf_on_redis_source_join(
+            self,
+            "127.0.0.1",
+            int(
+                self.redis_container.get_exposed_port(
+                    self.redis_container.port_to_expose
+                )
+            ),
+            "standalone",
+            self.redis_container.get_client(),
+        )
+
     def _test_redis_source_join_custom_key_derived_feature_view_standalone_mode(
         self,
     ):
@@ -1021,6 +1208,15 @@ class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
             self.redis_cluster_container.get_client(),
         )
 
+    def test_redis_sink_not_keep_timestamp_cluster_mode(self):
+        _test_redis_sink_not_keep_timestamp(
+            self,
+            "127.0.0.1",
+            7000,
+            "cluster",
+            self.redis_cluster_container.get_client(),
+        )
+
     def test_redis_sink_custom_key_cluster_mode(self):
         _test_redis_sink_custom_key(
             self,
@@ -1050,6 +1246,15 @@ class RedisSourceSinkClusterModeITTest(ABC, FeathubITTestBase):
 
     def test_redis_source_join_filter_map_key_cluster_mode(self):
         _test_redis_source_join_filter_map_key(
+            self,
+            "127.0.0.1",
+            7000,
+            "cluster",
+            self.redis_cluster_container.get_client(),
+        )
+
+    def test_python_udf_on_redis_source_join_cluster_mode(self):
+        _test_python_udf_on_redis_source_join(
             self,
             "127.0.0.1",
             7000,

--- a/python/feathub/materialization_group.py
+++ b/python/feathub/materialization_group.py
@@ -16,7 +16,7 @@ from datetime import timedelta, datetime
 from typing import List, Union, Optional
 
 from feathub.common.exceptions import FeathubException
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.processors.materialization_descriptor import (
     MaterializationDescriptor,
 )
@@ -40,7 +40,7 @@ class MaterializationGroup:
     def materialize_features(
         self,
         feature_descriptor: Union[str, TableDescriptor],
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,

--- a/python/feathub/processors/flink/flink_table.py
+++ b/python/feathub/processors/flink/flink_table.py
@@ -25,7 +25,7 @@ from pyflink.table import (
 
 from feathub.common.exceptions import FeathubException
 from feathub.common.types import MapType
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.processors.flink.flink_deployment_mode import DeploymentMode
 from feathub.processors.flink.flink_types_utils import to_feathub_schema
 from feathub.processors.materialization_descriptor import (
@@ -152,7 +152,7 @@ class FlinkTable(Table):
 
     def execute_insert(
         self,
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         allow_overwrite: bool = False,
     ) -> ProcessorJob:

--- a/python/feathub/processors/flink/job_submitter/tests/test_flink_application_job_entry.py
+++ b/python/feathub/processors/flink/job_submitter/tests/test_flink_application_job_entry.py
@@ -23,8 +23,8 @@ import pandas
 import pandas as pd
 
 from feathub.common.types import Int32, String
-from feathub.feature_tables.feature_table import FeatureTable
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
 from feathub.feature_views.feature import Feature
@@ -149,7 +149,7 @@ class FlinkApplicationJobEntryTest(unittest.TestCase):
         features: TableDescriptor,
         start_datetime: Optional[datetime],
         end_datetime: Optional[datetime],
-        sink: FeatureTable,
+        sink: Sink,
         join_table: Dict[str, TableDescriptor],
     ) -> str:
         path = tempfile.NamedTemporaryFile(dir=self.temp_dir, suffix=".txt").name

--- a/python/feathub/processors/local/local_processor.py
+++ b/python/feathub/processors/local/local_processor.py
@@ -36,6 +36,7 @@ from feathub.feature_tables.sinks.black_hole_sink import BlackHoleSink
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
 from feathub.feature_tables.sinks.memory_store_sink import MemoryStoreSink
 from feathub.feature_tables.sinks.print_sink import PrintSink
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.feature_tables.sources.datagen_source import DataGenSource
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
 from feathub.feature_views.derived_feature_view import DerivedFeatureView
@@ -92,7 +93,7 @@ def _is_spark_supported_source(source: FeatureTable) -> bool:
     return isinstance(source, (FileSystemSource, DataGenSource))
 
 
-def _is_spark_supported_sink(sink: FeatureTable) -> bool:
+def _is_spark_supported_sink(sink: Sink) -> bool:
     return isinstance(
         sink,
         (
@@ -216,7 +217,7 @@ class LocalProcessor(Processor):
         self,
         features: TableDescriptor,
         features_df: pd.DataFrame,
-        sink: FeatureTable,
+        sink: Sink,
         allow_overwrite: bool = False,
     ) -> LocalJob:
 
@@ -328,7 +329,7 @@ class LocalProcessor(Processor):
         self,
         df: pd.DataFrame,
         features: TableDescriptor,
-        sink: FeatureTable,
+        sink: Sink,
         allow_overwrite: bool = False,
     ) -> LocalJob:
         try:

--- a/python/feathub/processors/local/local_table.py
+++ b/python/feathub/processors/local/local_table.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pandas as pd
 
 from feathub.common import types
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.processors.processor_job import ProcessorJob
 from feathub.table.schema import Schema
 from feathub.table.table import Table
@@ -70,7 +70,7 @@ class LocalTable(Table):
 
     def execute_insert(
         self,
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         allow_overwrite: bool = False,
     ) -> ProcessorJob:

--- a/python/feathub/processors/materialization_descriptor.py
+++ b/python/feathub/processors/materialization_descriptor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from datetime import timedelta, datetime
 from typing import Union, Optional, Any
 
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.table.table_descriptor import TableDescriptor
 
 
@@ -29,7 +29,7 @@ class MaterializationDescriptor:
     def __init__(
         self,
         feature_descriptor: Union[str, TableDescriptor],
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,

--- a/python/feathub/processors/spark/dataframe_builder/source_sink_utils.py
+++ b/python/feathub/processors/spark/dataframe_builder/source_sink_utils.py
@@ -23,6 +23,7 @@ from feathub.feature_tables.sinks.black_hole_sink import BlackHoleSink
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
 from feathub.feature_tables.sinks.memory_store_sink import MemoryStoreSink
 from feathub.feature_tables.sinks.print_sink import PrintSink
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.feature_tables.sources.datagen_source import DataGenSource
 from feathub.feature_tables.sources.file_system_source import FileSystemSource
 from feathub.online_stores.memory_online_store import MemoryOnlineStore
@@ -74,7 +75,7 @@ def insert_into_sink(
     executor: Executor,
     dataframe: NativeSparkDataFrame,
     features_desc: TableDescriptor,
-    sink: FeatureTable,
+    sink: Sink,
     allow_overwrite: bool,
 ) -> Future:
     """

--- a/python/feathub/processors/spark/spark_table.py
+++ b/python/feathub/processors/spark/spark_table.py
@@ -18,7 +18,7 @@ from typing import Optional, Union
 import pandas as pd
 
 from feathub.common.exceptions import FeathubException
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.processors.materialization_descriptor import (
     MaterializationDescriptor,
 )
@@ -110,7 +110,7 @@ class SparkTable(Table):
 
     def execute_insert(
         self,
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         allow_overwrite: bool = False,
     ) -> ProcessorJob:

--- a/python/feathub/table/table.py
+++ b/python/feathub/table/table.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 import pandas as pd
 
-from feathub.feature_tables.feature_table import FeatureTable
+from feathub.feature_tables.sinks.sink import Sink
 from feathub.processors.processor_job import ProcessorJob
 from feathub.table.schema import Schema
 
@@ -60,7 +60,7 @@ class Table(ABC):
     @abstractmethod
     def execute_insert(
         self,
-        sink: FeatureTable,
+        sink: Sink,
         ttl: Optional[timedelta] = None,
         allow_overwrite: bool = False,
     ) -> ProcessorJob:


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds `keep_timestamp_field` in Sinks' constructors. The default value of this parameter is True, and the corresponding behavior matches the existing implementation. When the parameter is set to False, timestamp field would be removed before persisting to external systems using the Sinks.

## Brief change log

- Add `keep_timestamp_field` in Sinks' constructor
- Modify the signature of methods related to materialization, changing the data type of the sink parameter to Sink class.
- Fix the problem that processing time attribute is left unremoved after Redis lookup join.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? python docs