### PR TITLE
Prepares Feathub for 0.1.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 *.egg-info
 *.ipynb_checkpoints
 **/dependency-reduced-pom.xml
+tools/releasing/release

--- a/tools/releasing/create_github_release_and_upload_artifacts.sh
+++ b/tools/releasing/create_github_release_and_upload_artifacts.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Required variables
+##
+TAG=${TAG}
+GITHUB_TOKEN=${GITHUB_TOKEN}
+SHORT_RELEASE_VERSION=${SHORT_RELEASE_VERSION}
+
+if [ -z "${TAG}" ]; then
+    echo "TAG was not set."
+    exit 1
+fi
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+    echo "GITHUB_TOKEN was not set."
+    exit 1
+fi
+
+if [ -z "${SHORT_RELEASE_VERSION}" ]; then
+    echo "SHORT_RELEASE_VERSION was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../.."
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+cd $PROJECT_ROOT
+
+GIT_REMOTE_NAME=`git remote -v | grep "alibaba/feathub" | grep push | cut -d$'\t' -f1`
+
+if [[ -z "$GIT_REMOTE_NAME" ]]; then
+    echo "alibaba/feathub is not configured as a remote repository for this directory."
+    exit 1
+fi
+
+if ! git ls-remote --tags $GIT_REMOTE_NAME | grep -q "${TAG}"; then
+    echo "Tag ${TAG} not found in remote repository. Make sure you have pushed the tag before running this script."
+    exit 1
+fi
+
+release_id=`
+    curl -L \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        https://api.github.com/repos/alibaba/feathub/releases \
+        -d "{\"tag_name\":\"${TAG}\",\"target_commitish\":\"release-${SHORT_RELEASE_VERSION}\",\"name\":\"${TAG}\",\"body\":\"${TAG}\",\"draft\":false,\"prerelease\":true,\"generate_release_notes\":true}" \
+    | grep -o 'releases/\d\+\"' \
+    | grep -o '\d\+'
+`
+
+for filename in ${BASE_DIR}/release/*; do
+    base_name=$(basename ${filename})
+    
+    curl -L \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: application/octet-stream" \
+        "https://uploads.github.com/repos/alibaba/feathub/releases/${release_id}/assets?name=${base_name}" \
+        --data-binary "@${filename}"
+done
+
+cd ${CURR_DIR}

--- a/tools/releasing/create_python_sdk_release.sh
+++ b/tools/releasing/create_python_sdk_release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+    echo "RELEASE_VERSION was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+if [ "$(uname)" == "Darwin" ]; then
+    SHASUM="shasum -a 512"
+else
+    SHASUM="sha512sum"
+fi
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+RELEASE_DIR=${BASE_DIR}/release/
+mkdir -p ${RELEASE_DIR}
+
+cd ${PROJECT_ROOT}/java/
+${MVN} clean package -B -DskipTests
+
+python -m pip install --upgrade pip setuptools wheel
+cd ${PROJECT_ROOT}/python/
+
+# create a target/ directory like in MAVEN.
+# this directory will contain a temporary copy of the source
+# eventually the built artifact will be copied to ${PROJECT_ROOT}/python/dist and this target
+# directory will be deleted.
+rm -rf dist/
+rm -rf ../target/
+mkdir -p ../target/
+
+# copy all the sources into target
+rsync -a * ../target/
+
+cd ../target/
+
+python3 setup.py bdist_wheel
+
+cp -r dist ${PROJECT_ROOT}/python/dist
+
+mv dist/* ${RELEASE_DIR}
+
+cd ..
+rm -rf target
+
+SOURCE_DIST="feathub-$RELEASE_VERSION-py3-none-any.whl"
+
+cd ${RELEASE_DIR}
+${SHASUM} "${SOURCE_DIST}" > "${SOURCE_DIST}.sha512"
+
+cd ${CURR_DIR}

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+	echo "RELEASE_VERSION was not set"
+	exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+TARGET_BRANCH=release-${RELEASE_VERSION}
+
+cd ${PROJECT_ROOT}
+git checkout -b ${TARGET_BRANCH}
+
+RELEASE_COMMIT_HASH=`git rev-parse HEAD`
+echo "Done. Created a new release branch with commit hash ${RELEASE_COMMIT_HASH}."
+
+cd ${CURR_DIR}

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -1,0 +1,70 @@
+#
+# Copyright 2022 The Feathub Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
+## Required variables
+##
+OLD_VERSION=${OLD_VERSION}
+NEW_VERSION=${NEW_VERSION}
+
+if [ -z "${OLD_VERSION}" ]; then
+    echo "OLD_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+cd ${PROJECT_ROOT}
+
+# change version in all pom files
+$MVN versions:set -DgenerateBackupPoms=false -DnewVersion=${NEW_VERSION} -f ./java
+
+# change version of feathub
+perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${NEW_VERSION}\"#" python/feathub/version.py
+perl -pi -e "s#-SNAPSHOT#\\.dev0#" python/feathub/version.py
+
+git commit -am "[release] Update version to ${NEW_VERSION}"
+
+NEW_VERSION_COMMIT_HASH=`git rev-parse HEAD`
+
+echo "Done. Created a new commit for the new version ${NEW_VERSION}, with hash ${NEW_VERSION_COMMIT_HASH}"
+echo "If this is a new version to be released (or a candidate to be voted on), don't forget to create a signed release tag on GitHub and push the changes."
+echo "e.g., git tag -s -m \"FeatHub, release 0.1 candidate #2\" release-0.1-rc2 ${NEW_VERSION_COMMIT_HASH}"
+
+cd ${CURR_DIR}


### PR DESCRIPTION
## What is the purpose of the change

This pull request mainly adds the scripts needed during Feathub's release process.

The usage of these scripts is documented in an internal release guideline, which is not made public yet. The result of following that guideline (expect deploying to Pypi) is as follows.

- Creates a release branch and push it to Github ([link](https://github.com/yunfengzhou-hub/feathub/tree/release-0.1)).
- Updates the version information on the master branch ([link](https://github.com/yunfengzhou-hub/feathub/commit/ea6afe7cace54755be8c140723d99c8dd5db84ed)).
- Creates a [tag](https://github.com/yunfengzhou-hub/feathub/releases/tag/release-0.1.0-rc1) and [release](https://github.com/yunfengzhou-hub/feathub/releases/tag/release-0.1.0-rc1) for each release candidate, with the Python wheel to be deployed.
- Creates a [tag](https://github.com/yunfengzhou-hub/feathub/releases/tag/release-0.1.0) and [release](https://github.com/yunfengzhou-hub/feathub/releases/tag/release-0.1.0) for the final release, with the Python wheel to be deployed.


## Brief change log

- Adds the scripts needed during Feathub's release process.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable