### PR TITLE
Skip empty map when enable partal update in RedisSink

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkFunction.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-redis/src/main/java/com/alibaba/feathub/flink/connectors/redis/sink/RedisSinkFunction.java
@@ -99,7 +99,9 @@ public class RedisSinkFunction extends RichSinkFunction<RowData> {
                                 data.getMap(valueFieldIndex), (KeyValueDataType) dataType);
 
                 if (newMap == null || newMap.isEmpty()) {
-                    client.del(key);
+                    if (!enableHashPartialUpdate) {
+                        client.del(key);
+                    }
                     continue;
                 }
 

--- a/python/feathub/feature_tables/tests/test_redis_source_sink.py
+++ b/python/feathub/feature_tables/tests/test_redis_source_sink.py
@@ -320,7 +320,11 @@ def _test_redis_sink_update_entry_enable_hash_partial_update(
     redis_client: Union[Redis, RedisCluster],
 ):
     input_data = pd.DataFrame(
-        [[1, {"key1": False, "key2": True}], [1, {"key2": False, "key3": True}]],
+        [
+            [1, {"key1": False, "key2": True}],
+            [1, {"key2": False, "key3": True}],
+            [1, {}],
+        ],
         columns=["id", "val"],
     )
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request skips deleting Redis hash entry when `enable_hash_partial_update` is True and the input is None or an empty map.

## Brief change log

- Avoids deleting Redis hash entry when `enable_hash_partial_update` is True and the input is None or an empty map.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable