### PR TITLE
Support reporting metrics in non-final feature view

### DIFF
--- a/docs/content/metric-stores/overview.md
+++ b/docs/content/metric-stores/overview.md
@@ -44,6 +44,37 @@ f_total_cost = Feature(
 )
 ```
 
+Then when the FeatureView that hosts the above feature is being materialized,
+the related metrics will also be reported during the materialization process.
+
+By default, Feathub would only report the metrics directly defined in the
+FeatureView to be materialized. If the `keep_source_metrics` parameter is
+enabled when creating the feature view as follows, FeatHub will recursively
+enumerate the source feature view of this and every upstream feature view whose
+`keep_source_fields == true`, and report metrics defined in those feature views.
+
+```python
+feature_view_0 = ...
+
+feature_view_1 = SlidingFeatureView(
+    name="feature_view_1",
+    source=feature_view_0,
+    features=[f_total_cost], # A feature containg metrics.
+)
+
+feature_view_2 = DerivedFeatureView(
+    name="feature_view_2",
+    source=feature_view_1,
+    features=["name"],
+    keep_source_metrics=True, # enable keep_source_metrics here.
+)
+
+# This will report all metrics defined in feature_view_1 and feature_view_2. But
+# as feature_view_1 does not set keep_source_metrics to True, metrics defined in
+# feature_view_0 will not be reported.
+self.client.materialize_features(features, sink=...).wait()
+```
+
 ## Metric reporting format
 
 Metrics reported by metric stores will have the following format by default.

--- a/python/feathub/feature_tables/sinks/sink.py
+++ b/python/feathub/feature_tables/sinks/sink.py
@@ -24,6 +24,7 @@ class Sink(FeatureTable, ABC):
     Base class for all Sink Feature Table.
     """
 
+    # TODO: make sure sink subclasses expose the ability to configure table name.
     def __init__(
         self,
         name: str,

--- a/python/feathub/feature_views/derived_feature_view.py
+++ b/python/feathub/feature_views/derived_feature_view.py
@@ -51,6 +51,7 @@ class DerivedFeatureView(FeatureView):
         features: Sequence[Union[str, Feature]],
         keep_source_fields: bool = False,
         filter_expr: Optional[str] = None,
+        keep_source_metrics: bool = False,
     ):
         """
         :param name: The unique identifier of this feature view in the registry.
@@ -80,6 +81,11 @@ class DerivedFeatureView(FeatureView):
                             expression is evaluated after other transformations in the
                             feature view, and only those rows which evaluate to True
                             will be outputted by the feature view.
+        :param keep_source_metrics: If it is true and this feature view is materialized
+                                    to a sink, FeatHub will recursively enumerate source
+                                    feature view of this and every upstream feature
+                                    view whose keep_source_fields == true, and report
+                                    metrics defined in those feature views.
         """
         if any(
             isinstance(feature, Feature)
@@ -101,6 +107,7 @@ class DerivedFeatureView(FeatureView):
             source=source,
             features=features,
             keep_source_fields=keep_source_fields,
+            keep_source_metrics=keep_source_metrics,
         )
         self.filter_expr = filter_expr
 
@@ -158,6 +165,7 @@ class DerivedFeatureView(FeatureView):
             features=features,
             keep_source_fields=self.keep_source_fields,
             filter_expr=self.filter_expr,
+            keep_source_metrics=self.keep_source_metrics,
         )
 
     @staticmethod
@@ -269,6 +277,7 @@ class DerivedFeatureView(FeatureView):
             ],
             "keep_source_fields": self.keep_source_fields,
             "filter_expr": self.filter_expr,
+            "keep_source_metrics": self.keep_source_metrics,
         }
 
     @classmethod
@@ -284,4 +293,5 @@ class DerivedFeatureView(FeatureView):
             ],
             keep_source_fields=json_dict["keep_source_fields"],
             filter_expr=json_dict["filter_expr"],
+            keep_source_metrics=json_dict["keep_source_metrics"],
         )

--- a/python/feathub/feature_views/feature.py
+++ b/python/feathub/feature_views/feature.py
@@ -73,7 +73,8 @@ class Feature:
         :param description: The description of the feature.
         :param extra_props: The extra properties of the feature that are defined by
                             user.
-        :param metrics: The metrics of this feature.
+        :param metrics: The metrics of this feature. These metrics would be reported iff
+                        the host FeatureView is materialized to a sink.
         """
         if name.startswith("__") or name.endswith("__"):
             raise FeathubException(

--- a/python/feathub/feature_views/feature_view.py
+++ b/python/feathub/feature_views/feature_view.py
@@ -45,6 +45,7 @@ class FeatureView(TableDescriptor, ABC):
         keep_source_fields: bool = False,
         timestamp_field: Optional[str] = None,
         timestamp_format: str = "epoch",
+        keep_source_metrics: bool = False,
     ):
         """
         :param name: The unique identifier of this feature view in the registry.
@@ -68,11 +69,17 @@ class FeatureView(TableDescriptor, ABC):
                                  `timestamp_format` of the source TableDescriptor is
                                  used as the `timestamp_format` of the TableDescriptor
                                  represented by this FeatureView.
+        :param keep_source_metrics: If it is true and this feature view is materialized
+                                    to a sink, FeatHub will recursively enumerate source
+                                    feature view of this and every upstream feature
+                                    view whose keep_source_fields == true, and report
+                                    metrics defined in those feature views.
         """
 
         self.source = source
         self.features = features
         self.keep_source_fields = keep_source_fields
+        self.keep_source_metrics = keep_source_metrics
 
         is_unresolved = self.is_unresolved()
         keys = None if is_unresolved else self._get_keys()

--- a/python/feathub/feature_views/sliding_feature_view.py
+++ b/python/feathub/feature_views/sliding_feature_view.py
@@ -124,6 +124,7 @@ class SlidingFeatureView(FeatureView):
         timestamp_format: str = "epoch_millis",
         filter_expr: Optional[str] = None,
         extra_props: Optional[Dict] = None,
+        keep_source_metrics: bool = False,
     ):
         """
         :param name: The unique identifier of this feature view in the registry.
@@ -158,6 +159,11 @@ class SlidingFeatureView(FeatureView):
                             will be outputted by the feature view.
         :param extra_props: Optional. It is not None, it is the extra properties of the
                             SlidingFeatureView.
+        :param keep_source_metrics: If it is true and this feature view is materialized
+                                    to a sink, FeatHub will recursively enumerate source
+                                    feature view of this and every upstream feature
+                                    view whose keep_source_fields == true, and report
+                                    metrics defined in those feature views.
         """
         window_time_feature = self._get_window_time_feature(
             timestamp_field, timestamp_format
@@ -169,6 +175,7 @@ class SlidingFeatureView(FeatureView):
             keep_source_fields=False,
             timestamp_field=timestamp_field,
             timestamp_format=timestamp_format,
+            keep_source_metrics=keep_source_metrics,
         )
 
         self.filter_expr = filter_expr
@@ -271,6 +278,7 @@ class SlidingFeatureView(FeatureView):
             timestamp_format=self.timestamp_format,
             filter_expr=self.filter_expr,
             extra_props={**props, **self.config.original_props},
+            keep_source_metrics=self.keep_source_metrics,
         )
         return feature_view
 
@@ -345,6 +353,7 @@ class SlidingFeatureView(FeatureView):
             "timestamp_format": self.timestamp_format,
             "filter_expr": self.filter_expr,
             "extra_props": self.config.original_props,
+            "keep_source_metrics": self.keep_source_metrics,
         }
 
     @classmethod
@@ -362,6 +371,7 @@ class SlidingFeatureView(FeatureView):
             timestamp_format=json_dict["timestamp_format"],
             filter_expr=json_dict["filter_expr"],
             extra_props=json_dict["extra_props"],
+            keep_source_metrics=json_dict["keep_source_metrics"],
         )
 
     def _validate(self, source: TableDescriptor, features: Sequence[Feature]) -> None:


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for reporting metrics defined in non-final feature view.

## Brief change log

  - Adds support for reporting metrics defined in non-final feature view.
  - Adds debug log when constructing metric reporting workflow during compilation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & python docs