### PR TITLE
Support computing sliding window features with different filter expr and limits in one operator

### DIFF
--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/SlidingWindowDescriptor.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/SlidingWindowDescriptor.java
@@ -24,21 +24,16 @@ import java.util.Objects;
 /** Descriptor of a sliding window. */
 public class SlidingWindowDescriptor implements Serializable {
     public final Duration stepSize;
-    public final Integer limit;
     public final List<String> groupByKeys;
-    public final String filterExpr;
 
-    public SlidingWindowDescriptor(
-            Duration stepSize, Integer limit, List<String> groupByKeys, String filterExpr) {
+    public SlidingWindowDescriptor(Duration stepSize, List<String> groupByKeys) {
         this.stepSize = stepSize;
-        this.limit = limit;
         this.groupByKeys = groupByKeys;
-        this.filterExpr = filterExpr;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stepSize, limit, groupByKeys, filterExpr);
+        return Objects.hash(stepSize, groupByKeys);
     }
 
     @Override
@@ -48,8 +43,6 @@ public class SlidingWindowDescriptor implements Serializable {
         }
         SlidingWindowDescriptor descriptor = (SlidingWindowDescriptor) obj;
         return Objects.equals(this.stepSize, descriptor.stepSize)
-                && Objects.equals(this.limit, descriptor.limit)
-                && Objects.equals(this.groupByKeys, descriptor.groupByKeys)
-                && Objects.equals(this.filterExpr, descriptor.filterExpr);
+                && Objects.equals(this.groupByKeys, descriptor.groupByKeys);
     }
 }

--- a/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFuncWithFilterFlag.java
+++ b/java/feathub-udf/flink-udf/src/main/java/com/alibaba/feathub/flink/udf/aggregation/AggFuncWithFilterFlag.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The FeatHub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.feathub.flink.udf.aggregation;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+/** Aggregation function decorator that only aggregates records with filter flag set to true. */
+public class AggFuncWithFilterFlag<IN_T, OUT_T, ACC_T> implements AggFunc<Row, OUT_T, ACC_T> {
+
+    private final AggFunc<IN_T, OUT_T, ACC_T> innerAggFunc;
+
+    public AggFuncWithFilterFlag(AggFunc<IN_T, OUT_T, ACC_T> innerAggFunc) {
+        this.innerAggFunc = innerAggFunc;
+    }
+
+    @Override
+    public void add(ACC_T accumulator, Row value, long timestamp) {
+        Preconditions.checkArgument(
+                value.getArity() == 2, "Row to AggFuncWithFilterFlag can only have 2 columns.");
+        Boolean filterFlag = value.getFieldAs(1);
+        if (filterFlag) {
+            innerAggFunc.add(accumulator, value.getFieldAs(0), timestamp);
+        }
+    }
+
+    @Override
+    public void merge(ACC_T target, ACC_T source) {
+        innerAggFunc.merge(target, source);
+    }
+
+    @Override
+    public void retract(ACC_T accumulator, Row value) {
+        Preconditions.checkArgument(
+                value.getArity() == 2, "Row to AggFuncWithFilterFlag can only have 2 columns.");
+        Boolean filterFlag = value.getFieldAs(1);
+        if (filterFlag) {
+            innerAggFunc.retract(accumulator, value.getFieldAs(0));
+        }
+    }
+
+    @Override
+    public void retractAccumulator(ACC_T target, ACC_T source) {
+        innerAggFunc.retractAccumulator(target, source);
+    }
+
+    @Override
+    public OUT_T getResult(ACC_T accumulator) {
+        return innerAggFunc.getResult(accumulator);
+    }
+
+    @Override
+    public DataType getResultDatatype() {
+        return innerAggFunc.getResultDatatype();
+    }
+
+    @Override
+    public ACC_T createAccumulator() {
+        return innerAggFunc.createAccumulator();
+    }
+
+    @Override
+    public TypeInformation<ACC_T> getAccumulatorTypeInformation() {
+        return innerAggFunc.getAccumulatorTypeInformation();
+    }
+}

