### PR TITLE
Forward nullable information of Flink field types

### DIFF
--- a/python/feathub/feature_tables/sources/kafka_source.py
+++ b/python/feathub/feature_tables/sources/kafka_source.py
@@ -176,8 +176,8 @@ class KafkaSource(FeatureTable):
             topic=json_dict["topic"],
             key_format=json_dict["key_format"],
             value_format=json_dict["value_format"],
-            schema=from_json(json_dict["name"])
-            if json_dict["name"] is not None
+            schema=from_json(json_dict["schema"])
+            if json_dict["schema"] is not None
             else None,
             consumer_group=json_dict["consumer_group"],
             keys=json_dict["keys"],


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes the logic to cast feature types in FlinkProcessor, forwarding the nullable information of data types during casting instead of casting all fields as nullable. This change fields to avoid the gap of type cast logic between Flink's Table API and SQL API(FLINK-32464, FLINK-31830).

## Brief change log

- Change cast logic as described above.
- Change all flink join operations to SQL API to avoid implicit type cast.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable