### PR TITLE
Support Parquet format in FileSystem and Hive connector

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -39,6 +39,13 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
           cache: 'maven'
+      - name: Setup Hadoop environment
+        env:
+          HADOOP_VERSION: 3.1.3
+        run: |
+          wget https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
+          tar -xzf hadoop-$HADOOP_VERSION.tar.gz
+          echo "FEATHUB_TEST_HADOOP_CLASSPATH=`./hadoop-$HADOOP_VERSION/bin/hadoop classpath`" >> $GITHUB_ENV
       - name: Build and test Feathub Java library
         run: |
           cd java

--- a/README.md
+++ b/README.md
@@ -316,10 +316,26 @@ $ python -m pip install "./python[spark]"
 
 ### Run Tests
 
+Please execute the following commands under Feathub's root folder to run tests.
+
 ```bash
 $ mvn clean package -f ./java
 $ pytest --tb=line -W ignore::DeprecationWarning ./python
 ```
+
+While the commands above cover most of Feathub's tests, some FlinkProcessor's
+python tests, such as tests related to Parquet format, have been ignored by
+default as they require a Hadoop environment to function correctly. In order to
+run these tests, please install Hadoop on your local machine and set up
+environment variables as follows before executing the commands above.
+
+```bash
+export FEATHUB_TEST_HADOOP_CLASSPATH=`hadoop classpath`
+```
+
+You may refer to [Flink's document for Hive
+connector](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/table/hive/overview/#supported-hive-versions)
+for supported Hadoop & Hive versions.
 
 ### Format Code Style
 

--- a/docs/content/connectors/filesystem.md
+++ b/docs/content/connectors/filesystem.md
@@ -24,8 +24,8 @@ been tested and supported by each processor.
 ## Supported format
 
 - Local: CSV, JSON
-- Flink: CSV, JSON, Protobuf
-- Spark: CSV, JSON
+- Flink: CSV, JSON, Protobuf, Parquet
+- Spark: CSV, JSON, Parquet
 
 ## Examples
 

--- a/docs/content/connectors/formats/README.md
+++ b/docs/content/connectors/formats/README.md
@@ -3,3 +3,4 @@
 - [CSV](csv.md)
 - [JSON](json.md)
 - [Protobuf](protobuf.md)
+- [Parquet](parquet.md)

--- a/docs/content/connectors/formats/parquet.md
+++ b/docs/content/connectors/formats/parquet.md
@@ -1,0 +1,34 @@
+# Protobuf Format
+
+The [Parquet](https://parquet.apache.org/) format allows you to read and write
+Parquet data.
+
+## How to create a table with Parquet format
+
+Here is an example to create a table using the FileSystem connector and Parquet
+format.
+
+If you are using Parquet format in Flink Processor, make sure you have
+configured the environment variable HADOOP_CLASSPATH on both your Flink cluster
+and Feathub client. Please refer to [Flink's document for Hive
+connector](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/table/hive/overview/#supported-hive-versions)
+for supported Hadoop & Hive versions.
+
+Then you can use the Parquet format in filesystem connector as follows.
+
+```python
+schema = (
+    Schema.new_builder()
+    .column("id", types.Int64)
+    .column("val", types.Int64)
+    .column("ts", types.String)
+    .build()
+)
+
+source = FileSystemSource(
+    name="filesystem_source",
+    path="/tmp",
+    data_format="parquet",
+    schema=schema,
+)
+```

--- a/docs/content/connectors/hive.md
+++ b/docs/content/connectors/hive.md
@@ -9,6 +9,10 @@ materialize feature view to a Hive table.
 
 1. Only supports Hadoop 3.1.x
 
+## Supported format
+
+- Flink: CSV, Parquet
+
 ## Configuring Hive connector for FlinkProcessor
 
 Before using Hive connector in Flink Processor, make sure you have configured

--- a/java/feathub-dist/pom.xml
+++ b/java/feathub-dist/pom.xml
@@ -84,6 +84,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-parquet</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.alibaba.feathub</groupId>
             <artifactId>flink-udf</artifactId>
             <version>${project.version}</version>

--- a/python/feathub/feature_tables/format_config.py
+++ b/python/feathub/feature_tables/format_config.py
@@ -21,6 +21,7 @@ class DataFormat:
     CSV = "csv"
     JSON = "json"
     PROTOBUF = "protobuf"
+    PARQUET = "parquet"
 
 
 IGNORE_PARSE_ERRORS_CONFIG = "ignore_parse_error"

--- a/python/feathub/feature_tables/sinks/hive_sink.py
+++ b/python/feathub/feature_tables/sinks/hive_sink.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from feathub.common.utils import append_metadata_to_json
 from feathub.feature_tables.sinks.sink import Sink
@@ -30,6 +30,8 @@ class HiveSink(Sink):
         database: str,
         table: str,
         hive_catalog_conf_dir: str,
+        data_format: str,
+        data_format_props: Optional[Dict[str, Any]] = None,
         processor_specific_props: Optional[Dict[str, str]] = None,
         keep_timestamp_field: bool = True,
     ):
@@ -42,6 +44,8 @@ class HiveSink(Sink):
                                       supported by Hadoop FileSystem. If the URI is
                                       relative, i.e. without a scheme, local file
                                       system is assumed.
+        :param data_format: The format that should be used to read from hive.
+        :param data_format_props: The properties of the data format.
         :param processor_specific_props: Extra properties to be passthrough to the
                                          processor. The available configurations are
                                          different for different processors.
@@ -59,6 +63,8 @@ class HiveSink(Sink):
                 "database": database,
             },
             keep_timestamp_field=keep_timestamp_field,
+            data_format=data_format,
+            data_format_props=data_format_props,
         )
         self.database = database
         self.table = table
@@ -71,6 +77,8 @@ class HiveSink(Sink):
             "database": self.database,
             "table": self.table,
             "hive_catalog_conf_dir": self.hive_catalog_conf_dir,
+            "data_format": self.data_format,
+            "data_format_props": self.data_format_props,
             "processor_specific_props": self.processor_specific_props,
             "keep_timestamp_field": self.keep_timestamp_field,
         }
@@ -81,6 +89,8 @@ class HiveSink(Sink):
             database=json_dict["database"],
             table=json_dict["table"],
             hive_catalog_conf_dir=json_dict["hive_catalog_conf_dir"],
+            data_format=json_dict["data_format"],
+            data_format_props=json_dict["data_format_props"],
             processor_specific_props=json_dict["processor_specific_props"],
             keep_timestamp_field=json_dict["keep_timestamp_field"],
         )

--- a/python/feathub/feature_tables/sources/hive_source.py
+++ b/python/feathub/feature_tables/sources/hive_source.py
@@ -15,7 +15,7 @@ import hashlib
 import os.path
 import random
 import string
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Any
 
 from feathub.common.utils import (
     is_local_file_or_dir,
@@ -56,6 +56,8 @@ class HiveSource(FeatureTable):
         table: str,
         hive_catalog_conf_dir: str,
         schema: Schema,
+        data_format: str,
+        data_format_props: Optional[Dict[str, Any]] = None,
         keys: Optional[List[str]] = None,
         processor_specific_props: Optional[Dict[str, str]] = None,
     ):
@@ -70,6 +72,8 @@ class HiveSource(FeatureTable):
                                       supported by Hadoop FileSystem. If the URI is
                                       relative, i.e. without a scheme, local file
                                       system is assumed.
+        :param data_format: The format that should be used to write to hive.
+        :param data_format_props: The properties of the data format.
         :param keys: Optional. The names of fields in this feature view that are
                      necessary to interpret a row of this table. If it is not None, it
                      must be a superset of keys of any feature in this table.
@@ -90,6 +94,8 @@ class HiveSource(FeatureTable):
             keys=keys,
             schema=schema,
             timestamp_field=None,
+            data_format=data_format,
+            data_format_props=data_format_props,
         )
         self.name = name
         self.table = table
@@ -110,6 +116,8 @@ class HiveSource(FeatureTable):
             "schema": None if self.schema is None else self.schema.to_json(),
             "keys": self.keys,
             "hive_catalog_conf_dir": self.hive_catalog_conf_dir,
+            "data_format": self.data_format,
+            "data_format_props": self.data_format_props,
             "processor_specific_props": self.processor_specific_props,
         }
 
@@ -124,5 +132,7 @@ class HiveSource(FeatureTable):
             else None,
             keys=json_dict["keys"],
             hive_catalog_conf_dir=json_dict["hive_catalog_conf_dir"],
+            data_format=json_dict["data_format"],
+            data_format_props=json_dict["data_format_props"],
             processor_specific_props=json_dict["processor_specific_props"],
         )

--- a/python/feathub/processors/flink/table_builder/format_utils.py
+++ b/python/feathub/processors/flink/table_builder/format_utils.py
@@ -44,6 +44,9 @@ def load_format(
         protobuf_jar_path = config.get(PROTOBUF_JAR_PATH_CONFIG)
         _load_protobuf_format_jar(t_env, protobuf_jar_path)
         return
+    elif data_format == DataFormat.PARQUET:
+        _load_parquet_format_jar(t_env)
+        return
 
     raise FeathubException(f"Unsupported format {data_format}.")
 
@@ -63,6 +66,8 @@ def get_flink_format_config(
             "protobuf.message-class-name": config.get(PROTOBUF_CLASS_NAME_CONFIG),
             "protobuf.ignore-parse-errors": str(config.get(IGNORE_PARSE_ERRORS_CONFIG)),
         }
+    elif data_format == DataFormat.PARQUET:
+        return {}
 
     raise FeathubException(f"Unsupported format {data_format}.")
 
@@ -72,6 +77,10 @@ def _load_protobuf_format_jar(
 ) -> None:
     avro_jar_path = _get_jar_path("flink-sql-protobuf-*.jar")
     add_jar_to_t_env(t_env, avro_jar_path, protobuf_jar_path)
+
+
+def _load_parquet_format_jar(t_env: StreamTableEnvironment) -> None:
+    add_jar_to_t_env(t_env, _get_jar_path("flink-sql-parquet-*.jar"))
 
 
 def _get_jar_path(jar_files_pattern: str) -> str:

--- a/python/feathub/processors/local/tests/test_local_processor.py
+++ b/python/feathub/processors/local/tests/test_local_processor.py
@@ -147,3 +147,6 @@ class LocalProcessorITTest(
 
     def test_transform_with_zero_window_size(self):
         pass
+
+    def test_parquet_all_types(self):
+        pass

--- a/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/spark_ast_evaluator.py
@@ -71,9 +71,10 @@ class SparkAstEvaluator(AbstractAstEvaluator):
         return ", ".join([self.eval(value, variables) for value in ast.values])
 
     def eval_cast_node(self, ast: CastOp, variables: Optional[Dict]) -> Any:
+        type_name = ast.type_name.upper().replace("BYTES", "BINARY")
         if ast.exception_on_failure:
-            return f"CAST({self.eval(ast.child, variables)} AS {ast.type_name})"
-        return f"TRY_CAST({self.eval(ast.child, variables)} AS {ast.type_name})"
+            return f"CAST({self.eval(ast.child, variables)} AS {type_name})"
+        return f"TRY_CAST({self.eval(ast.child, variables)} AS {type_name})"
 
     def eval_logical_op(self, ast: LogicalOp, variables: Optional[Dict]) -> Any:
         left_val = self.eval(ast.left_child, variables)

--- a/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
+++ b/python/feathub/processors/spark/ast_evaluator/tests/test_spark_ast_evaluator.py
@@ -82,7 +82,7 @@ class SparkAstEvaluatorTest(unittest.TestCase):
         )
 
     def test_cast(self):
-        self.assertEqual("CAST('59' AS BYTES)", self._eval('cast("59" AS bytes)'))
+        self.assertEqual("CAST('59' AS BINARY)", self._eval('cast("59" AS bytes)'))
         self.assertEqual("CAST(0.1 AS STRING)", self._eval("CAST(0.1 AS STRING)"))
         self.assertEqual("CAST('59' AS INTEGER)", self._eval('CAST("59" AS INTEGER)'))
         self.assertEqual("CAST(`a` AS INTEGER)", self._eval("CAST(a AS INTEGER)"))


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for parquet format in FileSystem and Hive connector.

## Brief change log

  - Add format text(Hive's default format) and parquet.
  - Support for parquet format in FlinkProcessor FileSystem source/sink.
  - Support for parquet format in FlinkProcessor Hive source/sink.
  - Support for parquet format in SparkProcessor FileSystem source/sink.
  - Fix the bug that SparkProcessor cannot cast to bytes.

Changes related to hive have been verified using the corresponding [Feathub e2e example](https://github.com/flink-extended/feathub-examples/tree/master/flink-read-write-hive).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & python docs