--- a/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunctionTest.java
+++ b/java/feathub-udf/flink-udf/src/test/java/com/alibaba/feathub/flink/udf/processfunction/SlidingWindowKeyedProcessFunctionTest.java
@@ -75,8 +75,7 @@ public class SlidingWindowKeyedProcessFunctionTest {
             AggregationFieldsDescriptor aggDescriptors, Row zeroValuedRow, List<Row> expected) {
 
         SlidingWindowDescriptor windowDescriptor =
-                new SlidingWindowDescriptor(
-                        Duration.ofSeconds(1), null, Collections.singletonList("id"), null);
+                new SlidingWindowDescriptor(Duration.ofSeconds(1), Collections.singletonList("id"));
 
         Table table = inputTable;
         for (AggregationFieldsDescriptor.AggregationFieldDescriptor descriptor :
@@ -121,15 +120,45 @@ public class SlidingWindowKeyedProcessFunctionTest {
     void testMultiSlidingWindowSizeProcessFunction() {
         AggregationFieldsDescriptor aggDescriptors =
                 AggregationFieldsDescriptor.builder()
-                        .addField("val_sum_1", DataTypes.BIGINT(), DataTypes.BIGINT(), 1000L, "SUM")
-                        .addField("val_sum_2", DataTypes.BIGINT(), DataTypes.BIGINT(), 2000L, "SUM")
-                        .addField("val_avg_1", DataTypes.BIGINT(), DataTypes.FLOAT(), 1000L, "AVG")
-                        .addField("val_avg_2", DataTypes.BIGINT(), DataTypes.DOUBLE(), 2000L, "AVG")
+                        .addField(
+                                "val_sum_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                1000L,
+                                null,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_sum_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_avg_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.FLOAT(),
+                                1000L,
+                                null,
+                                null,
+                                "AVG")
+                        .addField(
+                                "val_avg_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.DOUBLE(),
+                                2000L,
+                                null,
+                                null,
+                                "AVG")
                         .addField(
                                 "val_value_counts_2",
                                 DataTypes.BIGINT(),
                                 DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
                                 2000L,
+                                null,
+                                null,
                                 "VALUE_COUNTS")
                         .build();
 
@@ -259,13 +288,29 @@ public class SlidingWindowKeyedProcessFunctionTest {
 
         AggregationFieldsDescriptor aggDescriptors =
                 AggregationFieldsDescriptor.builder()
-                        .addField("val_sum_2", DataTypes.BIGINT(), DataTypes.BIGINT(), 2000L, "SUM")
-                        .addField("val_avg_2", DataTypes.BIGINT(), DataTypes.DOUBLE(), 2000L, "AVG")
+                        .addField(
+                                "val_sum_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_avg_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.DOUBLE(),
+                                2000L,
+                                null,
+                                null,
+                                "AVG")
                         .addField(
                                 "val_value_counts_2",
                                 DataTypes.BIGINT(),
                                 DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
                                 2000L,
+                                null,
+                                null,
                                 "VALUE_COUNTS")
                         .build();
 
@@ -380,13 +425,29 @@ public class SlidingWindowKeyedProcessFunctionTest {
 
         AggregationFieldsDescriptor aggDescriptors =
                 AggregationFieldsDescriptor.builder()
-                        .addField("val_sum_2", DataTypes.BIGINT(), DataTypes.BIGINT(), 2000L, "SUM")
-                        .addField("val_avg_2", DataTypes.BIGINT(), DataTypes.DOUBLE(), 2000L, "AVG")
+                        .addField(
+                                "val_sum_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_avg_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.DOUBLE(),
+                                2000L,
+                                null,
+                                null,
+                                "AVG")
                         .addField(
                                 "val_value_counts_2",
                                 DataTypes.BIGINT(),
                                 DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BIGINT()),
                                 2000L,
+                                null,
+                                null,
                                 "VALUE_COUNTS")
                         .build();
 
@@ -496,10 +557,38 @@ public class SlidingWindowKeyedProcessFunctionTest {
     void testMinMax() {
         AggregationFieldsDescriptor aggDescriptors =
                 AggregationFieldsDescriptor.builder()
-                        .addField("val_max_1", DataTypes.BIGINT(), DataTypes.BIGINT(), 1000L, "MAX")
-                        .addField("val_max_2", DataTypes.BIGINT(), DataTypes.BIGINT(), 2000L, "MAX")
-                        .addField("val_min_1", DataTypes.BIGINT(), DataTypes.BIGINT(), 1000L, "MIN")
-                        .addField("val_min_2", DataTypes.BIGINT(), DataTypes.BIGINT(), 2000L, "MIN")
+                        .addField(
+                                "val_max_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                1000L,
+                                null,
+                                null,
+                                "MAX")
+                        .addField(
+                                "val_max_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "MAX")
+                        .addField(
+                                "val_min_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                1000L,
+                                null,
+                                null,
+                                "MIN")
+                        .addField(
+                                "val_min_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "MIN")
                         .build();
 
         List<Row> expected =
@@ -526,12 +615,16 @@ public class SlidingWindowKeyedProcessFunctionTest {
                                 DataTypes.BIGINT(),
                                 DataTypes.BIGINT(),
                                 1000L,
+                                null,
+                                null,
                                 "FIRST_VALUE")
                         .addField(
                                 "val_first_value_2",
                                 DataTypes.BIGINT(),
                                 DataTypes.BIGINT(),
                                 2000L,
+                                null,
+                                null,
                                 "FIRST_VALUE")
                         .build();
 
@@ -559,12 +652,16 @@ public class SlidingWindowKeyedProcessFunctionTest {
                                 DataTypes.BIGINT(),
                                 DataTypes.BIGINT(),
                                 1000L,
+                                null,
+                                null,
                                 "LAST_VALUE")
                         .addField(
                                 "val_last_value_2",
                                 DataTypes.BIGINT(),
                                 DataTypes.BIGINT(),
                                 2000L,
+                                null,
+                                null,
                                 "LAST_VALUE")
                         .build();
 
@@ -579,6 +676,123 @@ public class SlidingWindowKeyedProcessFunctionTest {
                         Row.of(0, 4L, 4L, Instant.ofEpochMilli(5999)),
                         Row.of(0, 5L, 5L, Instant.ofEpochMilli(6999)),
                         Row.of(0, null, 5L, Instant.ofEpochMilli(7999)));
+
+        verifyResult(aggDescriptors, null, expected);
+    }
+
+    @Test
+    void testMultipleLimitSize() {
+        final Row zeroValuedRow = Row.withNames();
+        zeroValuedRow.setField("val_sum_1", 0);
+        zeroValuedRow.setField("val_sum_2", 0);
+        zeroValuedRow.setField("val_sum_3", 0);
+        zeroValuedRow.setField("val_sum_4", 0);
+        AggregationFieldsDescriptor aggDescriptors =
+                AggregationFieldsDescriptor.builder()
+                        .addField(
+                                "val_sum_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                3000L,
+                                1L,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_sum_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                3000L,
+                                2L,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_sum_3",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                1L,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_sum_4",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "SUM")
+                        .build();
+
+        List<Row> expected =
+                java.util.Arrays.asList(
+                        Row.of(1, 2L, 2L, 2L, 2L, Instant.ofEpochMilli(999)),
+                        Row.of(1, 3L, 5L, 3L, 5L, Instant.ofEpochMilli(1999)),
+                        Row.of(1, 3L, 5L, 3L, 3L, Instant.ofEpochMilli(2999)),
+                        Row.of(1, 3L, 3L, 0L, 0L, Instant.ofEpochMilli(3999)),
+                        Row.of(1, 0L, 0L, 0L, 0L, Instant.ofEpochMilli(4999)),
+                        Row.of(0, 1L, 1L, 1L, 1L, Instant.ofEpochMilli(999)),
+                        Row.of(0, 1L, 1L, 1L, 1L, Instant.ofEpochMilli(1999)),
+                        Row.of(0, 1L, 1L, 0L, 0L, Instant.ofEpochMilli(2999)),
+                        Row.of(0, 0L, 0L, 0L, 0L, Instant.ofEpochMilli(3999)),
+                        Row.of(0, 3L, 3L, 3L, 3L, Instant.ofEpochMilli(4999)),
+                        Row.of(0, 4L, 7L, 4L, 7L, Instant.ofEpochMilli(5999)),
+                        Row.of(0, 5L, 9L, 5L, 9L, Instant.ofEpochMilli(6999)),
+                        Row.of(0, 5L, 9L, 5L, 5L, Instant.ofEpochMilli(7999)),
+                        Row.of(0, 5L, 5L, 0L, 0L, Instant.ofEpochMilli(8999)),
+                        Row.of(0, 0L, 0L, 0L, 0L, Instant.ofEpochMilli(9999)));
+
+        verifyResult(aggDescriptors, zeroValuedRow, expected);
+    }
+
+    @Test
+    void testWithFilterExpr() {
+        AggregationFieldsDescriptor aggDescriptors =
+                AggregationFieldsDescriptor.builder()
+                        .addField(
+                                "val_sum_1",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                null,
+                                "SUM")
+                        .addField(
+                                "val_sum_2",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                "`val` = 2",
+                                "SUM")
+                        .addField(
+                                "val_sum_3",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                null,
+                                "`val` = 2 OR `val` = 3",
+                                "SUM")
+                        .addField(
+                                "val_sum_4",
+                                DataTypes.BIGINT(),
+                                DataTypes.BIGINT(),
+                                2000L,
+                                1L,
+                                "`val` = 2 OR `val` = 3",
+                                "SUM")
+                        .build();
+
+        List<Row> expected =
+                java.util.Arrays.asList(
+                        Row.of(1, 2L, 2L, 2L, 2L, Instant.ofEpochMilli(999)),
+                        Row.of(1, 5L, 2L, 5L, 3L, Instant.ofEpochMilli(1999)),
+                        Row.of(1, 3L, 0L, 3L, 3L, Instant.ofEpochMilli(2999)),
+                        Row.of(0, 1L, 0L, 0L, 0L, Instant.ofEpochMilli(999)),
+                        Row.of(0, 1L, 0L, 0L, 0L, Instant.ofEpochMilli(1999)),
+                        Row.of(0, 3L, 0L, 3L, 3L, Instant.ofEpochMilli(4999)),
+                        Row.of(0, 7L, 0L, 3L, 3L, Instant.ofEpochMilli(5999)),
+                        Row.of(0, 9L, 0L, 0L, 0L, Instant.ofEpochMilli(6999)),
+                        Row.of(0, 5L, 0L, 0L, 0L, Instant.ofEpochMilli(7999)));
 
         verifyResult(aggDescriptors, null, expected);
     }

--- a/python/feathub/feature_views/tests/test_sliding_feature_view.py
+++ b/python/feathub/feature_views/tests/test_sliding_feature_view.py
@@ -488,6 +488,78 @@ class SlidingFeatureViewTest(unittest.TestCase):
         self.assertTrue(built_feature.config.get(ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG))
         self.assertFalse(built_feature.config.get(SKIP_SAME_WINDOW_OUTPUT_CONFIG))
 
+    def test_sliding_feature_view_step_size(self):
+        feature_1 = Feature(
+            name="feature_1",
+            dtype=types.Float32,
+            transform=SlidingWindowTransform(
+                expr="CAST(fare_amount AS FLOAT)",
+                agg_func="SUM",
+                window_size=timedelta(seconds=30),
+                group_by_keys=["id"],
+                step_size=timedelta(seconds=10),
+            ),
+        )
+
+        feature_2 = Feature(
+            name="feature_2",
+            dtype=types.Float32,
+            transform=SlidingWindowTransform(
+                expr="CAST(fare_amount AS FLOAT) + 1",
+                agg_func="SUM",
+                window_size=timedelta(seconds=30),
+                group_by_keys=["id"],
+                step_size=timedelta(seconds=10),
+            ),
+        )
+
+        feature_view = SlidingFeatureView(
+            name="feature_view_1",
+            source=self.source,
+            features=[
+                feature_1,
+                feature_2,
+            ],
+        )
+
+        self.assertEqual(timedelta(seconds=10), feature_view.step_size)
+
+    def test_sliding_feature_view_group_by_keys(self):
+        feature_1 = Feature(
+            name="feature_1",
+            dtype=types.Float32,
+            transform=SlidingWindowTransform(
+                expr="CAST(fare_amount AS FLOAT)",
+                agg_func="SUM",
+                window_size=timedelta(seconds=30),
+                group_by_keys=["id"],
+                step_size=timedelta(seconds=10),
+            ),
+        )
+
+        feature_2 = Feature(
+            name="feature_2",
+            dtype=types.Float32,
+            transform=SlidingWindowTransform(
+                expr="CAST(fare_amount AS FLOAT) + 1",
+                agg_func="SUM",
+                window_size=timedelta(seconds=30),
+                group_by_keys=["id"],
+                step_size=timedelta(seconds=10),
+            ),
+        )
+
+        feature_view = SlidingFeatureView(
+            name="feature_view_1",
+            source=self.source,
+            features=[
+                feature_1,
+                feature_2,
+            ],
+        )
+
+        self.assertEqual(("id",), feature_view.group_by_keys)
+
 
 class SlidingFeatureViewITTest(ABC, FeathubITTestBase):
     def test_sliding_feature_view_filter_expr(self):

--- a/python/feathub/processors/flink/table_builder/aggregation_utils.py
+++ b/python/feathub/processors/flink/table_builder/aggregation_utils.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from datetime import timedelta
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 
 from pyflink.table.types import DataType, DataTypes
 
@@ -41,12 +41,16 @@ class AggregationFieldDescriptor:
         expr: str,
         agg_func: AggFunc,
         window_size: timedelta,
+        limit: Optional[int],
+        filter_expr: Optional[str],
     ) -> None:
         self.field_name = field_name
         self.field_data_type = field_data_type
         self.expr = expr
         self.agg_func = agg_func
         self.window_size = window_size
+        self.limit = limit
+        self.filter_expr = filter_expr
 
     @staticmethod
     def from_feature(feature: Feature) -> "AggregationFieldDescriptor":
@@ -58,12 +62,19 @@ class AggregationFieldDescriptor:
             raise FeathubException(
                 f"Cannot convert {feature} to AggregationFieldDescriptor."
             )
+        filter_expr = (
+            to_flink_sql_expr(transform.filter_expr)
+            if transform.filter_expr is not None
+            else None
+        )
         return AggregationFieldDescriptor(
             feature.name,
             to_flink_type(feature.dtype),
             to_flink_sql_expr(transform.expr),
             transform.agg_func,
             transform.window_size,
+            transform.limit,
+            filter_expr,
         )
 
 

--- a/python/feathub/processors/flink/table_builder/sliding_window_utils.py
+++ b/python/feathub/processors/flink/table_builder/sliding_window_utils.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from datetime import timedelta
-from typing import List, Optional, Sequence, Any
+from typing import List, Sequence, Any
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table import (
@@ -27,17 +27,12 @@ from feathub.feature_views.sliding_feature_view import (
     SlidingFeatureViewConfig,
     ENABLE_EMPTY_WINDOW_OUTPUT_CONFIG,
     SKIP_SAME_WINDOW_OUTPUT_CONFIG,
-)
-from feathub.feature_views.transforms.sliding_window_transform import (
-    SlidingWindowTransform,
+    SlidingFeatureView,
 )
 from feathub.processors.constants import EVENT_TIME_ATTRIBUTE_NAME
 from feathub.processors.flink.table_builder.aggregation_utils import (
     AggregationFieldDescriptor,
     get_default_value_and_type,
-)
-from feathub.processors.flink.table_builder.flink_sql_expr_utils import (
-    to_flink_sql_expr,
 )
 
 
@@ -49,29 +44,18 @@ class SlidingWindowDescriptor:
     def __init__(
         self,
         step_size: timedelta,
-        limit: Optional[int],
         group_by_keys: Sequence[str],
-        filter_expr: Optional[str],
     ) -> None:
         self.step_size = step_size
-        self.limit = limit
         self.group_by_keys = group_by_keys
-        self.filter_expr = filter_expr
 
     @staticmethod
-    def from_sliding_window_transform(
-        sliding_window_agg: SlidingWindowTransform,
+    def from_sliding_feature_view(
+        sliding_feature_view: SlidingFeatureView,
     ) -> "SlidingWindowDescriptor":
-        filter_expr = (
-            to_flink_sql_expr(sliding_window_agg.filter_expr)
-            if sliding_window_agg.filter_expr is not None
-            else None
-        )
         return SlidingWindowDescriptor(
-            sliding_window_agg.step_size,
-            sliding_window_agg.limit,
-            sliding_window_agg.group_by_keys,
-            filter_expr,
+            sliding_feature_view.step_size,
+            sliding_feature_view.group_by_keys,
         )
 
     def to_java_descriptor(self) -> Any:
@@ -80,29 +64,18 @@ class SlidingWindowDescriptor:
             gateway.jvm.java.time.Duration.ofMillis(
                 int(self.step_size.total_seconds() * 1e3)
             ),
-            self.limit,
             self.group_by_keys,
-            self.filter_expr,
         )
 
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, self.__class__)
             and self.step_size == other.step_size
-            and self.limit == other.limit
             and self.group_by_keys == other.group_by_keys
-            and self.filter_expr == other.filter_expr
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.step_size,
-                self.limit,
-                tuple(self.group_by_keys),
-                self.filter_expr,
-            )
-        )
+        return hash((self.step_size, tuple(self.group_by_keys)))
 
 
 # TODO: Retracting the value when the window becomes empty when the Sink support
@@ -155,6 +128,8 @@ def evaluate_sliding_window_transform(
             ),
             _to_java_data_type(agg_descriptor.field_data_type),
             int(agg_descriptor.window_size.total_seconds() * 1000),
+            agg_descriptor.limit,
+            agg_descriptor.filter_expr,
             agg_descriptor.agg_func.name,
         )
 

--- a/python/feathub/processors/flink/table_builder/tests/test_aggregation_utils.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_aggregation_utils.py
@@ -1,0 +1,86 @@
+#  Copyright 2022 The FeatHub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from datetime import timedelta
+
+from pyflink.table import DataTypes
+
+from feathub.common.exceptions import FeathubException
+from feathub.common.types import Int32
+from feathub.feature_views.feature import Feature
+from feathub.feature_views.transforms.over_window_transform import OverWindowTransform
+from feathub.feature_views.transforms.sliding_window_transform import (
+    SlidingWindowTransform,
+)
+from feathub.processors.flink.table_builder.aggregation_utils import (
+    AggregationFieldDescriptor,
+)
+
+
+class AggregationUtilsTest(unittest.TestCase):
+    def test_aggregation_descriptor(self):
+
+        sliding_feature = Feature(
+            name="feature_1",
+            transform=SlidingWindowTransform(
+                expr="a",
+                agg_func="COUNT",
+                window_size=timedelta(seconds=10),
+                step_size=timedelta(seconds=1),
+                group_by_keys=["id"],
+                filter_expr="a > 100",
+                limit=10,
+            ),
+            dtype=Int32,
+        )
+
+        descriptor = AggregationFieldDescriptor.from_feature(sliding_feature)
+
+        self.assertEqual("feature_1", descriptor.field_name)
+        self.assertEqual("`a`", descriptor.expr)
+        self.assertEqual(DataTypes.INT(), descriptor.field_data_type)
+        self.assertEqual(timedelta(seconds=10), descriptor.window_size)
+        self.assertEqual("`a` > 100", descriptor.filter_expr)
+        self.assertEqual(10, descriptor.limit)
+
+        over_feature = Feature(
+            name="feature_1",
+            transform=OverWindowTransform(
+                expr="a",
+                agg_func="COUNT",
+                window_size=timedelta(seconds=10),
+                group_by_keys=["id"],
+                filter_expr="a > 100",
+                limit=10,
+            ),
+            dtype=Int32,
+        )
+
+        descriptor = AggregationFieldDescriptor.from_feature(over_feature)
+
+        self.assertEqual("feature_1", descriptor.field_name)
+        self.assertEqual("`a`", descriptor.expr)
+        self.assertEqual(DataTypes.INT(), descriptor.field_data_type)
+        self.assertEqual(timedelta(seconds=10), descriptor.window_size)
+        self.assertEqual("`a` > 100", descriptor.filter_expr)
+        self.assertEqual(10, descriptor.limit)
+
+        expression_feature = Feature(
+            name="feature_1",
+            transform="a + 1",
+            dtype=Int32,
+        )
+
+        with self.assertRaises(FeathubException):
+            AggregationFieldDescriptor.from_feature(expression_feature)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to FeatHub - we are happy that you want to help us improve FeatHub. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
## Contribution Checklist
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review. 
  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support computing sliding window features with different filter expr and limits in one operator to avoid full outer join after sliding window.

Fix #97 #170 

## Brief change log
- Support computing sliding window features with different filter expr and limits in one operator

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable