### PR TITLE
Fix Hive document's example when instantiating Hive source/sink

### DIFF
--- a/docs/content/connectors/hive.md
+++ b/docs/content/connectors/hive.md
@@ -34,6 +34,7 @@ hive_sink = HiveSink(
     database="default",
     table="table",
     hive_catalog_conf_dir=".",
+    data_format="parquet",
     processor_specific_props={
         'sink.partition-commit.policy.kind': 'metastore,success-file',
     }
@@ -60,6 +61,7 @@ source = HiveSource(
     database="default",
     table="table",
     schema=schema,
+    data_format="parquet",
     keys=["key"],
     hive_catalog_conf_dir=".",
     timestamp_field="timestamp",


### PR DESCRIPTION
## What is the purpose of the change

Fixes Feathub's document that data_format must be specified when creating Hive source/sink.

## Brief change log

- Fixes Feathub's document that data_format must be specified when creating Hive source/sink.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable