### PR TITLE
Fix join expr for single field names

### DIFF
--- a/python/feathub/common/utils.py
+++ b/python/feathub/common/utils.py
@@ -134,6 +134,9 @@ def from_json(json_dict: Dict) -> Any:
     delimiter_index = str(json_dict["class"]).rindex(".")
     module_name = json_dict["class"][:delimiter_index]
 
+    # TODO: Modify configurations to align the format requirement between
+    #  black and flake8 about whitespaces between functions and colons.
+
     # avoid contradict requirements for code format between black and flake8
     class_name_start_index = delimiter_index + 1
     class_name = json_dict["class"][class_name_start_index:]

--- a/python/feathub/dsl/expr_utils.py
+++ b/python/feathub/dsl/expr_utils.py
@@ -54,12 +54,7 @@ def get_var_name(expr: str) -> str:
     Returns the variable name from the feature expression of the
     expression is a single ID.
     """
-    match_result = re.match(VARIABLE_NAME_REGEX, expr)
-    # TODO: Modify configurations to align the format requirement between
-    #  black and flake8 about whitespaces between functions and colons.
-    start_index = match_result.start()
-    end_index = match_result.end()
-    return expr[start_index:end_index]
+    return re.search(VARIABLE_NAME_REGEX, expr)[0]
 
 
 def is_static_map_lookup_op(expr: str) -> bool:

--- a/python/feathub/feature_service/local_feature_service.py
+++ b/python/feathub/feature_service/local_feature_service.py
@@ -16,7 +16,7 @@ import pandas as pd
 from typing import Optional, List, Dict, Union
 
 from feathub.common.exceptions import FeathubException
-from feathub.dsl.expr_utils import is_id
+from feathub.dsl.expr_utils import is_id, get_var_name
 from feathub.feature_service.feature_service import FeatureService
 from feathub.feature_tables.feature_table import FeatureTable
 from feathub.feature_tables.sources.mysql_source import MySQLSource
@@ -137,7 +137,9 @@ class LocalFeatureService(FeatureService):
 
         if isinstance(source, RedisSource) or isinstance(source, MySQLSource):
             client = self._get_online_store_client(source)
-            return client.get(input_data=input_df, feature_names=[join_transform.expr])
+            return client.get(
+                input_data=input_df, feature_names=[get_var_name(join_transform.expr)]
+            )
 
         raise RuntimeError(f"Unsupported source {source.to_json()}.")
 

--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -205,7 +205,7 @@ class DerivedFeatureView(FeatureView):
                 return Feature(
                     name=join_feature_name,
                     dtype=join_feature.dtype,
-                    transform=JoinTransform(join_table_name, join_feature_name),
+                    transform=JoinTransform(join_table_name, f"`{join_feature_name}`"),
                     keys=join_feature.keys,
                 )
             elif is_static_map_lookup_op(parts[1]):

--- a/python/feathub/feature_views/on_demand_feature_view.py
+++ b/python/feathub/feature_views/on_demand_feature_view.py
@@ -132,7 +132,9 @@ class OnDemandFeatureView(FeatureView):
                     feature = Feature(
                         name=join_feature_name,
                         dtype=table_desc.get_feature(join_feature_name).dtype,
-                        transform=JoinTransform(join_table_name, join_feature_name),
+                        transform=JoinTransform(
+                            join_table_name, f"`{join_feature_name}`"
+                        ),
                         keys=table_desc.keys,
                     )
 

--- a/python/feathub/processors/flink/table_builder/join_utils.py
+++ b/python/feathub/processors/flink/table_builder/join_utils.py
@@ -119,7 +119,7 @@ class JoinFieldDescriptor:
 
     @staticmethod
     def from_field_name(field_name: str) -> "JoinFieldDescriptor":
-        return JoinFieldDescriptor(field_name)
+        return JoinFieldDescriptor(f"`{field_name}`")
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/python/feathub/processors/local/local_processor.py
+++ b/python/feathub/processors/local/local_processor.py
@@ -30,7 +30,7 @@ from feathub.common.config import TIMEZONE_CONFIG
 from feathub.common.exceptions import FeathubException, FeathubTransformationException
 from feathub.common.types import to_numpy_dtype
 from feathub.dsl.expr_parser import ExprParser
-from feathub.dsl.expr_utils import is_id
+from feathub.dsl.expr_utils import is_id, get_var_name
 from feathub.feature_tables.feature_table import FeatureTable
 from feathub.feature_tables.sinks.black_hole_sink import BlackHoleSink
 from feathub.feature_tables.sinks.file_system_sink import FileSystemSink
@@ -484,7 +484,7 @@ class LocalProcessor(Processor):
         join_timestamp_field = join_descriptor.timestamp_field
         join_timestamp_format = join_descriptor.timestamp_format
         join_df = table_by_names[join_transform.table_name].df
-        join_feature = join_descriptor.get_feature(join_transform.expr)
+        join_feature = join_descriptor.get_feature(get_var_name(join_transform.expr))
         if join_feature.keys is None:
             raise FeathubException(
                 f"The Feature {join_feature} to join must have keys."
@@ -516,7 +516,7 @@ class LocalProcessor(Processor):
                         break
                 if not keys_match:
                     continue
-                joined_value = join_row[join_transform.expr]
+                joined_value = join_row[get_var_name(join_transform.expr)]
                 joined_timestamp = join_timestamp
             result.append(joined_value)
 

--- a/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
+++ b/python/feathub/processors/spark/dataframe_builder/spark_dataframe_builder.py
@@ -16,7 +16,7 @@ from typing import Dict, Tuple, List, Sequence, Union, Optional
 
 import pandas as pd
 
-from feathub.dsl.expr_utils import is_id
+from feathub.dsl.expr_utils import is_id, get_var_name
 from feathub.feature_views.transforms.join_transform import JoinTransform
 from pyspark.sql import DataFrame as NativeSparkDataFrame, functions
 from pyspark.sql import SparkSession
@@ -297,7 +297,7 @@ class SparkDataFrameBuilder:
                 join_field_descriptors[
                     join_transform.expr
                 ] = JoinFieldDescriptor.from_table_descriptor_and_field_name(
-                    right_table_descriptor, join_transform.expr
+                    right_table_descriptor, get_var_name(join_transform.expr)
                 )
             else:
                 raise RuntimeError(


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the bug that exception would be thrown when field names that equal to reserved keywords are used as keys in JoinTransforms.

## Brief change log

- Fixes the expression for join field descriptors to support cases when the field names are equal to reserved keywords.
- Fixes the bug that `expr_utils.get_var_name` cannot correct extract field name from expressions like "\`field_name\`".

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable