### PR TITLE
Add metric CountMap and Average

### DIFF
--- a/docs/content/feathub-sdk/functions.md
+++ b/docs/content/feathub-sdk/functions.md
@@ -112,6 +112,11 @@ JSON_STRING(MAP("a", 1, "b", 2))
 The function expects to have at least two arguments and an even number of arguments. 
 All the keys must be of the same type, and all the values must be of the same type.
 
+### SIZE
+
+`SIZE(expr)` -  Returns the size of a vector or a map. The function returns null
+for null input.
+
 ### Type Conversion Functions
 
 | Function                          | Description                                                                               |

--- a/docs/content/metric-stores/metrics.md
+++ b/docs/content/metric-stores/metrics.md
@@ -55,3 +55,58 @@ It exposes the following metric-specific tags:
 See
 [here](https://github.com/alibaba/feathub/blob/master/python/feathub/metric_stores/tests/test_prometheus_metric_store.py#L122)
 for example usages.
+
+## CountMap
+
+CountMap is a map that maps each unique feature value to the number of
+occurrences of this value. It has the following parameters:
+
+- filter_expr: Optional with None as the default value. If it is not None, it
+  represents a partial FeatHub expression which evaluates to a boolean value.
+  The partial Feathub expression should be a binary operator whose left child is
+  absent and would be filled in with the host feature name. For example, "IS
+  NULL" will be enriched into "{feature_name} IS NULL". Only features that
+  evaluate this expression into True will be considered when computing the
+  metric.
+- window_size: Optional with 0 as the default value. The time range to compute
+  the metric. It should be zero or a positive time span. If it is zero, the
+  metric will be computed from all feature values that have been processed since
+  the Feathub job is created.
+
+It exposes the following metric-specific tags:
+
+- metric_type: "count_map"
+- value: The feature value whose occurences are counted.
+- filter_expr: The value of the filter_expr parameter.
+- window_size_sec: The value of the window_size parameter in seconds.
+
+See
+[here](https://github.com/alibaba/feathub/blob/master/python/feathub/metric_stores/tests/test_metric_store.py#L87)
+for example usages.
+
+## Average
+
+Average is a metric that that shows the average of feature values. It has the
+following parameters:
+
+- filter_expr: Optional with None as the default value. If it is not None, it
+  represents a partial FeatHub expression which evaluates to a boolean value.
+  The partial Feathub expression should be a binary operator whose left child is
+  absent and would be filled in with the host feature name. For example, "IS
+  NULL" will be enriched into "{feature_name} IS NULL". Only features that
+  evaluate this expression into True will be considered when computing the
+  metric.
+- window_size: Optional with 0 as the default value. The time range to compute
+  the metric. It should be zero or a positive time span. If it is zero, the
+  metric will be computed from all feature values that have been processed since
+  the Feathub job is created.
+
+It exposes the following metric-specific tags:
+
+- metric_type: "average"
+- filter_expr: The value of the filter_expr parameter.
+- window_size_sec: The value of the window_size parameter in seconds.
+
+See
+[here](https://github.com/alibaba/feathub/blob/master/python/feathub/metric_stores/tests/test_metric_store.py#L76)
+for example usages.

--- a/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusSinkFunction.java
+++ b/java/feathub-connectors/flink-connectors/flink-connector-prometheus/src/main/java/com/alibaba/feathub/flink/connectors/prometheus/PrometheusSinkFunction.java
@@ -193,6 +193,11 @@ public class PrometheusSinkFunction extends RichSinkFunction<RowData> {
                 break;
             case MAP:
                 final MapData mapData = row.getMap(index);
+                if (mapData == null) {
+                    // TODO: Remove this after the default value of VALUE_COUNTS for
+                    //  empty window is changed to empty map.
+                    return;
+                }
                 final ArrayData keyArray = mapData.keyArray();
                 final ArrayData valueArray = mapData.valueArray();
                 Map<String, Double> mapMetric = new HashMap<>();
@@ -406,7 +411,8 @@ public class PrometheusSinkFunction extends RichSinkFunction<RowData> {
             throw new RuntimeException(
                     "PrometheusSink only support numeric data type, map data type from string type to "
                             + "numeric type, and array data type of numeric type or map data type from "
-                            + "string type to numeric type.");
+                            + "string type to numeric type, while the input is "
+                            + logicalType);
         }
 
         private MetricUpdater<?> getMetricWrapper(CollectorRegistry registry) {

--- a/python/feathub/dsl/built_in_func.py
+++ b/python/feathub/dsl/built_in_func.py
@@ -14,7 +14,7 @@
 from typing import List, Callable
 
 from feathub.common.exceptions import FeathubExpressionException
-from feathub.common.types import DType, String, Int64, MapType, VectorType
+from feathub.common.types import DType, String, Int64, MapType, VectorType, Int32
 
 
 class BuiltInFuncDefinition:
@@ -67,6 +67,8 @@ BUILTIN_FUNCS = [
         name="ARRAY",
         result_type_strategy=lambda input_types: VectorType(input_types[0]),
     ),
+    # TODO: Verify the length and type of arguments uniformly.
+    BuiltInFuncDefinition(name="SIZE", result_type_strategy=lambda input_types: Int32),
 ]
 
 BUILTIN_FUNC_DEF_MAP = {f.name: f for f in BUILTIN_FUNCS}

--- a/python/feathub/feature_views/transforms/tests/test_expression_transform.py
+++ b/python/feathub/feature_views/transforms/tests/test_expression_transform.py
@@ -527,6 +527,50 @@ class ExpressionTransformITTest(ABC, FeathubITTestBase):
         result_df = self.client.get_features(feature_view_1).to_pandas()
         self.assertTrue(expected_result_df.equals(result_df))
 
+    def test_size(self):
+        input_data = pd.DataFrame(
+            [
+                [[1, 2, 3], {"a": 1, "b": 2}],
+                [[], {}],
+                [None, None],
+            ],
+            columns=["list_v", "map_v"],
+        )
+
+        source = self.create_file_source(
+            input_data,
+            schema=Schema.new_builder()
+            .column("list_v", VectorType(Int64))
+            .column("map_v", MapType(String, Int64))
+            .build(),
+            timestamp_field=None,
+            data_format="json",
+        )
+
+        feature_view_1 = DerivedFeatureView(
+            name="feature_view_1",
+            source=source,
+            features=[
+                Feature(name="list_v_size", transform="SIZE(list_v)"),
+                Feature(name="map_v_size", transform="SIZE(map_v)"),
+            ],
+            keep_source_fields=False,
+        )
+
+        expected_result_df = pd.DataFrame(
+            [
+                [3, 2],
+                [0, 0],
+                [None, None],
+            ],
+            columns=[
+                "list_v_size",
+                "map_v_size",
+            ],
+        )
+        result_df = self.client.get_features(feature_view_1).to_pandas()
+        self.assertTrue(expected_result_df.equals(result_df))
+
     def test_bracket(self):
         input_data = pd.DataFrame(
             [

--- a/python/feathub/metric_stores/tests/test_metric_store.py
+++ b/python/feathub/metric_stores/tests/test_metric_store.py
@@ -1,0 +1,217 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC
+from datetime import timedelta
+
+import numpy as np
+import pandas as pd
+
+from feathub.common.test_utils import to_epoch_millis
+from feathub.common.types import String, Int64
+from feathub.feature_tables.sinks.black_hole_sink import BlackHoleSink
+from feathub.feature_tables.sinks.sink import Sink
+from feathub.feature_views.derived_feature_view import DerivedFeatureView
+from feathub.feature_views.feature import Feature
+from feathub.feature_views.feature_view import FeatureView
+from feathub.metric_stores.metric import CountMap, Count, Ratio, Average
+from feathub.metric_stores.metric_store import MetricStore
+from feathub.table.schema import Schema
+from feathub.tests.feathub_it_test_base import FeathubITTestBase
+
+
+class DummyMetricStore(MetricStore):
+    def __init__(self) -> None:
+        super(DummyMetricStore, self).__init__({})
+
+    def _get_metrics_sink(self, data_sink: Sink) -> Sink:
+        raise Exception()
+
+
+class MetricStoreITTest(ABC, FeathubITTestBase):
+    def test_metric_transformation(self):
+        metric_store = DummyMetricStore()
+
+        df = pd.DataFrame(
+            [["2022-01-01 08:01:00", "abc", 1], ["2022-01-01 08:02:00", "abc", -1]],
+            columns=["time", "string_v", "int64_v"],
+        )
+        source = self.create_file_source(
+            df,
+            data_format="json",
+            schema=Schema.new_builder()
+            .column("time", String)
+            .column("string_v", String)
+            .column("int64_v", Int64)
+            .build(),
+            timestamp_field="time",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        features: FeatureView = DerivedFeatureView(
+            name="features",
+            source=source,
+            features=[
+                Feature(
+                    name="int64_v",
+                    transform="int64_v",
+                    metrics=[
+                        Count(
+                            filter_expr="> 0",
+                            window_size=timedelta(days=1),
+                        ),
+                        Ratio(
+                            filter_expr="> 0",
+                            window_size=timedelta(days=1),
+                        ),
+                        Average(
+                            filter_expr="> 0",
+                            window_size=timedelta(days=1),
+                        ),
+                    ],
+                ),
+                Feature(
+                    name="string_v",
+                    transform="string_v",
+                    metrics=[
+                        CountMap(
+                            window_size=timedelta(days=1),
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        features = metric_store._get_metrics_view(
+            features_desc=features,
+            data_sink=BlackHoleSink(),
+            window_size=timedelta(days=1),
+        )
+
+        result_df = self.client.get_features(
+            # Remove the PeriodicEmitLastValueOperator to avoid having
+            # metric results filtered according to report interval
+            feature_descriptor=features.get_resolved_source()
+        ).to_pandas()
+
+        expected_result_df = pd.DataFrame(
+            [
+                [
+                    to_epoch_millis("2022-01-01 23:59:59.999"),
+                    1,
+                    0.5,
+                    1.0,
+                    {"abc": 2},
+                ],
+                [
+                    to_epoch_millis("2022-01-02 23:59:59.999"),
+                    0,
+                    0.0,
+                    np.nan,
+                    None,
+                ],
+            ],
+            columns=[
+                "window_time",
+                "default_int64_v_count",
+                "default_int64_v_ratio",
+                "default_int64_v_average",
+                "default_string_v_count_map",
+            ],
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))
+
+    def test_metric_transformation_with_infinite_window(self):
+        metric_store = DummyMetricStore()
+
+        df = pd.DataFrame(
+            [
+                ["2022-01-01 08:01:00", "abc", 1],
+                ["2022-01-01 08:02:00", "def", 2],
+            ],
+            columns=["time", "string_v", "int64_v"],
+        )
+        source = self.create_file_source(
+            df,
+            data_format="json",
+            schema=Schema.new_builder()
+            .column("time", String)
+            .column("string_v", String)
+            .column("int64_v", Int64)
+            .build(),
+            timestamp_field="time",
+            timestamp_format="%Y-%m-%d %H:%M:%S",
+        )
+
+        features: FeatureView = DerivedFeatureView(
+            name="features",
+            source=source,
+            features=[
+                Feature(
+                    name="int64_v",
+                    transform="int64_v",
+                    metrics=[
+                        Count(),
+                        Ratio(filter_expr="> 0"),
+                        Average(),
+                    ],
+                ),
+                Feature(
+                    name="string_v",
+                    transform="string_v",
+                    metrics=[
+                        CountMap(),
+                    ],
+                ),
+            ],
+        )
+
+        features = metric_store._get_metrics_view(
+            features_desc=features,
+            data_sink=BlackHoleSink(),
+            window_size=timedelta(seconds=0),
+        )
+
+        result_df = self.client.get_features(
+            # Remove the PeriodicEmitLastValueOperator to avoid having
+            # metric results filtered according to report interval
+            feature_descriptor=features.get_resolved_source()
+        ).to_pandas()
+
+        expected_result_df = pd.DataFrame(
+            [
+                [
+                    to_epoch_millis("2022-01-01 08:01:00.000"),
+                    1,
+                    1.0,
+                    1.0,
+                    {"abc": 1},
+                ],
+                [
+                    to_epoch_millis("2022-01-01 08:02:00.000"),
+                    2,
+                    1.0,
+                    1.5,
+                    {"abc": 1, "def": 1},
+                ],
+            ],
+            columns=[
+                "window_time",
+                "default_int64_v_count",
+                "default_int64_v_ratio",
+                "default_int64_v_average",
+                "default_string_v_count_map",
+            ],
+        )
+
+        self.assertTrue(expected_result_df.equals(result_df))

--- a/python/feathub/processors/flink/ast_evaluator/functions.py
+++ b/python/feathub/processors/flink/ast_evaluator/functions.py
@@ -41,4 +41,6 @@ def evaluate_function(func_name: str, args: List[Any]) -> str:
         return f"MAP[{', '.join(args)}]"
     elif func_name == "ARRAY":
         return f"ARRAY[{', '.join(args)}]"
+    elif func_name == "SIZE":
+        return f"CARDINALITY({', '.join(args)})"
     raise RuntimeError(f"Unsupported function: {func_name}.")

--- a/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
+++ b/python/feathub/processors/flink/table_builder/tests/test_flink_processor.py
@@ -68,6 +68,7 @@ from feathub.feature_views.transforms.tests.test_python_udf_transform import (
 from feathub.feature_views.transforms.tests.test_sliding_window_transform import (
     SlidingWindowTransformITTest,
 )
+from feathub.metric_stores.tests.test_metric_store import MetricStoreITTest
 from feathub.metric_stores.tests.test_prometheus_metric_store import (
     PrometheusMetricStoreITTest,
 )
@@ -314,6 +315,7 @@ class FlinkProcessorITTest(
     FileSystemSourceSinkITTest,
     JoinTransformITTest,
     KafkaSourceSinkITTest,
+    MetricStoreITTest,
     OverWindowTransformITTest,
     PrintSinkITTest,
     PrometheusMetricStoreITTest,

--- a/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
+++ b/python/feathub/processors/local/ast_evaluator/local_func_evaluator.py
@@ -48,4 +48,8 @@ class LocalFuncEvaluator:
             for i in range(0, len(values), 2):
                 res[values[i]] = values[i + 1]
             return res
+        elif func_name == "SIZE":
+            if values[0] is None:
+                return None
+            return len(values[0])
         raise RuntimeError(f"Unsupported function: {func_name}.")

--- a/python/feathub/processors/spark/ast_evaluator/functions.py
+++ b/python/feathub/processors/spark/ast_evaluator/functions.py
@@ -20,7 +20,7 @@ from feathub.common.utils import to_java_date_format
 This set contains the name of the built-in functions whose name
 and argument list is the same between FeatHub and in Spark.
 """
-_functions_with_equal_signature = {"LOWER", "MAP", "CONCAT", "CONCAT_WS"}
+_functions_with_equal_signature = {"LOWER", "MAP", "CONCAT", "CONCAT_WS", "SIZE"}
 
 
 def evaluate_function(func_name: str, args: List[Any]) -> str:

--- a/python/feathub/processors/spark/spark_processor.py
+++ b/python/feathub/processors/spark/spark_processor.py
@@ -77,7 +77,7 @@ class SparkProcessor(Processor):
         spark_session_builder = spark_session_builder.master(config.get(MASTER_CONFIG))
         spark_session_builder = spark_session_builder.config(
             "spark.sql.session.timeZone", config.get(TIMEZONE_CONFIG)
-        )
+        ).config("spark.sql.legacy.sizeOfNull", False)
 
         prefix_len = len(NATIVE_CONFIG_PREFIX)
         for k, v in config.original_props_with_prefix(

--- a/python/feathub/table/table_descriptor.py
+++ b/python/feathub/table/table_descriptor.py
@@ -18,6 +18,7 @@ from abc import abstractmethod
 from typing import Optional, List, TYPE_CHECKING, Dict
 
 from feathub.common.exceptions import FeathubException
+from feathub.common.utils import from_json
 from feathub.feature_views.feature import Feature
 from feathub.registries.entity import Entity
 
@@ -97,8 +98,7 @@ class TableDescriptor(Entity):
         :return: A resolved table descriptor.
         """
 
-        # TODO: return a COPY of self instead of the existing Python object.
-        return self
+        return from_json(self.to_json())
 
     def get_feature(self, feature_name: str) -> Feature:
         """


### PR DESCRIPTION
## What is the purpose of the change

This PR mainly adds metrics CountMap and Average.

## Brief change log

  - Introduce built-in function `SIZE`
  - Adds metrics `CountMap` and `Average`.
  - Fixes the bug that prometheus sink function does not remove map-typed metrics with outdated labels.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & python docs