### PR TITLE
Add retry and warning for network exceptions in Prometheus Sink

### DIFF
--- a/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusConfigs.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusConfigs.java
@@ -58,4 +58,12 @@ public class PrometheusConfigs {
                                     + "and value are separated by '=', and labels are separated by ',', e.g., "
                                     + "k1=v1,k2=v2. Please ensure that your grouping key meets the Prometheus requirements. "
                                     + "Use backslash '\\' to escape '=' and ',' if they are used in label value.");
+
+    public static final ConfigOption<Long> RETRY_TIMEOUT_MS =
+            ConfigOptions.key("retryTimeoutMs")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription(
+                            "The max timeout in milliseconds this sink may take retrying in case of occasional exceptions."
+                                    + "If timeout is reached before the retry succeeds, the sink would drop the record being processed.");
 }

--- a/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusDynamicTableFactory.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusDynamicTableFactory.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import static com.alibaba.feathub.flink.connectors.prometheus.PrometheusConfigs.DELETE_ON_SHUTDOWN;
 import static com.alibaba.feathub.flink.connectors.prometheus.PrometheusConfigs.EXTRA_LABELS;
 import static com.alibaba.feathub.flink.connectors.prometheus.PrometheusConfigs.JOB_NAME;
+import static com.alibaba.feathub.flink.connectors.prometheus.PrometheusConfigs.RETRY_TIMEOUT_MS;
 import static com.alibaba.feathub.flink.connectors.prometheus.PrometheusConfigs.SERVER_URL;
 
 /** The table factory for {@link PrometheusDynamicTableSink}. */
@@ -58,6 +59,7 @@ public class PrometheusDynamicTableFactory implements DynamicTableSinkFactory {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(EXTRA_LABELS);
         options.add(DELETE_ON_SHUTDOWN);
+        options.add(RETRY_TIMEOUT_MS);
         return options;
     }
 }

--- a/python/feathub/feature_tables/sinks/prometheus_sink.py
+++ b/python/feathub/feature_tables/sinks/prometheus_sink.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from datetime import timedelta
 from typing import Dict
 
 from feathub.common.utils import append_metadata_to_json
@@ -24,6 +25,7 @@ class PrometheusSink(Sink):
         job_name: str,
         delete_on_shutdown: bool,
         extra_labels: Dict[str, str],
+        retry_timeout: timedelta,
     ):
         """
         :param server_url: The PushGateway server server URL including scheme,
@@ -35,6 +37,8 @@ class PrometheusSink(Sink):
                                    Feathub will try its best to delete the
                                    metrics but this is not guaranteed.
         :param extra_labels: The extra labels of all metrics pushed by this sink.
+        :param retry_timeout: The max timeout this sink may take retrying in case
+                              of occasional exceptions.
         """
         super().__init__(
             name="",
@@ -47,6 +51,7 @@ class PrometheusSink(Sink):
         self.job_name = job_name
         self.delete_on_shutdown = delete_on_shutdown
         self.extra_labels = extra_labels
+        self.retry_timeout = retry_timeout
 
     @append_metadata_to_json
     def to_json(self) -> Dict:
@@ -55,6 +60,7 @@ class PrometheusSink(Sink):
             "job_name": self.job_name,
             "delete_on_shutdown": self.delete_on_shutdown,
             "extra_labels": self.extra_labels,
+            "retry_timeout": self.retry_timeout / timedelta(milliseconds=1),
         }
 
     @classmethod
@@ -64,4 +70,5 @@ class PrometheusSink(Sink):
             job_name=json_dict["job_name"],
             delete_on_shutdown=json_dict["delete_on_shutdown"],
             extra_labels=json_dict["extra_labels"],
+            retry_timeout=timedelta(milliseconds=json_dict["retry_timeout"]),
         )

--- a/python/feathub/metric_stores/prometheus_metric_store.py
+++ b/python/feathub/metric_stores/prometheus_metric_store.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections
+from datetime import timedelta
 from typing import Any
 from typing import Dict, List, OrderedDict
 
@@ -106,4 +107,5 @@ class PrometheusMetricStore(MetricStore):
             job_name=self.namespace,
             delete_on_shutdown=self.delete_on_shutdown,
             extra_labels={"table_name": data_sink.name},
+            retry_timeout=timedelta(seconds=self.report_interval_sec),
         )

--- a/python/feathub/processors/flink/table_builder/prometheus_utils.py
+++ b/python/feathub/processors/flink/table_builder/prometheus_utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import glob
 import os
+from datetime import timedelta
 
 from pyflink.table import (
     expressions as native_flink_expr,
@@ -61,6 +62,9 @@ def add_prometheus_sink_to_statement_set(
         .option(
             "extraLabels",
             ",".join(f"{key}={value}" for key, value in sink.extra_labels.items()),
+        )
+        .option(
+            "retryTimeoutMs", str(int(sink.retry_timeout / timedelta(milliseconds=1)))
         )
     )
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request avoids job failures due to Prometheus network instabilities by adding retries and converting failures into log warnings.

## Brief change log

- Add retry mechanism to Prometheus sink.
- Add logging to metric-related codes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable